### PR TITLE
Implement find references

### DIFF
--- a/jl4/lsp/LSP/L4/Rules.hs
+++ b/jl4/lsp/LSP/L4/Rules.hs
@@ -128,16 +128,16 @@ data GetReferences = GetReferences
 
 data ReferenceMapping =
   ReferenceMapping
-  { actualToOriginal :: IntervalMap SrcPos Name
+  { actualToOriginal :: IntervalMap SrcPos Unique
   -- ^ getting the original occurence of a name, based on its source range
-  , originalToActual :: MonoidalMap Name [SrcRange]
+  , originalToActual :: MonoidalMap Unique [SrcRange]
   -- ^ getting the source range of all references of an original definition
   }
   deriving stock Generic
   deriving anyclass NFData
   deriving (Semigroup, Monoid) via Generically ReferenceMapping
 
-singletonReferenceMapping :: Name -> SrcRange -> ReferenceMapping
+singletonReferenceMapping :: Unique -> SrcRange -> ReferenceMapping
 singletonReferenceMapping originalName actualRange
   = ReferenceMapping
   { actualToOriginal = IVMap.singleton (srcRangeToInterval actualRange) originalName
@@ -341,7 +341,7 @@ jl4Rules recorder = do
     let spanOf resolved
           = maybe
               mempty
-              (singletonReferenceMapping $ getOriginal resolved)
+              (singletonReferenceMapping $ getUnique resolved)
               -- NOTE: the source range of the actual Name
               (rangeOf resolved)
 

--- a/jl4/src/L4/Syntax.hs
+++ b/jl4/src/L4/Syntax.hs
@@ -15,7 +15,7 @@ import qualified Generics.SOP as SOP
 import Optics
 
 data Name = MkName Anno RawName
-  deriving stock (GHC.Generic, Eq, Ord, Show)
+  deriving stock (GHC.Generic, Eq, Show)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data RawName =
@@ -32,7 +32,7 @@ data Resolved =
     Def Unique Name        -- ^ defining occurrence of name
   | Ref Name Unique Name   -- ^ referring occurrence of name, original occurrence of name
   | OutOfScope Unique Name -- ^ used to make progress for names where name resolution failed
-  deriving stock (GHC.Generic, Eq, Ord, Show)
+  deriving stock (GHC.Generic, Eq, Show)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 -- | Extract the original name, i.e., for referring occurrences, the defining occurrence of the name.
@@ -60,7 +60,7 @@ data Type' n =
   | Forall Anno [n] (Type' n) -- ^ universally quantified type
   | InfVar Anno RawName Int -- ^ only used during type inference
   -- | ParenType Anno (Type' n) -- temporary
-  deriving stock (GHC.Generic, Eq, Ord, Show, Functor)
+  deriving stock (GHC.Generic, Eq, Show, Functor)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data TypedName n =
@@ -70,12 +70,12 @@ data TypedName n =
 
 data OptionallyTypedName n =
   MkOptionallyTypedName Anno n (Maybe (Type' n))
-  deriving stock (GHC.Generic, Eq, Ord, Show)
+  deriving stock (GHC.Generic, Eq, Show)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data OptionallyNamedType n =
   MkOptionallyNamedType Anno (Maybe n) (Type' n)
-  deriving stock (GHC.Generic, Eq, Ord, Show, Functor)
+  deriving stock (GHC.Generic, Eq, Show, Functor)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data TypeSig n =
@@ -238,7 +238,7 @@ data Extension = Extension
   { resolvedType :: Maybe (Type' Resolved)
   , nlg :: Maybe Nlg
   }
-  deriving stock (GHC.Generic, Eq, Ord, Show)
+  deriving stock (GHC.Generic, Eq, Show)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 
@@ -400,7 +400,7 @@ data Comment = MkComment Anno [Text]
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Nlg = MkNlg Anno [Text]
-  deriving stock (Show, Eq, Ord, GHC.Generic)
+  deriving stock (Show, Eq, GHC.Generic)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Ref = MkRef Anno [Text]

--- a/jl4/src/L4/TypeCheck.hs
+++ b/jl4/src/L4/TypeCheck.hs
@@ -1734,12 +1734,11 @@ deriving anyclass instance ToResolved (TypeSig Resolved)
 deriving anyclass instance ToResolved (GivethSig Resolved)
 deriving anyclass instance ToResolved (GivenSig Resolved)
 deriving anyclass instance ToResolved (Directive Resolved)
-deriving anyclass instance ToResolved Lit
 
-instance ToResolved Int where
+instance ToResolved Lit where
   toResolved = const []
 
-instance ToResolved Text where
+instance ToResolved Int where
   toResolved = const []
 
 instance ToResolved RawName where


### PR DESCRIPTION
Resolves #132 

New rule which creates a mapping from source locations to the defining
occurence of a name and a mapping from defining occurences to source
ranges of references of that occurence.

The handler builds the mapping based on the rule and looks up the
definition in the map by the use of the source position sent as part of
the lookup.