### PR TITLE
Refactor the visualize-L4-expression command name and title

### DIFF
--- a/jl4/lsp/Server.hs
+++ b/jl4/lsp/Server.hs
@@ -81,7 +81,7 @@ lspOptions =
     { optTextDocumentSync = Just syncOptions
     , optExecuteCommandCommands =
         Just
-          [ "viz.showViz"
+          [ "l4.visualize"
           ]
     }
 

--- a/ts-apps/vscode/package.json
+++ b/ts-apps/vscode/package.json
@@ -48,8 +48,8 @@
     ],
     "commands": [
       {
-        "command": "viz.showViz",
-        "title": "Show Visualisation"
+        "command": "l4.visualize",
+        "title": "Visualize L4 expression"
       }
     ]
   },

--- a/ts-apps/vscode/src/commands.ts
+++ b/ts-apps/vscode/src/commands.ts
@@ -1,1 +1,1 @@
-export const showVisualisation = 'viz.showViz'
+export const showVisualisation = 'l4.visualize'


### PR DESCRIPTION
Quick refactor, as preparation for further work on visualization:

* Refactor the visualize-L4-expression command name to add a `l4` namespace, and to make the verb just `visualize` 
(This is probably subjective, but I find `showViz` a bit misleading --- `showViz` makes it sound as if the visualization has already been created and we are just 'showing' it. It also places a bit too much emphasis on the 'showing' as opposed to the 'visualizing'.)
* Refactor the title of the command accordingly. The hope is that "Visualize L4 expression" might be less technical or jargon-y (though "expression" is still jargon). 