### PR TITLE
Completions for toplevel declarations

### DIFF
--- a/jl4/lsp/LSP/L4/Handlers.hs
+++ b/jl4/lsp/LSP/L4/Handlers.hs
@@ -52,7 +52,6 @@ import Language.LSP.VFS (VFS)
 import qualified Optics
 import qualified StmContainers.Map as STM
 import UnliftIO (MonadUnliftIO)
-import Debug.Trace
 
 data ReactorMessage
   = ReactorNotification (IO ())
@@ -286,7 +285,9 @@ handlers recorder =
                     f
                     False
 
-            let mkKeyWordCompletionItem kw = (defaultCompletionItem kw) { CompletionItem._kind =  Just CompletionItemKind_Keyword }
+            let mkKeyWordCompletionItem kw = (defaultCompletionItem kw)
+                  { CompletionItem._kind =  Just CompletionItemKind_Keyword
+                  }
                 keyWordMatches = filterMatchesOn id $ Map.keys keywords 
                 -- FUTUREWORK(mangoiv): we could 
                 -- 1 pass through the token here 
@@ -294,7 +295,8 @@ handlers recorder =
                 -- 3 set the CompletionItemKind to CompletionItemKind_Operator
                 keywordItems = map mkKeyWordCompletionItem keyWordMatches
 
-            (typeCheck, _positionMapping) <- liftIO $ runAction "typecheck" ide $ useWithStale_ TypeCheck (fromUri (toNormalizedUri uri))
+            (typeCheck, _positionMapping) <- liftIO $ runAction "typecheck" ide $
+              useWithStale_ TypeCheck (fromUri (toNormalizedUri uri))
 
             let topDeclItems 
                   = filterMatchesOn CompletionItem._label 
@@ -308,14 +310,12 @@ handlers recorder =
                             checkEntity
                         )
                       ) 
-                      typeCheck.finalEnvironment
+                      typeCheck.environment
 
             -- TODO: maybe we should sort these as follows
             -- 1 keywords 
             -- 2 toplevel values 
             -- 3 toplevel types 
-            
-            traceShowM topDeclItems
 
             let items = keywordItems <> topDeclItems
 

--- a/jl4/tests/Main.hs
+++ b/jl4/tests/Main.hs
@@ -77,10 +77,10 @@ parseFile file input =
     Right prog -> do
       Text.putStrLn "Parsing successful"
       case JL4.doCheckProgram prog of
-        CheckResult {errors, resolvedProgram}
+        CheckResult {errors, program}
           | all ((== JL4.SInfo) . JL4.severity) errors -> do
             Text.putStrLn "Typechecking successful"
-            let results = JL4.doEvalProgram resolvedProgram
+            let results = JL4.doEvalProgram program
             let msgs = (typeErrorToMessage <$> errors) ++ (evalResultToMessage <$> results)
             Text.putStr (Text.unlines (renderMessage <$> sortOn fst msgs))
           | otherwise -> do


### PR DESCRIPTION
- [x] figure out why code does not work well with multi-word completions
- [x] revise layout for details (type is a bit close to the thing whose type we're displaying)
- [x] use final environment and not `Program Resolved`
- [x] get inferred types for `DECIDE`s 
- [x] builtin environment elements (e.g. `BOOLEAN`) are missing
- [x] Check if rule for in scope identifiers is still necessary if we're relying on the entire type checked `Program` anyway