### PR TITLE
[fix] don't restore on imperfect cache hits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
           path: ${{ steps.setup.outputs.cabal-store }}
           key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
 
+      - name: Get some information
+        run: |
+          ls -l ~/.cabal
+
       - name: Install dependencies
         # If we had an exact cache hit, the dependencies will be up to date.
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
- since imperfect cache hits seem to have been introducing corruption, we don't restore from them, ever, so we do a full rebuild when we change dependencies