### PR TITLE
[chore] add editorconfig for trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.{hs,cabal}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
Since we don't have any formatting, here are some agreeable rules to make the editor more helpful in haskell or cabal files
- indents are two spaces
- trailing whitespace is removed