### PR TITLE
Allow for more zooming out when the flow is fit to view, to avoid truncating some of the wider graphs/flows

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -29,6 +29,14 @@
 
   const { context, node: exprLirNode }: ExprFlowDisplayerProps = $props()
 
+  /* TODO:
+  - Come up with more-easily-understandable units for the minZoom
+  - Prob good to add contextual zoom + hint ("Zoom in to see the details!") for wider graphs
+  */
+  const sfVisualOptions = {
+    smallestThatCanZoomOutTo: 0.2,
+  }
+
   /***********************************
     Make initial SF nodes and edges
   ************************************/
@@ -120,9 +128,13 @@
     window.requestAnimationFrame(() => {
       console.log('fitting view!')
 
-      fitView({ padding: 0.1, duration: 15 })
+      fitView({
+        padding: 0.1,
+        minZoom: sfVisualOptions.smallestThatCanZoomOutTo,
+        duration: 15,
+      })
       /***************************
-       * Notes on fitView padding
+       * Notes on fitView options
        ***************************
        *
        * 0.1 is the default
@@ -131,6 +143,12 @@
        *
        * https://github.com/xyflow/xyflow/blob/23669c330d2344d6ae19a237b69a74ee34fc64e8/packages/system/src/utils/general.ts#L177
        *
+       * See their `src/lib/container/SvelteFlow/types.ts` for the defaults they use.
+       *
+       * `minZoom` is the smallest zoom level that the view *can* be zoomed to when the flow is fit to view.
+       * I.e., decreasing it means that fitView can zoom out more for wider graphs.
+       * Being able to zoom out more seems helpful for our usecase (understanding the broad structure of the law).
+       * The default minZoom is 0.5.
        */
     })
   }
@@ -146,6 +164,7 @@
     bind:nodes={NODES}
     bind:edges={EDGES}
     nodeTypes={sfNodeTypes}
+    minZoom={sfVisualOptions.smallestThatCanZoomOutTo}
     fitView
     connectionLineType={ConnectionLineType.Bezier}
     defaultEdgeOptions={{ type: 'bezier', animated: false }}


### PR DESCRIPTION
Decrease minZoom so that won't truncate some of the wider graphs when flow is fit to view (though if you make it wider still, will eventually end up with truncation):

<img width="1737" alt="image" src="https://github.com/user-attachments/assets/848e4dce-8f15-46a0-8db9-b4c5c15bc2a5" />

### Future TODO: 

Should probably also add contextual zoom (https://svelteflow.dev/examples/interaction/contextual-zoom) + hint ("Zoom in to see the details!") for wider graphs, though, since it might come off as being a bit unpolished when the graphs are wide. But that shouldn't be an issue for the demo.
