### PR TITLE
Add .npmrc with engine-strict=true, so that npm commands fail if the required engine versions do not match

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 # Note: any configuration settings in the repo-root .npmrc file
 # will also apply to the packages within the monorepo
+engine-strict=true


### PR DESCRIPTION
This should help with misleading errors that really have to do with using outdated node or npm versions.