### PR TITLE
Add support for SemanticTokens spanning multiple lines

### DIFF
--- a/jl4/lsp/LSP/L4/SemanticTokens.hs
+++ b/jl4/lsp/LSP/L4/SemanticTokens.hs
@@ -80,11 +80,12 @@ srcPosToPosition s =
 -- ----------------------------------------------------------------------------
 
 instance ToSemToken PosToken where
-  toSemToken :: PosToken -> SemanticTokenTypes -> [SemanticTokenModifiers] -> [SemanticToken]
+  toSemToken :: PosToken -> SemanticTokenTypes -> [SemanticTokenModifiers] -> NonEmpty SemanticToken
   toSemToken token category modifiers
     | token.range.start.line /= token.range.end.line =
         splitTokens (mkSingleSemToken token) (displayPosToken token)
-    | otherwise = [mkSingleSemToken token]
+    | otherwise =
+        pure (mkSingleSemToken token)
    where
     mkSingleSemToken :: PosToken -> SemanticToken
     mkSingleSemToken t = SemanticToken
@@ -145,4 +146,4 @@ instance ToSemTokens PosToken Lit where
 instance ToSemTokens PosToken PosToken where
   toSemTokens t = do
     ctx <- ask
-    pure $ fromMaybe [] (fromSemanticTokenContext ctx t)
+    pure $ maybe [] toList (fromSemanticTokenContext ctx t)

--- a/jl4/src/Base.hs
+++ b/jl4/src/Base.hs
@@ -14,6 +14,7 @@ import Data.Kind as X
 import Data.List as X
 import Data.Map.Strict as X (Map, (!))
 import Data.Maybe as X
+import Data.List.NonEmpty as X (NonEmpty(..), nonEmpty)
 import Data.Set as X (Set)
 import Data.String as X
 import Data.Text as X (Text)

--- a/jl4/src/L4/ExactPrint.hs
+++ b/jl4/src/L4/ExactPrint.hs
@@ -15,8 +15,6 @@ import L4.Syntax
 
 import qualified Control.Monad.Extra as Extra
 import qualified Data.Text as Text
-import Text.Pretty.Simple
-import Data.Text.Lazy (toStrict)
 
 -- ----------------------------------------------------------------------------
 -- ExactPrinting Interface

--- a/jl4/src/L4/Lexer.hs
+++ b/jl4/src/L4/Lexer.hs
@@ -9,7 +9,6 @@ import qualified Base.Text as Text
 
 import Control.DeepSeq (NFData)
 import Data.Char hiding (Space)
-import Data.List.NonEmpty (NonEmpty((:|)), nonEmpty)
 import Data.Proxy
 import GHC.Show (showLitString)
 import Text.Megaparsec as Megaparsec

--- a/jl4/src/L4/Parser.hs
+++ b/jl4/src/L4/Parser.hs
@@ -17,7 +17,6 @@ import Base
 
 import qualified Control.Applicative as Applicative
 import Data.Functor.Compose
-import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text


### PR DESCRIPTION
I got annoyed by syntax highlighting behaving incorrectly for multi-line comments in VSCode.

This fixes syntax highlighting for tokens that span multiple lines:
![image](https://github.com/user-attachments/assets/e83a5443-2d80-4aa7-bf71-3a9d48e409a6)
