### PR TITLE
Add '^' for now as a copy / ditto token.

### DIFF
--- a/jl4/examples/anti-social.l4
+++ b/jl4/examples/anti-social.l4
@@ -1,0 +1,44 @@
+
+-- An authorised person may issue a community protection notice to an
+-- individual aged 16 or over, or a body, if satisfied on reasonable grounds that—
+--
+--   a. the conduct of the individual or body is having a detrimental effect,
+--      of a persistent or continuing nature, on the quality of life of those
+--      in the locality, and
+--   b. the conduct is unreasonable.
+
+ASSUME Person IS A TYPE
+ASSUME `is authorised`  IS A FUNCTION FROM Person TO BOOLEAN
+
+ASSUME Receiver IS A TYPE
+ASSUME `is an individual aged 16 or over` IS A FUNCTION FROM Receiver TO BOOLEAN
+ASSUME `is a body` IS A FUNCTION FROM Receiver TO BOOLEAN
+
+ASSUME Effect IS A TYPE
+ASSUME EffectTarget IS A TYPE
+
+ASSUME `is detrimental` IS A FUNCTION FROM Effect TO BOOLEAN
+ASSUME `is of a persistent or continuing nature` IS A FUNCTION FROM Effect TO BOOLEAN
+ASSUME `affects the quality of life of those in the locality` IS A FUNCTION FROM Effect TO BOOLEAN
+
+ASSUME Conduct IS A TYPE
+ASSUME conduct IS A FUNCTION FROM Receiver TO Conduct
+ASSUME effect IS A FUNCTION FROM Conduct TO Effect
+ASSUME `is unreasonable` IS A FUNCTION FROM Conduct TO BOOLEAN
+
+GIVEN person     IS A Person      -- person issuing the notice
+      receiver   IS A Receiver    -- target of the notice
+DECIDE `may issue a community protection notice` IF
+      `is authorised` person
+  AND    `is an individual aged 16 or over` receiver
+      OR `is a body` receiver
+  AND -- it is satisfied on reasonable grounds that
+          -- a.
+              `is detrimental`                                       OF `the effect`
+          AND `is of a persistent or continuing nature`              OF `the effect`
+          AND `affects the quality of life of those in the locality` OF `the effect`
+      AND -- b.
+          `is unreasonable` OF `the conduct`
+  WHERE
+    `the conduct` MEANS conduct OF receiver
+    `the effect`  MEANS effect OF `the conduct`

--- a/jl4/examples/appform.l4
+++ b/jl4/examples/appform.l4
@@ -1,0 +1,19 @@
+
+foo x y MEANS
+  x + y
+
+DECLARE Pair
+  HAS px IS A NUMBER
+      py IS A NUMBER
+
+DECLARE Colour
+  IS ONE OF
+    red
+    green
+    blue
+
+isNiceColour c MEANS
+  CONSIDER c
+  WHEN red THEN TRUE
+  WHEN green THEN FALSE
+  WHEN blue THEN TRUE

--- a/jl4/examples/ditto.l4
+++ b/jl4/examples/ditto.l4
@@ -1,0 +1,15 @@
+
+ASSUME x IS A BOOLEAN
+^      y ^  ^ ^
+^      n ^  ^ NUMBER
+
+-- we can even have whitespace and comments in between
+
+^      m ^  ^ ^
+
+test MEANS
+  IF n AT LEAST m
+  THEN    x
+       OR y
+       ^  x
+  ELSE TRUE

--- a/jl4/examples/tests/anti-social.ep.golden
+++ b/jl4/examples/tests/anti-social.ep.golden
@@ -1,0 +1,44 @@
+
+-- An authorised person may issue a community protection notice to an
+-- individual aged 16 or over, or a body, if satisfied on reasonable grounds that—
+--
+--   a. the conduct of the individual or body is having a detrimental effect,
+--      of a persistent or continuing nature, on the quality of life of those
+--      in the locality, and
+--   b. the conduct is unreasonable.
+
+ASSUME Person IS A TYPE
+ASSUME `is authorised`  IS A FUNCTION FROM Person TO BOOLEAN
+
+ASSUME Receiver IS A TYPE
+ASSUME `is an individual aged 16 or over` IS A FUNCTION FROM Receiver TO BOOLEAN
+ASSUME `is a body` IS A FUNCTION FROM Receiver TO BOOLEAN
+
+ASSUME Effect IS A TYPE
+ASSUME EffectTarget IS A TYPE
+
+ASSUME `is detrimental` IS A FUNCTION FROM Effect TO BOOLEAN
+ASSUME `is of a persistent or continuing nature` IS A FUNCTION FROM Effect TO BOOLEAN
+ASSUME `affects the quality of life of those in the locality` IS A FUNCTION FROM Effect TO BOOLEAN
+
+ASSUME Conduct IS A TYPE
+ASSUME conduct IS A FUNCTION FROM Receiver TO Conduct
+ASSUME effect IS A FUNCTION FROM Conduct TO Effect
+ASSUME `is unreasonable` IS A FUNCTION FROM Conduct TO BOOLEAN
+
+GIVEN person     IS A Person      -- person issuing the notice
+      receiver   IS A Receiver    -- target of the notice
+DECIDE `may issue a community protection notice` IF
+      `is authorised` person
+  AND    `is an individual aged 16 or over` receiver
+      OR `is a body` receiver
+  AND -- it is satisfied on reasonable grounds that
+          -- a.
+              `is detrimental`                                       OF `the effect`
+          AND `is of a persistent or continuing nature`              OF `the effect`
+          AND `affects the quality of life of those in the locality` OF `the effect`
+      AND -- b.
+          `is unreasonable` OF `the conduct`
+  WHERE
+    `the conduct` MEANS conduct OF receiver
+    `the effect`  MEANS effect OF `the conduct`

--- a/jl4/examples/tests/anti-social.golden
+++ b/jl4/examples/tests/anti-social.golden
@@ -1,0 +1,2 @@
+Parsing successful
+Typechecking successful

--- a/jl4/examples/tests/appform.ep.golden
+++ b/jl4/examples/tests/appform.ep.golden
@@ -1,0 +1,19 @@
+
+foo x y MEANS
+  x + y
+
+DECLARE Pair
+  HAS px IS A NUMBER
+      py IS A NUMBER
+
+DECLARE Colour
+  IS ONE OF
+    red
+    green
+    blue
+
+isNiceColour c MEANS
+  CONSIDER c
+  WHEN red THEN TRUE
+  WHEN green THEN FALSE
+  WHEN blue THEN TRUE

--- a/jl4/examples/tests/appform.golden
+++ b/jl4/examples/tests/appform.golden
@@ -1,0 +1,2 @@
+Parsing successful
+Typechecking successful

--- a/jl4/examples/tests/ditto.ep.golden
+++ b/jl4/examples/tests/ditto.ep.golden
@@ -1,0 +1,15 @@
+
+ASSUME x IS A BOOLEAN
+^      y ^  ^ ^
+^      n ^  ^ NUMBER
+
+-- we can even have whitespace and comments in between
+
+^      m ^  ^ ^
+
+test MEANS
+  IF n AT LEAST m
+  THEN    x
+       OR y
+       ^  x
+  ELSE TRUE

--- a/jl4/examples/tests/ditto.golden
+++ b/jl4/examples/tests/ditto.golden
@@ -1,0 +1,2 @@
+Parsing successful
+Typechecking successful

--- a/jl4/src/L4/Lexer.hs
+++ b/jl4/src/L4/Lexer.hs
@@ -11,6 +11,7 @@ import Control.DeepSeq (NFData)
 import Data.Char hiding (Space)
 import Data.List.NonEmpty (NonEmpty((:|)), nonEmpty)
 import Data.Proxy
+import GHC.Show (showLitString)
 import Text.Megaparsec as Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.State
@@ -70,6 +71,8 @@ data TokenType =
   | TIntLit       !Text !Int
   | TStringLit    !Text
   | TDirective    !Text
+    -- copy token / ditto mark, currently '^'
+  | TCopy         (Maybe TokenType)
     -- parentheses
   | TPOpen
   | TPClose
@@ -219,7 +222,7 @@ tokenPayload :: Lexer TokenType
 tokenPayload =
       uncurry TIntLit <$> try integerLiteral
   <|> TStringLit      <$> stringLiteral
-  <|> TGenitive       <$ string "'s"
+  <|> TGenitive       <$  string "'s"
   <|> TQuoted         <$> quoted
   <|> TDirective      <$> directiveLiteral
   <|> TNlg            <$> nlgAnnotation
@@ -227,16 +230,17 @@ tokenPayload =
   <|> TSpace          <$> whitespace
   <|> TLineComment    <$> lineComment
   <|> TBlockComment   <$> blockComment
-  <|> TPOpen          <$ char '('
-  <|> TPClose         <$ char ')'
-  <|> TCOpen          <$ char '{'
-  <|> TCClose         <$ char '}'
-  <|> TSOpen          <$ char '['
-  <|> TSClose         <$ char ']'
-  <|> TParagraph      <$ char '§'
-  <|> TComma          <$ char ','
-  <|> TSemicolon      <$ char ';'
-  <|> TDot            <$ char '.'
+  <|> TPOpen          <$  char '('
+  <|> TPClose         <$  char ')'
+  <|> TCOpen          <$  char '{'
+  <|> TCClose         <$  char '}'
+  <|> TSOpen          <$  char '['
+  <|> TSClose         <$  char ']'
+  <|> TParagraph      <$  char '§'
+  <|> TComma          <$  char ','
+  <|> TSemicolon      <$  char ';'
+  <|> TDot            <$  char '.'
+  <|> TCopy Nothing   <$  char '^'
   <|> symbolic
   <|> identifierOrKeyword
 
@@ -352,26 +356,91 @@ execLexer file input =
       Right rtoks -> Right (mkPosTokens file input rtoks)
       Left errs   -> Left (errorBundleToErrorMessages errs)
 
+data TokenState =
+  MkTokenState
+    { posState        :: !(PosState Text)
+    , currentLine     :: Int
+    , currentLineToks :: [PosToken]
+    , prevLineToks    :: [PosToken] -- immediately preceding non-whitespace line
+    }
+  deriving Generic
+
+initialTokenState :: FilePath -> Text -> TokenState
+initialTokenState filepath txt =
+  MkTokenState
+    (initialPosState filepath txt)
+    0
+    []
+    []
+
+-- | This traversal postprocesses raw tokens and turns them into pos tokens
+-- by converting their positions.
+--
+-- At the same time, we interpret copy tokens.
+--
 mkPosTokens :: FilePath -> Text -> [RawToken] -> [PosToken]
 mkPosTokens filepath txt rtoks =
-    evalState (traverse go rtoks) (initialPosState filepath txt)
+    evalState (traverse go rtoks) (initialTokenState filepath txt)
   where
-    go :: RawToken -> StateT (PosState Text) Identity PosToken
+    go :: RawToken -> StateT TokenState Identity PosToken
     go rtok = do
-      pst <- get
+      ts <- get
       let
+        pst      = ts.posState
         pstStart = reachOffsetNoLine rtok.start pst
         pstEnd   = reachOffsetNoLine rtok.end pstStart
-      put pstEnd
-      pure
-        (MkPosToken
-          (MkSrcRange
-            (convertPos (pstateSourcePos pstStart))
-            (convertPos (pstateSourcePos pstEnd  ))
-            (rtok.end - rtok.start)
-          )
-          rtok.payload
-        )
+        posStart = convertPos (pstateSourcePos pstStart)
+        posEnd   = convertPos (pstateSourcePos pstEnd  )
+      when (posStart.line /= ts.currentLine) $ do
+        assign #currentLine posStart.line
+        assign #currentLineToks []
+        -- We ignore purely "whitespace" lines, and count comments as whitespace, but currently not annotations.
+        unless (all isSpaceToken ts.currentLineToks) (assign #prevLineToks ts.currentLineToks)
+      assign #posState pstEnd
+      prevLineToks' <- use #prevLineToks
+      let
+        payload  =
+          case rtok.payload of
+            TCopy Nothing -> TCopy (findMatchingToken posStart.column prevLineToks')
+            other         -> other
+        pt       =
+          MkPosToken
+            (MkSrcRange
+              posStart
+              posEnd
+              (rtok.end - rtok.start)
+            )
+            payload
+      modifying #currentLineToks (pt :)
+      pure pt
+
+findMatchingToken :: Int -> [PosToken] -> Maybe TokenType
+findMatchingToken c pts = do
+  -- trace ("trying to find match: " <> show pts) (pure ())
+  pt <- find (\ pt -> pt.range.start.column == c) pts
+  -- trace ("found match: " <> show (computedPayload pt)) $
+  pure (computedPayload pt)
+
+computedPayload :: PosToken -> TokenType
+computedPayload pt =
+  case pt.payload of
+    TCopy (Just original) -> original
+    other                 -> other
+
+isSpaceToken :: PosToken -> Bool
+isSpaceToken t =
+  case computedPayload t of
+    TSpace _        -> True
+    TLineComment _  -> True
+    TBlockComment _ -> True
+    _               -> False
+
+isAnnotationToken :: PosToken -> Bool
+isAnnotationToken t =
+  case computedPayload t of
+    TNlg _ -> True
+    TRef _ -> True
+    _      -> False
 
 -- | Convert from a Megaparsec source position to one of ours.
 convertPos :: SourcePos -> SrcPos
@@ -570,14 +639,22 @@ errorFancyLength = \case
   ErrorCustom a -> errorComponentLen a
   _ -> 1
 
+-- | This isn't truly precise, but it should be mostly fine, because we use
+-- the Haskell escape sequences both in the parser and in printing.
+--
+showStringLit :: Text -> Text
+showStringLit t =
+  Text.pack ((showChar '"' . showLitString (Text.unpack t) . showChar '"') "")
+
 displayPosToken :: PosToken -> Text
 displayPosToken (MkPosToken _r tt) =
   case tt of
     TIdentifier t    -> t
     TQuoted t        -> "`" <> t <> "`"
     TIntLit t _i     -> t
-    TStringLit s     -> Text.pack (show s) -- ideally, this should be fine, because we use the Haskell escape sequences
+    TStringLit s     -> showStringLit s
     TDirective t     -> "#" <> t
+    TCopy _          -> "^"
     TPOpen           -> "("
     TPClose          -> ")"
     TCOpen           -> "{"
@@ -676,6 +753,7 @@ data TokenCategory
   | CDirective
   | CAnnotation
   | CEOF
+  deriving stock Eq
 
 posTokenCategory :: TokenType -> TokenCategory
 posTokenCategory =
@@ -685,6 +763,8 @@ posTokenCategory =
     TIntLit _ _ -> CNumberLit
     TStringLit _ -> CStringLit
     TDirective _ -> CDirective
+    TCopy Nothing -> CSymbol
+    TCopy (Just t) -> posTokenCategory t
     TPOpen -> CSymbol
     TPClose -> CSymbol
     TCOpen -> CSymbol

--- a/jl4/src/L4/Parser.hs
+++ b/jl4/src/L4/Parser.hs
@@ -54,21 +54,6 @@ blockRefAnnotation :: Parser [PosToken]
 blockRefAnnotation =
   (\open (mid, close) -> [open] <> mid <> [close]) <$> plainToken TAOpen <*> manyTill_ (anySingle <?> "Ref Block Annotation") (plainToken TAClose)
 
-isSpaceToken :: PosToken -> Bool
-isSpaceToken t =
-  case t.payload of
-    TSpace _        -> True
-    TLineComment _  -> True
-    TBlockComment _ -> True
-    _               -> False
-
-isAnnotationToken :: PosToken -> Bool
-isAnnotationToken t =
-  case t.payload of
-    TNlg _ -> True
-    TRef _ -> True
-    _      -> False
-
 lexeme :: Parser a -> Parser (Lexeme a)
 lexeme p = do
   a <- p
@@ -78,7 +63,7 @@ lexeme p = do
 plainToken :: TokenType -> Parser PosToken
 plainToken tt =
   token
-    (\ t -> if t.payload == tt then Just t else Nothing)
+    (\ t -> if computedPayload t == tt then Just t else Nothing)
     (Set.singleton (Tokens (trivialToken tt :| [])))
 
 trivialToken :: TokenType -> PosToken
@@ -100,7 +85,7 @@ spacedToken cond lbl =
   lexToEpa' <$>
     lexeme
       (token
-        (\ t -> (t,) <$> cond t.payload)
+        (\ t -> (t,) <$> cond (computedPayload t))
         Set.empty
       )
     <?> lbl


### PR DESCRIPTION
Using it means the same token as at the same column in the line directly above (ignoring whitespace and comment lines).

The nicer syntax of '"' conflicts with string literals, unfortunately.