### PR TITLE
Add decision web-service which allows you to run L4 functions through a REST API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,8 @@ jobs:
           libncurses-dev
           pkg-config
           zlib1g-dev
+          liblzma-dev
+          xz-utils
       - name: Update git config
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       # FIXME: this is a temporary fix, the docker container should never be dirty

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
 packages: 
   ./jl4
+  ./jl4-decision-service
   ./jl4-websessions

--- a/jl4-decision-service/app/Main.hs
+++ b/jl4-decision-service/app/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Application
+
+main :: IO ()
+main = defaultMain

--- a/jl4-decision-service/jl4-decision-service.cabal
+++ b/jl4-decision-service/jl4-decision-service.cabal
@@ -1,0 +1,131 @@
+cabal-version: 3.0
+name: jl4-decision-service
+version: 0.1.0.0
+build-type: Simple
+tested-with: ghc ==9.6.6
+extra-source-files:
+  CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/cclaw/l4-ide/jl4-decision-service
+
+common defaults
+  default-language: GHC2021
+  ghc-options:
+    -Wall
+    -Wderiving-typeable
+    -Wunused-packages
+    -Werror
+    -Wall
+    -Widentities
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wmissing-export-lists
+    -Wmissing-home-modules
+    -Wpartial-fields
+    -Wredundant-constraints
+
+  default-extensions:
+    BlockArguments
+    DefaultSignatures
+    DeriveAnyClass
+    DerivingStrategies
+    DerivingVia
+    DuplicateRecordFields
+    LambdaCase
+    NoFieldSelectors
+    OverloadedLabels
+    OverloadedRecordDot
+    OverloadedStrings
+    -- This is annoying with fourmolu
+    NoImportQualifiedPost
+
+  build-depends:
+    base >=4.7 && <5
+
+library
+  import: defaults
+  exposed-modules:
+    Application
+    Backend.Api
+    Backend.Jl4
+    Examples
+    Options
+    Schema
+    Server
+
+  other-modules:
+    Paths_jl4_decision_service
+
+  autogen-modules:
+    Paths_jl4_decision_service
+
+  hs-source-dirs:
+    src
+
+  build-depends:
+    aeson,
+    aeson-combinators,
+    bytestring,
+    chronos,
+    containers,
+    extra,
+    filepath,
+    jl4,
+    lens,
+    openapi3,
+    optics,
+    optparse-applicative,
+    scientific,
+    servant >=0.20.2 && <0.21,
+    servant-openapi3,
+    servant-server >=0.20.2 && <0.21,
+    servant-swagger-ui,
+    stm,
+    string-interpolate,
+    text,
+    transformers,
+    vector,
+    wai,
+    wai-logger,
+    warp,
+
+executable jl4-decision-service-exe
+  import: defaults
+  main-is: Main.hs
+  other-modules:
+    Paths_jl4_decision_service
+
+  autogen-modules:
+    Paths_jl4_decision_service
+
+  hs-source-dirs:
+    app
+
+  build-depends:
+    jl4-decision-service
+
+test-suite jl4-decision-service-test
+  import: defaults
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+    Paths_jl4_decision_service
+    SchemaSpec
+
+  hs-source-dirs:
+    test
+
+  build-tool-depends:
+    hspec-discover:hspec-discover
+
+  build-depends:
+    QuickCheck,
+    base >=4.7 && <5,
+    hspec,
+    quickcheck-instances,
+    servant >=0.20.2 && <0.21,
+    servant-openapi3,
+    text,
+    jl4-decision-service,

--- a/jl4-decision-service/src/Application.hs
+++ b/jl4-decision-service/src/Application.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Application (defaultMain) where
+
+import Control.Concurrent.STM (newTVarIO)
+import Control.Monad.Trans.Reader (ReaderT (..))
+import qualified Examples
+import Network.Wai
+import Network.Wai.Handler.Warp
+import Network.Wai.Logger
+import Options
+import Options.Applicative as Opts
+import Schema
+import Servant
+import Servant.Swagger.UI (SwaggerSchemaUI, swaggerSchemaUIServer)
+import Server
+
+-- ----------------------------------------------------------------------------
+-- Option Parser
+-- ----------------------------------------------------------------------------
+
+opts :: ParserInfo Options
+opts =
+  Opts.info
+    (optionsParser <**> helper)
+    ( fullDesc
+        <> progDesc "Serve a Web Service for interacting with the L4 evaluator"
+        <> header "L4 explainable - A web server for L4"
+    )
+
+-- ----------------------------------------------------------------------------
+-- Main Application and wiring
+-- ----------------------------------------------------------------------------
+
+defaultMain :: IO ()
+defaultMain = do
+  Options{port, serverName} <- execParser opts
+  dbRef <- newTVarIO Examples.functionSpecs
+  let
+    initialState = DbState dbRef
+  putStrLn $ "Application started on port: " <> show port
+  withStdoutLogger $ \aplogger -> do
+    let
+      settings = setPort port $ setLogger aplogger defaultSettings
+    runSettings settings (app initialState serverName)
+
+type ApiWithSwagger =
+  SwaggerSchemaUI "swagger-ui" "swagger.json"
+    :<|> Api
+
+appWithSwagger :: DbState -> Maybe ServerName -> Servant.Server ApiWithSwagger
+appWithSwagger initialDb mServerName =
+  swaggerSchemaUIServer (serverOpenApi mServerName)
+    :<|> hoistServer (Proxy @Api) (nt initialDb) handler
+ where
+  nt :: DbState -> AppM a -> Handler a
+  nt s x = runReaderT x s
+
+app :: DbState -> Maybe ServerName -> Application
+app initialDb mServerName = do
+  serve (Proxy @ApiWithSwagger) (appWithSwagger initialDb mServerName)

--- a/jl4-decision-service/src/Backend/Api.hs
+++ b/jl4-decision-service/src/Backend/Api.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Backend.Api (
+  module Backend.Api,
+) where
+
+import Control.Monad.Trans.Except (ExceptT)
+import Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.KeyMap as Aeson
+import Data.Aeson.Types as Aeson
+import Data.Bifunctor (bimap)
+import qualified Data.Foldable as Foldable
+import Data.Map.Strict (Map)
+import qualified Data.Scientific as Scientific
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Read as TextReader
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+import Optics.Cons
+import Servant.API
+
+type FunctionName = Text
+
+data FnLiteral
+  = FnLitInt !Integer
+  | FnLitDouble !Double
+  | FnLitBool !Bool
+  | FnLitString !Text
+  | FnArray [FnLiteral]
+  | FnObject [(Text, FnLiteral)]
+  | FnUncertain
+  | FnUnknown
+  deriving (Show, Read, Ord, Eq, Generic)
+
+instance ToJSON FnLiteral where
+  toJSON = \case
+    FnLitInt val -> String $ tshow val
+    FnLitDouble val -> String $ tshow val
+    FnLitBool val -> String $ tshow val
+    FnLitString val -> String val
+    FnArray vals -> Array $ V.fromList $ fmap toJSON vals
+    FnObject ps -> Object $ Aeson.fromList $ fmap (bimap Aeson.fromText toJSON) ps
+    FnUncertain -> Object $ Aeson.fromList []
+    FnUnknown -> Null
+   where
+    tshow :: forall a. (Show a) => a -> Text
+    tshow = Text.pack . show
+
+instance FromJSON FnLiteral where
+  parseJSON = \case
+    String val -> pure $ parseTextAsFnLiteral val
+    Bool val -> pure $ FnLitBool val
+    Number val
+      | Just (i :: Int) <- Scientific.toBoundedInteger val -> pure $ FnLitInt $ fromIntegral i
+      | Right d <- Scientific.toBoundedRealFloat val -> pure $ FnLitDouble d
+      | otherwise -> Aeson.typeMismatch "Failed to parse number into bounded real or integer" (Number val)
+    Null -> pure FnUnknown
+    Array vals -> FnArray <$> traverse parseJSON (Foldable.toList vals)
+    Object o
+      | [] <- Aeson.toList o -> pure FnUncertain
+      | otherwise -> do
+          ps <- traverse (\(k, v) -> fmap (Aeson.toText k,) (parseJSON v)) (Aeson.toList o)
+          pure $ FnObject ps
+
+data RunFunction = RunFunction
+  { -- | Run a function with parameters
+    runFunction ::
+      [(Text, Maybe FnLiteral)] ->
+      -- ^ Parameters to the function
+      Maybe (Set Text) ->
+      -- ^ Output filter, as the function may return a record of
+      -- outputs.
+      -- If this filter is 'Nothing', we do not filter anything.
+      ExceptT EvaluatorError IO ResponseWithReason
+  }
+
+-- | A Function declaration is the definition of a function from the
+-- perspective of this decision REST API.
+data FunctionDeclaration = FunctionDeclaration
+  { name :: !Text
+  -- ^ Name of the function.
+  -- Used in the interpreter of the various backends.
+  , description :: !Text
+  -- ^ A description of the function.
+  , longNames :: !(Set Text)
+  -- ^ A set of parameter names which the function can be called with.
+  , nameMapping :: !(Map Text Text)
+  -- ^ How to translate 'short' names to their 'long' counter part.
+  }
+
+data ResponseWithReason = ResponseWithReason
+  { values :: [(Text, FnLiteral)]
+  , reasoning :: Reasoning
+  }
+  deriving (Show, Read, Ord, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- | Wrap our reasoning into a top-level field.
+data Reasoning = Reasoning
+  { payload :: ReasoningTree
+  }
+  deriving (Show, Read, Ord, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+emptyTree :: Reasoning
+emptyTree =
+  Reasoning
+    { payload =
+        ReasoningTree
+          { payload =
+              ReasonNode
+                { exampleCode = []
+                , explanation = []
+                }
+          , children = []
+          }
+    }
+
+-- | Basically a rose tree, but serialisable to json and specialised to our purposes.
+data ReasoningTree = ReasoningTree
+  { payload :: ReasonNode
+  , children :: [ReasoningTree]
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data ReasonNode = ReasonNode
+  { exampleCode :: [Text]
+  , explanation :: [Text]
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- | An 'EvaluatorError' is some form of panic thrown by an evaluator.
+-- The execution of a function had to be interrupted for /some/ reason.
+-- Such an exception is unrecoverable.
+-- The error message may contain hints of what might have gone wrong.
+data EvaluatorError
+  = InterpreterError !Text
+  | RequiredParameterMissing !ParameterMismatch
+  | UnknownArguments ![Text]
+  | CannotHandleParameterType !FnLiteral
+  | CannotHandleUnknownVars
+  deriving stock (Show, Read, Ord, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data ParameterMismatch = ParameterMismatch
+  { expected :: !Int
+  , actual :: !Int
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+instance FromHttpApiData FnLiteral where
+  parseQueryParam t = Right $ parseTextAsFnLiteral t
+
+parseTextAsFnLiteral :: Text -> FnLiteral
+parseTextAsFnLiteral t
+  | Right (d, "") <- TextReader.signed TextReader.decimal t = FnLitInt d
+  | Right (d, "") <- TextReader.double t = FnLitDouble d
+  | Just b <- parseAsBool = FnLitBool b
+  | Just st <- stripQuotes = FnLitString st
+  | otherwise = FnLitString t
+ where
+  parseAsBool = case Text.toLower t of
+    "true" -> Just True
+    "false" -> Just False
+    "yes" -> Just True
+    "no" -> Just False
+    _ -> Nothing
+
+  stripQuotes = do
+    ('\"', t') <- uncons t
+    (t'', '\"') <- unsnoc t'
+    pure t''

--- a/jl4-decision-service/src/Backend/Jl4.hs
+++ b/jl4-decision-service/src/Backend/Jl4.hs
@@ -1,0 +1,171 @@
+module Backend.Jl4 (createFunction) where
+
+import Backend.Api
+import Base.Text
+import qualified Base.Text as Text
+import Control.Monad.Trans.Except
+import L4.Annotation
+import qualified L4.Evaluate as Evaluate
+import qualified L4.Evaluate.Value as Eval
+import L4.Main
+import L4.Print
+import L4.Syntax
+import System.FilePath ((<.>))
+
+createFunction ::
+  (Monad m) =>
+  FunctionDeclaration ->
+  Text ->
+  ExceptT EvaluatorError m RunFunction
+createFunction fnDecl fnImpl =
+  pure $
+    RunFunction
+      { runFunction = \params _outFilter {- TODO: how to handle the outFilter? -} -> do
+          l4Params <- traverse (uncurry toL4Param) params
+          let
+            l4InputWithEval =
+              Text.unlines
+                [ fnImpl
+                , prettyLayout $ evalStatement l4Params
+                ]
+          case parseAndCheck file l4InputWithEval of
+            Left cliError -> do
+              let
+                errMsg = prettyCliError cliError
+              throwE $ InterpreterError errMsg
+            Right p -> do
+              case Evaluate.doEvalProgram p of
+                [(_srcRange, valEither)] -> case valEither of
+                  Left evalExc -> throwE $ InterpreterError $ Text.show evalExc
+                  Right val -> do
+                    r <- valueToFnLiteral val
+                    pure $
+                      ResponseWithReason
+                        { values = [("result", r)]
+                        , reasoning = emptyTree
+                        }
+                [] -> throwE $ InterpreterError "L4 Internal Error: No #EVAL"
+                _xs -> throwE $ InterpreterError "L4 Error: More than ONE #EVAL found"
+      }
+ where
+  toL4Param _ Nothing = do
+    throwE CannotHandleUnknownVars
+  toL4Param nameText (Just fnLiteral) = do
+    (mkName nameText,) <$> literalToExpr fnLiteral
+
+  file = Text.unpack fnDecl.name <.> "l4"
+
+  funName = mkName fnDecl.name
+
+  inputName = mkName "Inputs"
+
+  evalStatement args =
+    mkTopDeclDirective $
+      mkEval $
+        mkFunApp
+          funName
+          [ mkInputs inputName $
+              fmap (uncurry mkArg) args
+          ]
+
+literalToExpr :: (Monad m) => FnLiteral -> ExceptT EvaluatorError m (Expr Name)
+literalToExpr = \case
+  FnLitInt i -> pure . mkLit $ mkNumericLit $ fromIntegral i
+  FnLitDouble d -> throwE $ CannotHandleParameterType $ FnLitDouble d
+  FnLitBool b -> pure . mkVar $ mkBoolean b
+  FnLitString s -> pure . mkLit $ mkStringLit s
+  FnArray arr -> do
+    es <- traverse literalToExpr arr
+    pure $ mkList es
+  FnObject obj -> throwE $ CannotHandleParameterType $ FnObject obj
+  FnUncertain -> pure $ mkVar mkUncertain
+  FnUnknown -> pure $ mkVar mkUnknown
+
+valueToFnLiteral :: (Monad m) => Eval.Value -> ExceptT EvaluatorError m FnLiteral
+valueToFnLiteral = \case
+  Eval.ValNumber i -> pure $ FnLitInt $ fromIntegral i
+  Eval.ValString t -> pure $ FnLitString t
+  Eval.ValList vals -> do
+    lits <- traverse valueToFnLiteral vals
+    pure $ FnArray lits
+  Eval.ValClosure _ _ _ -> do
+    throwE $ InterpreterError $ "#EVAL produced function closure."
+  Eval.ValUnappliedConstructor name ->
+    pure $ FnLitString $ prettyLayout name
+  Eval.ValConstructor resolved [] ->
+    -- Constructors such as TRUE and FALSE
+    pure $ FnLitString $ prettyLayout $ getActual resolved
+  Eval.ValConstructor resolved vals -> do
+    lits <- traverse valueToFnLiteral vals
+    pure $
+      FnObject
+        [ (prettyLayout $ getActual resolved, FnArray lits)
+        ]
+  Eval.ValAssumed var ->
+    throwE $ InterpreterError $ "#EVAL produced ASSUME: " <> prettyLayout var
+
+-- ----------------------------------------------------------------------------
+-- L4 syntax builders
+-- ----------------------------------------------------------------------------
+
+mkTopDeclDirective :: Directive n -> TopDecl n
+mkTopDeclDirective = Directive emptyAnno
+
+mkEval :: Expr n -> Directive n
+mkEval = Eval emptyAnno
+
+mkFunApp :: n -> [Expr n] -> Expr n
+mkFunApp =
+  App emptyAnno
+
+mkInputs :: n -> [NamedExpr n] -> Expr n
+mkInputs con args =
+  AppNamed emptyAnno con args Nothing
+
+mkArg :: n -> Expr n -> NamedExpr n
+mkArg =
+  MkNamedExpr emptyAnno
+
+mkName :: Text -> Name
+mkName =
+  MkName emptyAnno . NormalName
+
+mkVar :: n -> Expr n
+mkVar =
+  Var emptyAnno
+
+mkLit :: Lit -> Expr n
+mkLit =
+  Lit emptyAnno
+
+l4True :: Name
+l4True =
+  MkName emptyAnno $ NormalName "TRUE"
+
+l4False :: Name
+l4False =
+  MkName emptyAnno $ NormalName "FALSE"
+
+mkBoolean :: Bool -> Name
+mkBoolean b =
+  case b of
+    True -> l4True
+    False -> l4False
+
+mkNumericLit :: Int -> Lit
+mkNumericLit =
+  NumericLit emptyAnno
+
+mkStringLit :: Text -> Lit
+mkStringLit =
+  StringLit emptyAnno
+
+mkList :: [Expr n] -> Expr n
+mkList =
+  List emptyAnno
+
+mkUncertain :: Name
+mkUncertain = mkName "uncertain"
+
+mkUnknown :: Name
+mkUnknown = mkName "unknown"

--- a/jl4-decision-service/src/Examples.hs
+++ b/jl4-decision-service/src/Examples.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Examples (functionSpecs) where
+
+import Backend.Jl4 as Jl4
+import Control.Monad.Trans.Except
+import qualified Data.Map.Strict as Map
+import Data.String.Interpolate
+import Data.Text (Text)
+import Server
+
+-- ----------------------------------------------------------------------------
+-- Example data
+-- ----------------------------------------------------------------------------
+
+functionSpecs :: Map.Map Text ValidatedFunction
+functionSpecs =
+  Map.fromList
+    [ (f.fnImpl.name, f)
+    | f <-
+        [ builtinProgram personQualifiesFunction
+        , builtinProgram rodentsAndVerminFunction
+        ]
+    ]
+
+-- | Metadata about the function that the user might want to know.
+-- Further, an LLM could use this info to ask specific questions to the user.
+personQualifiesFunction :: Except EvaluatorError ValidatedFunction
+personQualifiesFunction = do
+  let
+    fnDecl =
+      Function
+        { name = "compute_qualifies"
+        , description =
+            [__i|Determines if a person qualifies for the purposes of the rule.
+                  The input object describes the person's properties in the primary parameters: walks, eats, drinks.
+                  Secondary parameters can be given which are sufficient to determine some of the primary parameters.
+                  A person drinks whether or not they consume an alcoholic or a non-alcoholic beverage, in part or in whole;
+                  those specific details don't really matter.
+                  The output of the function can be either a request for required information;
+                  a restatement of the user input requesting confirmation prior to function calling;
+                  or a Boolean answer with optional explanation summary.
+                |]
+        , parameters =
+            Parameters $
+              Map.fromList
+                [ ("walks", Parameter "string" Nothing ["true", "false"] "Did the person walk?")
+                , ("eats", Parameter "string" Nothing ["true", "false"] "Did the person eat?")
+                , ("drinks", Parameter "string" Nothing ["true", "false"] "Did the person drink?")
+                ]
+        , supportedEvalBackend = []
+        }
+  pure $
+    ValidatedFunction
+      { fnImpl = fnDecl
+      , fnEvaluator =
+          Map.fromList
+            [ (JL4, builtinProgram $ Jl4.createFunction (toDecl fnDecl) computeQualifiesJL4)
+            ]
+      }
+
+-- | Metadata about the function that the user might want to know.
+-- Further, an LLM could use this info to ask specific questions to the user.
+rodentsAndVerminFunction :: Except EvaluatorError ValidatedFunction
+rodentsAndVerminFunction = do
+  let
+    fnDecl =
+      Function
+        { name = "vermin_and_rodent"
+        , description =
+            [__i|We do not cover any loss or damage caused by rodents, insects, vermin, or birds.
+                  However, this exclusion does not apply to:
+                  a) loss or damage to your contents caused by birds; or
+                  b) ensuing covered loss unless any other exclusion applies or where an animal causes water to escape from
+                    a household appliance, swimming pool or plumbing, heating or air conditioning system
+                  |]
+        , parameters =
+            Parameters $
+              Map.fromList
+                [ ("Loss or Damage.caused by insects", Parameter "string" Nothing ["true", "false"] "Was the damage caused by insects?")
+                , ("Loss or Damage.caused by birds", Parameter "string" Nothing ["true", "false"] "Was the damage caused by birds?")
+                , ("Loss or Damage.caused by vermin", Parameter "string" Nothing ["true", "false"] "Was the damage caused by vermin?")
+                , ("Loss or Damage.caused by rodents", Parameter "string" Nothing ["true", "false"] "Was the damage caused by rodents?")
+                , ("Loss or Damage.to Contents", Parameter "string" Nothing ["true", "false"] "Is the damage to your contents?")
+                , ("Loss or Damage.ensuing covered loss", Parameter "string" Nothing ["true", "false"] "Is the damage ensuing covered loss")
+                , ("any other exclusion applies", Parameter "string" Nothing ["true", "false"] "Are any other exclusions besides mentioned ones?")
+                , ("a household appliance", Parameter "string" Nothing ["true", "false"] "Did water escape from a household appliance due to an animal?")
+                , ("a swimming pool", Parameter "string" Nothing ["true", "false"] "Did water escape from a swimming pool due to an animal?")
+                , ("a plumbing, heating, or air conditioning system", Parameter "string" Nothing ["true", "false"] "Did water escape from a plumbing, heating or conditioning system due to an animal?")
+                ]
+        , supportedEvalBackend = []
+        }
+  pure $
+    ValidatedFunction
+      { fnImpl = fnDecl
+      , fnEvaluator =
+          Map.fromList
+            [ (JL4, builtinProgram $ Jl4.createFunction (toDecl fnDecl) rodentsAndVerminJL4)
+            ]
+      }
+
+computeQualifiesJL4 :: Text
+computeQualifiesJL4 =
+  [i|
+DECLARE Inputs
+  HAS
+    walks IS A BOOLEAN
+    drinks IS A BOOLEAN
+    eats IS A BOOLEAN
+
+GIVEN i IS Inputs
+GIVETH A BOOLEAN
+DECIDE `compute_qualifies` i IF
+        i's walks
+ AND    i's drinks
+     OR i's eats
+|]
+
+rodentsAndVerminJL4 :: Text
+rodentsAndVerminJL4 =
+  [i|
+DECLARE Inputs
+  HAS
+    `Loss or Damage.caused by rodents` IS A BOOLEAN
+    `Loss or Damage.caused by insects` IS A BOOLEAN
+    `Loss or Damage.caused by vermin` IS A BOOLEAN
+    `Loss or Damage.caused by birds` IS A BOOLEAN
+    `Loss or Damage.to Contents` IS A BOOLEAN
+    `any other exclusion applies` IS A BOOLEAN
+    `a household appliance` IS A BOOLEAN
+    `a swimming pool` IS A BOOLEAN
+    `a plumbing, heating, or air conditioning system` IS A BOOLEAN
+    `Loss or Damage.ensuing covered loss` IS A BOOLEAN
+
+GIVEN i IS Inputs
+GIVETH A BOOLEAN
+DECIDE `vermin_and_rodent` i IF
+    `not covered if`
+         `loss or damage by animals`
+     AND NOT               `damage to contents and caused by birds`
+                OR         `ensuing covered loss`
+                    AND NOT `exclusion apply`
+ WHERE
+    `not covered if` MEANS GIVEN x YIELD x
+
+    `loss or damage by animals` MEANS
+        i's `Loss or Damage.caused by rodents`
+     OR i's `Loss or Damage.caused by insects`
+     OR i's `Loss or Damage.caused by vermin`
+     OR i's `Loss or Damage.caused by birds`
+
+    `damage to contents and caused by birds` MEANS
+         i's `Loss or Damage.to Contents`
+     AND i's `Loss or Damage.caused by birds`
+
+    `ensuing covered loss` MEANS
+        i's `Loss or Damage.ensuing covered loss`
+
+    `exclusion apply` MEANS
+        i's `any other exclusion applies`
+     OR i's `a household appliance`
+     OR i's `a swimming pool`
+     OR i's `a plumbing, heating, or air conditioning system`
+|]
+
+builtinProgram :: Except EvaluatorError a -> a
+builtinProgram m = case runExcept m of
+  Left err -> error $ "Builtin failed to load " <> show err
+  Right e -> e

--- a/jl4-decision-service/src/Options.hs
+++ b/jl4-decision-service/src/Options.hs
@@ -14,7 +14,7 @@ data Options = Options
 optionsParser :: Parser Options
 optionsParser = do
   Options
-    <$> ( option
+    <$> option
             auto
             ( long "port"
                 <> short 'p'
@@ -22,7 +22,6 @@ optionsParser = do
                 <> value 8081
                 <> help "HTTP port to use"
             )
-        )
     <*> optional
       ( strOption
           ( long "serverName"

--- a/jl4-decision-service/src/Options.hs
+++ b/jl4-decision-service/src/Options.hs
@@ -1,0 +1,33 @@
+module Options (
+  Options (..),
+  optionsParser,
+) where
+
+import qualified Data.Text as Text
+import Options.Applicative
+
+data Options = Options
+  { port :: Int
+  , serverName :: Maybe Text.Text
+  }
+
+optionsParser :: Parser Options
+optionsParser = do
+  Options
+    <$> ( option
+            auto
+            ( long "port"
+                <> short 'p'
+                <> metavar "PORT"
+                <> value 8081
+                <> help "HTTP port to use"
+            )
+        )
+    <*> optional
+      ( strOption
+          ( long "serverName"
+              <> short 's'
+              <> metavar "URL"
+              <> help "Name of the server. Exposed in swagger.json field."
+          )
+      )

--- a/jl4-decision-service/src/Schema.hs
+++ b/jl4-decision-service/src/Schema.hs
@@ -10,7 +10,7 @@ module Schema (
 
 --
 
-import Backend.Api hiding (description, name)
+import Backend.Api
 import Control.Lens hiding ((.=))
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
@@ -23,16 +23,16 @@ import qualified Data.Text as Text
 import GHC.TypeLits
 import Servant
 import Servant.OpenApi
-import Server hiding (description, name)
+import Server
 
 type ServerName = Text
 
 serverOpenApi :: Maybe ServerName -> OpenApi
 serverOpenApi serverName =
   toOpenApi (Proxy :: Proxy Api)
-    & info . title .~ "MathLang Function API"
+    & info . title .~ "JL4 Function API"
     & info . version .~ "1.0"
-    & info . description ?~ "API for invoking MathLang functions"
+    & info . description ?~ "API for invoking JL4 functions"
     & servers .~ Maybe.maybeToList ((\sName -> Server sName mempty mempty) <$> serverName)
 
 instance (KnownSymbol desc, HasOpenApi api) => HasOpenApi (OperationId desc :> api) where
@@ -197,7 +197,7 @@ instance ToSchema FnLiteral where
     fnLiteralSchema <- declareSchemaRef (Proxy @FnLiteral)
     pure $
       NamedSchema (Just "Literal") $
-        (toParamSchema p)
+        toParamSchema p
           & oneOf
             ?~ [ intSchema
                , mTextSchema
@@ -252,7 +252,7 @@ instance ToSchema BatchRequest where
     let
       intRef =
         Inline $
-          (toParamSchema $ Proxy @Int)
+          toParamSchema (Proxy @Int)
             & default_ ?~ Aeson.Number 0
             & example ?~ Aeson.Number 0
     pure $
@@ -305,7 +305,7 @@ instance ToSchema BatchResponse where
     let
       intRef =
         Inline $
-          (toParamSchema $ Proxy @Int)
+          toParamSchema (Proxy @Int)
             & default_ ?~ Aeson.Number 0
             & example ?~ Aeson.Number 0
     doubleRef <- declareSchemaRef (Proxy @Double)

--- a/jl4-decision-service/src/Schema.hs
+++ b/jl4-decision-service/src/Schema.hs
@@ -1,0 +1,348 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wall -Wno-orphans #-}
+
+module Schema (
+  serverOpenApi,
+  ServerName,
+) where
+
+--
+
+import Backend.Api hiding (description, name)
+import Control.Lens hiding ((.=))
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import Data.Map (Map)
+import qualified Data.Maybe as Maybe
+import Data.OpenApi
+import Data.Proxy
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.TypeLits
+import Servant
+import Servant.OpenApi
+import Server hiding (description, name)
+
+type ServerName = Text
+
+serverOpenApi :: Maybe ServerName -> OpenApi
+serverOpenApi serverName =
+  toOpenApi (Proxy :: Proxy Api)
+    & info . title .~ "MathLang Function API"
+    & info . version .~ "1.0"
+    & info . description ?~ "API for invoking MathLang functions"
+    & servers .~ Maybe.maybeToList ((\sName -> Server sName mempty mempty) <$> serverName)
+
+instance (KnownSymbol desc, HasOpenApi api) => HasOpenApi (OperationId desc :> api) where
+  toOpenApi _ =
+    toOpenApi (Proxy :: Proxy api)
+      & allOperations . operationId %~ (Just (Text.pack (symbolVal (Proxy :: Proxy desc))) <>)
+
+-- ----------------------------------------------------------------------------
+-- Document and describe the Json schema using the OpenAPI standard
+-- ----------------------------------------------------------------------------
+
+instance ToSchema SimpleFunction where
+  declareNamedSchema _ = do
+    textRef <- declareSchemaRef (Proxy @Text)
+    pure $
+      NamedSchema (Just "Function") $
+        mempty
+          & title ?~ "Function"
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ [ ("type", textRef)
+               ,
+                 ( "function"
+                 , Inline $
+                    mempty
+                      & properties
+                        .~ [ ("name", textRef)
+                           , ("description", textRef)
+                           ]
+                 )
+               ]
+
+-- This is correct, since we don't overwrite the
+-- 'ToJSON' instance yet.
+instance ToSchema SimpleResponse
+
+-- This is correct, since we don't overwrite the
+-- 'ToJSON' instance yet.
+instance ToSchema EvaluatorError
+
+-- This is correct, since we don't overwrite the
+-- 'ToJSON' instance yet.
+instance ToSchema ParameterMismatch
+
+-- This is correct, since we don't overwrite the
+-- 'ToJSON' instance yet.
+instance ToSchema ResponseWithReason
+
+-- This is correct, since we don't overwrite the
+-- 'ToJSON' instance yet.
+instance ToSchema Reasoning
+
+-- This is correct, since we don't overwrite the
+-- 'ToJSON' instance yet.
+instance ToSchema ReasoningTree
+
+-- This is correct, since we don't overwrite the
+-- 'ToJSON' instance yet.
+instance ToSchema ReasonNode
+
+-- This is correct, since we don't overwrite the
+-- 'ToJSON' instance yet.
+instance ToSchema FnArguments
+
+instance ToSchema Function where
+  declareNamedSchema _ = do
+    textRef <- declareSchemaRef (Proxy @Text)
+    parametersRef <- declareSchemaRef (Proxy @Parameters)
+    evalBackendsRef <- declareSchemaRef (Proxy @[EvalBackend])
+    pure $
+      NamedSchema (Just "Function") $
+        mempty
+          & title ?~ "Function"
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ [ ("type", textRef)
+               ,
+                 ( "function"
+                 , Inline $
+                    mempty
+                      & properties
+                        .~ [ ("name", textRef)
+                           , ("description", textRef)
+                           , ("supportedBackends", evalBackendsRef)
+                           ,
+                             ( "parameters"
+                             , Inline $
+                                mempty
+                                  & properties
+                                    .~ [ ("type", textRef)
+                                       , ("properties", parametersRef)
+                                       ]
+                             )
+                           ]
+                 )
+               ]
+
+instance ToSchema FunctionImplementation where
+  declareNamedSchema _ = do
+    implRef <- declareSchemaRef (Proxy @(Map EvalBackend Text))
+    functionDeclRef <- declareSchemaRef (Proxy @Function)
+    pure $
+      NamedSchema (Just "Implementation") $
+        mempty
+          & title ?~ "Implementation"
+          & type_ ?~ OpenApiObject
+          & properties
+            .~ [ ("declaration", functionDeclRef)
+               , ("implementation", implRef)
+               ]
+
+instance ToSchema Parameters where
+  declareNamedSchema _ = do
+    -- parameterSchema <- declareSchemaRef (Proxy @Parameter)
+    mapSchema <- declareNamedSchema (Proxy @(Map Text Parameter))
+    pure $
+      mapSchema
+        & name ?~ "FunctionParameters"
+
+instance ToSchema Parameter where
+  declareNamedSchema _ = do
+    textSchema <- declareSchemaRef (Proxy @Text)
+    mTextSchema <- declareSchemaRef (Proxy @(Maybe Text))
+    textListSchema <- declareSchemaRef (Proxy @[Text])
+    pure $
+      NamedSchema (Just "FunctionParameter") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & title ?~ "Parameter"
+          & properties
+            .~ [ ("enum", textListSchema)
+               , ("description", textSchema)
+               , ("alias", mTextSchema)
+               , ("type", textSchema)
+               ]
+          & required .~ ["type"]
+          & example
+            ?~ Aeson.object
+              [ "enum" .= (["true", "false", "uncertain"] :: Aeson.Array)
+              , "description" .= Aeson.String "Can a person walk?"
+              , "alias" .= Aeson.String "w"
+              , "type" .= Aeson.String "string"
+              ]
+
+instance ToParamSchema FnLiteral where
+  toParamSchema _ =
+    mempty
+      & title ?~ "Argument"
+      -- Even though this is strictly speaking not *only* a string, custom GPT seem
+      -- to need this, otherwise they will fail to send any requests to any endpoint with
+      -- this query parameter.
+      & type_ ?~ OpenApiString
+      & example ?~ Aeson.String "true"
+      & description ?~ "A Function argument which can be either 'true' or 'false', or a floating point number. Additionally accepts 'yes' and 'no' as synonyms for 'true' and 'false' respectively."
+
+instance ToSchema FnLiteral where
+  declareNamedSchema p = do
+    intSchema <- declareSchemaRef (Proxy @Int)
+    mTextSchema <- declareSchemaRef (Proxy @Text)
+    fracSchema <- declareSchemaRef (Proxy @Double)
+    boolSchema <- declareSchemaRef (Proxy @Bool)
+    fnLiteralSchema <- declareSchemaRef (Proxy @FnLiteral)
+    pure $
+      NamedSchema (Just "Literal") $
+        (toParamSchema p)
+          & oneOf
+            ?~ [ intSchema
+               , mTextSchema
+               , fracSchema
+               , boolSchema
+               , Inline $
+                  mempty
+                    & type_ ?~ OpenApiObject
+                    & properties .~ []
+                    & additionalProperties ?~ AdditionalPropertiesAllowed True
+               , Inline $
+                  mempty & type_ ?~ OpenApiNull
+               , Inline $
+                  mempty
+                    & type_ ?~ OpenApiArray
+                    & items ?~ OpenApiItemsObject fnLiteralSchema
+               ]
+
+instance ToSchema EvalBackend where
+  declareNamedSchema p = do
+    pure $
+      NamedSchema (Just "EvalBackend") $
+        toParamSchema p
+
+instance ToParamSchema EvalBackend where
+  toParamSchema _ =
+    mempty
+      & type_ ?~ OpenApiString
+      & title ?~ "Evaluation Backends"
+      & example ?~ Aeson.String "jl4"
+      & default_ ?~ Aeson.String "hl4"
+      & enum_ ?~ [Aeson.String "jl4"]
+      & description ?~ "Backend for evaluation of a function. Backends can greatly affect the explanation quality. Additionally, backends may or may not support parts of natural4."
+
+instance ToParamSchema (Map Text FnLiteral) where
+  toParamSchema _ =
+    mempty
+      & type_ ?~ OpenApiObject
+      & title ?~ "Function Arguments"
+      & example
+        ?~ Aeson.Object
+          [ "drinks" .= Aeson.String "true"
+          , "eats" .= Aeson.String "true"
+          , "walks" .= Aeson.String "false"
+          , "amount" .= Aeson.Number 2.0
+          ]
+      & description ?~ "Provide arguments to the function to be invoked."
+
+instance ToSchema BatchRequest where
+  declareNamedSchema _ = do
+    textRef <- declareSchemaRef (Proxy @Text)
+    let
+      intRef =
+        Inline $
+          (toParamSchema $ Proxy @Int)
+            & default_ ?~ Aeson.Number 0
+            & example ?~ Aeson.Number 0
+    pure $
+      NamedSchema (Just "BatchRequest") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & title ?~ "Batch Request"
+          & properties
+            .~ [
+                 ( "outcomes"
+                 , Inline $
+                    mempty
+                      & type_ ?~ OpenApiArray
+                      & items
+                        ?~ OpenApiItemsObject
+                          ( Inline $
+                              mempty
+                                & oneOf
+                                  ?~ [ textRef
+                                     , Inline $
+                                        mempty
+                                          & type_ ?~ OpenApiObject
+                                          & additionalProperties ?~ AdditionalPropertiesAllowed True
+                                          & properties
+                                            .~ [ ("@id", textRef)
+                                               ]
+                                     ]
+                          )
+                 )
+               ,
+                 ( "cases"
+                 , Inline $
+                    mempty
+                      & type_ ?~ OpenApiArray
+                      & items
+                        ?~ OpenApiItemsObject
+                          ( Inline $
+                              mempty
+                                & additionalProperties ?~ AdditionalPropertiesAllowed True
+                                & type_ ?~ OpenApiObject
+                                & properties
+                                  .~ [ ("@id", intRef)
+                                     ]
+                          )
+                 )
+               ]
+
+instance ToSchema BatchResponse where
+  declareNamedSchema _ = do
+    let
+      intRef =
+        Inline $
+          (toParamSchema $ Proxy @Int)
+            & default_ ?~ Aeson.Number 0
+            & example ?~ Aeson.Number 0
+    doubleRef <- declareSchemaRef (Proxy @Double)
+    pure $
+      NamedSchema (Just "BatchResponse") $
+        mempty
+          & type_ ?~ OpenApiObject
+          & title ?~ "Batch Response"
+          & properties
+            .~ [
+                 ( "cases"
+                 , Inline $
+                    mempty
+                      & type_ ?~ OpenApiArray
+                      & items
+                        ?~ OpenApiItemsObject
+                          ( Inline $
+                              mempty
+                                & type_ ?~ OpenApiObject
+                                & additionalProperties ?~ AdditionalPropertiesAllowed True
+                                & properties
+                                  .~ [("@id", intRef)]
+                          )
+                 )
+               ,
+                 ( "summary"
+                 , Inline $
+                    mempty
+                      & type_ ?~ OpenApiArray
+                      & type_ ?~ OpenApiObject
+                      & properties
+                        .~ [ ("casesRead", intRef)
+                           , ("casesProcessed", intRef)
+                           , ("casesIgnored", intRef)
+                           , ("processorDurationSec", doubleRef)
+                           , ("processorCasesPerSec", doubleRef)
+                           , ("processorQueuedSec", doubleRef)
+                           ]
+                 )
+               ]

--- a/jl4-decision-service/src/Server.hs
+++ b/jl4-decision-service/src/Server.hs
@@ -1,0 +1,854 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Server (
+  -- * AppM
+  AppM,
+  DbState (..),
+  ValidatedFunction (..),
+
+  -- * Servant
+  OperationId,
+
+  -- * REST API
+  Api,
+  FunctionApi,
+  FunctionApi' (..),
+  SingleFunctionApi,
+  SingleFunctionApi' (..),
+  FunctionCrud,
+  FunctionCrud' (..),
+  handler,
+
+  -- * API json types
+  Parameters (..),
+  Parameter (..),
+  Function (..),
+  SimpleFunction (..),
+  SimpleResponse (..),
+  Reasoning (..),
+  ReasoningTree (..),
+  ResponseWithReason (..),
+  EvaluatorError (..),
+  FnLiteral (..),
+  EvalBackend (..),
+  FunctionImplementation (..),
+  FnArguments (..),
+  Outcomes (..),
+  OutcomeObject (..),
+  OutcomeStyle (..),
+  BatchRequest (..),
+  InputCase (..),
+  OutputCase (..),
+  BatchResponse (..),
+  OutputSummary (..),
+
+  -- * utilities
+  toDecl,
+) where
+
+import Backend.Api
+import Backend.Api as Api
+import qualified Backend.Jl4 as Jl4
+
+import qualified Chronos
+import Control.Applicative
+import Control.Concurrent.STM
+import Control.Exception (evaluate)
+import Control.Monad (forM, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Reader (ReaderT (..), asks)
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey, (.:), (.=))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Combinators.Decode (Decoder)
+import qualified Data.Aeson.Combinators.Decode as ACD
+import qualified Data.Aeson.Key as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString as BS
+import Data.Fixed
+import Data.Int
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Maybe as Maybe
+import Data.Scientific (Scientific)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TL
+import qualified Data.Tuple.Extra as Tuple
+import Data.Typeable
+import qualified GHC.Clock as Clock
+import GHC.Generics
+import GHC.TypeLits
+import Servant
+import System.Timeout (timeout)
+
+-- ----------------------------------------------------------------------------
+-- Servant API
+-- ----------------------------------------------------------------------------
+
+data DbState = DbState
+  { functionDatabase :: TVar (Map Text ValidatedFunction)
+  }
+  deriving stock (Eq, Generic)
+
+data ValidatedFunction = ValidatedFunction
+  { fnImpl :: !Function
+  , fnEvaluator :: !(Map EvalBackend RunFunction)
+  }
+  deriving stock (Generic)
+
+type AppM = ReaderT DbState Handler
+
+type Api = NamedRoutes FunctionApi'
+type FunctionApi = NamedRoutes FunctionApi'
+
+-- | API that can be invoked by a custom gpt.
+--
+-- See https://openai.com/index/introducing-gpts/
+data FunctionApi' mode = FunctionApi
+  { functionRoutes :: mode :- "functions" :> FunctionCrud
+  }
+  deriving stock (Generic)
+
+type FunctionCrud = NamedRoutes FunctionCrud'
+
+-- | API for interacting with the 'function' resource.
+data FunctionCrud' mode = FunctionCrud
+  { batchEntities ::
+      mode
+        :- Summary "Shortened descriptions of all available functions and their parameters"
+          :> OperationId "getAllFunctions"
+          :> Get '[JSON] [SimpleFunction]
+  , singleEntity ::
+      mode
+        :- Capture "name" String
+          :> SingleFunctionApi
+  }
+  deriving stock (Generic)
+
+type SingleFunctionApi = NamedRoutes SingleFunctionApi'
+data SingleFunctionApi' mode = SingleFunctionApi
+  { getFunction ::
+      mode
+        :- Summary "Get a detailed description of the function and its parameters"
+          :> OperationId "getFunction"
+          :> Get '[JSON] Function
+  , postFunction ::
+      mode
+        :- Summary "Add a function resource that can be evaluated."
+          :> ReqBody '[JSON] FunctionImplementation
+          :> OperationId "createFunction"
+          :> Post '[JSON] ()
+  , putFunction ::
+      mode
+        :- Summary "Update a function resource"
+          :> ReqBody '[JSON] FunctionImplementation
+          :> OperationId "updateFunction"
+          :> Put '[JSON] ()
+  , deleteFunction ::
+      mode
+        :- Summary "Delete the function"
+          :> OperationId "deleteFunction"
+          :> Delete '[JSON] ()
+  , evalFunction ::
+      mode
+        :- "evaluation"
+          :> Summary "Evaluate a function with arguments"
+          :> ReqBody '[JSON] FnArguments
+          :> OperationId "evalFunction"
+          :> Post '[JSON] SimpleResponse
+  , batchFunction ::
+      mode
+        :- "batch"
+          :> Summary "Run a function using a batch of arguments"
+          :> Description "Evaluate a function with a batch of arguments, conforming to Oracle Intelligent Advisor Batch API"
+          :> ReqBody '[JSON] BatchRequest
+          :> Post '[JSON] BatchResponse
+  -- ^ Run a function with a "batch" of parameters.
+  -- This API aims to be consistent with
+  -- https://docs.oracle.com/en/cloud/saas/b2c-service/opawx/using-batch-assess-rest-api.html
+  }
+  deriving stock (Generic)
+
+data SimpleFunction = SimpleFunction
+  { simpleName :: Text
+  , simpleDescription :: Text
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+
+data Function = Function
+  { name :: !Text
+  , description :: !Text
+  , parameters :: !Parameters
+  , supportedEvalBackend :: [EvalBackend]
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+
+data FunctionImplementation = FunctionImplementation
+  { declaration :: !Function
+  , implementation :: !(Map EvalBackend Text)
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+
+newtype Parameters = Parameters
+  { getParameters :: Map Text Parameter
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+
+data Parameter = Parameter
+  { parameterType :: !Text
+  , parameterAlias :: !(Maybe Text)
+  , parameterEnum :: ![Text]
+  , parameterDescription :: !Text
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+
+data SimpleResponse
+  = SimpleResponse !ResponseWithReason
+  | SimpleError !EvaluatorError
+  deriving stock (Show, Read, Ord, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data FnArguments = FnArguments
+  { fnEvalBackend :: Maybe EvalBackend
+  , fnArguments :: Map Text (Maybe FnLiteral)
+  }
+  deriving stock (Show, Read, Ord, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- ----------------------------------------------------------------------------
+-- Servant Combinators
+-- ----------------------------------------------------------------------------
+
+data OperationId (symbol :: Symbol)
+
+instance (HasLink sub) => HasLink (OperationId s :> sub) where
+  type MkLink (OperationId s :> sub) a = MkLink sub a
+  toLink = simpleToLink (Proxy :: Proxy sub)
+
+simpleToLink ::
+  forall sub a combinator.
+  (HasLink sub, MkLink sub a ~ MkLink (combinator :> sub) a) =>
+  Proxy sub ->
+  (Link -> a) ->
+  Proxy (combinator :> sub) ->
+  Link ->
+  MkLink (combinator :> sub) a
+simpleToLink _ toA _ = toLink toA (Proxy :: Proxy sub)
+
+-- | Ignore @'OperationId'@ in server handlers.
+instance (HasServer api ctx) => HasServer (OperationId desc :> api) ctx where
+  type ServerT (OperationId desc :> api) m = ServerT api m
+
+  route _ = route (Proxy :: Proxy api)
+  hoistServerWithContext _ pc nt s = hoistServerWithContext (Proxy :: Proxy api) pc nt s
+
+-- ----------------------------------------------------------------------------
+-- Web Service Handlers
+-- ----------------------------------------------------------------------------
+
+data EvalBackend
+  = JL4
+  deriving ()
+  deriving stock (Show, Eq, Ord, Enum, Read, Bounded, Generic)
+
+handler :: ServerT Api AppM
+handler =
+  FunctionApi
+    { functionRoutes =
+        FunctionCrud
+          { batchEntities = getAllFunctions
+          , singleEntity = \name ->
+              SingleFunctionApi
+                { getFunction =
+                    getFunctionHandler name
+                , putFunction =
+                    putFunctionHandler name
+                , postFunction =
+                    postFunctionHandler name
+                , deleteFunction =
+                    deleteFunctionHandler name
+                , evalFunction =
+                    evalFunctionHandler name
+                , batchFunction =
+                    batchFunctionHandler name
+                }
+          }
+    }
+
+evalFunctionHandler :: String -> FnArguments -> AppM SimpleResponse
+evalFunctionHandler name' args = do
+  functionsTVar <- asks (.functionDatabase)
+  functions <- liftIO $ readTVarIO functionsTVar
+  case Map.lookup name functions of
+    Nothing -> throwError err404
+    Just fnImpl ->
+      runEvaluatorFor args.fnEvalBackend fnImpl (Map.assocs args.fnArguments) Nothing
+ where
+  name = Text.pack name'
+
+batchFunctionHandler :: String -> BatchRequest -> AppM BatchResponse
+batchFunctionHandler name' batchArgs = do
+  functionsTVar <- asks (.functionDatabase)
+  functions <- liftIO $ readTVarIO functionsTVar
+  case Map.lookup name functions of
+    Nothing -> throwError err404
+    Just fnImpl -> do
+      (execTime, responses) <- stopwatchM $ forM batchArgs.cases $ \inputCase -> do
+        let
+          args = Map.assocs $ fmap Just inputCase.attributes
+
+        r <- runEvaluatorFor Nothing fnImpl args outputFilter
+        pure (inputCase.id, r)
+
+      let
+        nCases = length responses
+
+        successfulRuns =
+          Maybe.mapMaybe
+            ( \(rid, simpleRes) -> case simpleRes of
+                SimpleResponse r -> Just (rid, r)
+                SimpleError _ -> Nothing
+            )
+            responses
+
+        nSuccessful = length successfulRuns
+        nIgnored = nCases - nSuccessful
+
+      pure $
+        BatchResponse
+          { cases =
+              [ OutputCase
+                { id = rid
+                , attributes = Map.fromList response.values
+                }
+              | (rid, response) <- successfulRuns
+              ]
+          , summary =
+              OutputSummary
+                { casesRead = nCases
+                , casesProcessed = nSuccessful
+                , casesIgnored = nIgnored
+                , processorDurationSec = nsToS execTime
+                , casesPerSec = nsToS execTime / realToFrac nCases
+                , processorQueuedSec = 0
+                }
+          }
+ where
+  outputFilter = if null outputFilter' then Nothing else Just outputFilter'
+  outputFilter' =
+    Set.fromList $
+      Maybe.mapMaybe
+        ( \case
+            OutcomeAttribute t -> Just t
+            OutcomePropertyObject _ -> Nothing
+        )
+        batchArgs.outcomes
+  name = Text.pack name'
+
+  nsToS :: Chronos.Timespan -> Centi
+  nsToS n = (realToFrac @Int @Centi $ fromIntegral @Int64 @Int (Chronos.getTimespan n)) / 10e9
+
+runEvaluatorFor :: Maybe EvalBackend -> ValidatedFunction -> [(Text, Maybe FnLiteral)] -> Maybe (Set Text) -> AppM SimpleResponse
+runEvaluatorFor engine validatedFunc args outputFilter = do
+  eval <- evaluationEngine evalBackend validatedFunc
+  evaluationResult <-
+    timeoutAction $
+      runExceptT
+        ( eval.runFunction
+            args
+            outputFilter
+        )
+
+  case evaluationResult of
+    Left err -> pure $ SimpleError err
+    Right r -> pure $ SimpleResponse r
+ where
+  evalBackend = Maybe.fromMaybe JL4 engine
+
+deleteFunctionHandler :: String -> AppM ()
+deleteFunctionHandler name' = do
+  functionsTVar <- asks (.functionDatabase)
+  exists <- liftIO $ atomically $ stateTVar functionsTVar $ \functions ->
+    case Map.member name functions of
+      True ->
+        (True, Map.delete name functions)
+      False ->
+        (False, functions)
+
+  when (not exists) $
+    throwError
+      err404
+        { errBody =
+            "Resource "
+              <> BS.fromStrict (Text.encodeUtf8 name)
+              <> " does not exist"
+        }
+ where
+  name = Text.pack name'
+
+putFunctionHandler :: String -> FunctionImplementation -> AppM ()
+putFunctionHandler name' updatedFunctionImpl = do
+  validatedFunction <- validateFunction updatedFunctionImpl
+  functionsTVar <- asks (.functionDatabase)
+  exists <- liftIO $ atomically $ stateTVar functionsTVar $ \functions ->
+    case Map.member name functions of
+      True ->
+        (True, Map.insert name validatedFunction functions)
+      False ->
+        (False, functions)
+
+  when (not exists) $
+    -- Error code has been chosen in accordance with
+    -- https://stackoverflow.com/a/70371989
+    throwError
+      err404
+        { errBody =
+            "Resource "
+              <> BS.fromStrict (Text.encodeUtf8 name)
+              <> " does not exist"
+        }
+ where
+  name = Text.pack name'
+
+postFunctionHandler :: String -> FunctionImplementation -> AppM ()
+postFunctionHandler name' newFunctionImpl = do
+  validatedFunction <- validateFunction newFunctionImpl
+  functionsTVar <- asks (.functionDatabase)
+  exists <- liftIO $ atomically $ stateTVar functionsTVar $ \functions ->
+    case Map.member name functions of
+      True ->
+        (True, functions)
+      False ->
+        (False, Map.insert name validatedFunction functions)
+
+  when exists $
+    -- Error code has been chosen in accordance with
+    -- https://stackoverflow.com/a/70371989
+    throwError
+      err409
+        { errBody =
+            "Resource "
+              <> BS.fromStrict (Text.encodeUtf8 name)
+              <> " already exists"
+        }
+ where
+  name = Text.pack name'
+
+validateFunction :: FunctionImplementation -> AppM ValidatedFunction
+validateFunction fn = do
+  evaluators <- Map.traverseWithKey validateImplementation fn.implementation
+  pure
+    ValidatedFunction
+      { fnImpl = fn.declaration
+      , fnEvaluator = evaluators
+      }
+ where
+  validateImplementation :: EvalBackend -> Text -> AppM RunFunction
+  validateImplementation JL4 program = do
+    case runExcept $ Jl4.createFunction (toDecl fn.declaration) program of
+      Left err -> throwError err422{errBody = "Failed to parse program: " <> TL.encodeUtf8 (TL.pack $ show err)}
+      Right parsed -> pure parsed
+
+getAllFunctions :: AppM [SimpleFunction]
+getAllFunctions = do
+  functions <- liftIO . readTVarIO =<< asks (.functionDatabase)
+  pure $ fmap (toSimpleFunction . (.fnImpl)) $ Map.elems functions
+ where
+  toSimpleFunction s =
+    SimpleFunction
+      { simpleName = s.name
+      , simpleDescription = s.description
+      }
+
+getFunctionHandler :: String -> AppM Function
+getFunctionHandler name = do
+  functions <- liftIO . readTVarIO =<< asks (.functionDatabase)
+  case Map.lookup (Text.pack name) functions of
+    Nothing -> throwError err404
+    Just function -> pure function.fnImpl
+
+timeoutAction :: IO b -> AppM b
+timeoutAction act =
+  liftIO (timeout (seconds 60) act) >>= \case
+    Nothing -> throwError err500
+    Just r -> pure r
+ where
+  seconds n = 1_000_000 * n
+
+stopwatchM :: AppM a -> AppM (Chronos.Timespan, a)
+stopwatchM action = do
+  start <- liftIO Clock.getMonotonicTimeNSec
+  a' <- action
+  a <- liftIO $ evaluate a'
+  end <- liftIO Clock.getMonotonicTimeNSec
+  pure ((Chronos.Timespan (fromIntegral (end - start))), a)
+
+-- ----------------------------------------------------------------------------
+-- "Database" layer
+-- ----------------------------------------------------------------------------
+
+evaluationEngine :: EvalBackend -> ValidatedFunction -> AppM RunFunction
+evaluationEngine b valFn = do
+  case Map.lookup b valFn.fnEvaluator of
+    Nothing -> throwError err404
+    Just eval -> pure eval
+
+-- ----------------------------------------------------------------------------
+-- Json encoders and decoders that are not derived.
+-- We often need custom instances, as we want to be more lenient in what we accept
+-- than what aeson does by default. Further, we try to provide a specific json schema.
+--
+-- ----------------------------------------------------------------------------
+
+instance ToJSON SimpleFunction where
+  toJSON (SimpleFunction n desc) =
+    Aeson.object
+      [ "type" .= Aeson.String "function"
+      , "function"
+          .= Aeson.object
+            [ "name" .= Aeson.String n
+            , "description" .= Aeson.String desc
+            ]
+      ]
+
+instance FromJSON SimpleFunction where
+  parseJSON = Aeson.withObject "Function" $ \o -> do
+    "function" :: Text <- o .: "type"
+    props <- o .: "function"
+    simpleFn <-
+      Aeson.withObject
+        "function body"
+        ( \p -> do
+            SimpleFunction
+              <$> p .: "name"
+              <*> p .: "description"
+        )
+        props
+    pure simpleFn
+
+instance ToJSON Function where
+  toJSON (Function n desc params backends) =
+    Aeson.object
+      [ "type" .= Aeson.String "function"
+      , "function"
+          .= Aeson.object
+            [ "name" .= Aeson.String n
+            , "description" .= Aeson.String desc
+            , "parameters" .= params
+            , "supportedBackends" .= backends
+            ]
+      ]
+
+instance FromJSON Function where
+  parseJSON = Aeson.withObject "Function" $ \o -> do
+    fnType <- o .: "type"
+    case fnType :: Text of
+      "function" -> pure ()
+      e -> fail $ "Expected \"function\" but got" <> Text.unpack e
+    props <- o .: "function"
+    Aeson.withObject
+      "function body"
+      ( \p -> do
+          Function
+            <$> p .: "name"
+            <*> p .: "description"
+            <*> p .: "parameters"
+            <*> p .: "supportedBackends"
+      )
+      props
+
+instance ToJSON FunctionImplementation where
+  toJSON fnImpl =
+    Aeson.object
+      [ "declaration" .= fnImpl.declaration
+      , "implementation" .= fnImpl.implementation
+      ]
+
+instance FromJSON FunctionImplementation where
+  parseJSON = Aeson.withObject "Function Implementation" $ \o -> do
+    FunctionImplementation
+      <$> o .: "declaration"
+      <*> o .: "implementation"
+
+instance ToJSON Parameters where
+  toJSON (Parameters props) =
+    Aeson.object
+      [ "type" .= Aeson.String "object"
+      , "properties" .= props
+      ]
+
+instance FromJSON Parameters where
+  parseJSON = Aeson.withObject "Parameters" $ \o -> do
+    _ :: Text <- o .: "type"
+    props <- o .: "properties"
+    pure $ Parameters props
+
+instance ToJSON Parameter where
+  toJSON p =
+    Aeson.object
+      [ "type" .= p.parameterType
+      , "alias" .= p.parameterAlias
+      , "enum" .= p.parameterEnum
+      , "description" .= p.parameterDescription
+      ]
+
+instance FromJSON Parameter where
+  parseJSON = Aeson.withObject "Parameter" $ \p ->
+    Parameter
+      <$> p .: "type"
+      <*> p .: "alias"
+      <*> p .: "enum"
+      <*> p .: "description"
+
+instance FromHttpApiData EvalBackend where
+  parseQueryParam t = case Text.toLower t of
+    "jl4" -> Right JL4
+    _ -> Left $ "Invalid evaluation backend: " <> t
+
+instance ToJSON EvalBackend where
+  toJSON = \case
+    JL4 -> Aeson.String "jl4"
+
+instance FromJSON EvalBackend where
+  parseJSON (Aeson.String s) = case Text.toLower s of
+    "jl4" -> pure JL4
+    o -> Aeson.prependFailure "EvalBackend" (Aeson.typeMismatch "String" $ Aeson.String o)
+  parseJSON o = Aeson.prependFailure "EvalBackend" (Aeson.typeMismatch "String" o)
+
+instance ToJSONKey EvalBackend
+
+instance FromJSONKey EvalBackend
+
+toDecl :: Function -> Api.FunctionDeclaration
+toDecl fn =
+  Api.FunctionDeclaration
+    { Api.name = fn.name
+    , Api.description = fn.description
+    , Api.longNames = Map.keysSet $ fn.parameters.getParameters
+    , Api.nameMapping = shortToLongNameMapping
+    }
+ where
+  shortToLongNameMapping :: Map Text Text
+  shortToLongNameMapping =
+    Map.fromList $
+      Maybe.mapMaybe (fmap Tuple.swap . Tuple.secondM (.parameterAlias)) $
+        Map.assocs fn.parameters.getParameters
+
+-- ----------------------------------------------------------------------------
+-- Oracle DB
+-- ----------------------------------------------------------------------------
+
+type Id = Int
+
+data Outcomes
+  = OutcomeAttribute Text
+  | OutcomePropertyObject OutcomeObject
+  deriving stock (Show, Eq, Ord)
+
+data OutcomeObject = OutcomeObject
+  { id :: Text
+  , showSilent :: Maybe Bool
+  , showInvisible :: Maybe Bool
+  , resolveIndecisionRelationships :: Maybe Bool
+  , knownOutcomeStyle :: Maybe OutcomeStyle
+  , unknownOutcomeStyle :: Maybe OutcomeStyle
+  }
+  deriving stock (Show, Eq, Ord)
+
+data OutcomeStyle
+  = ValueOnly
+  | DecisionReport
+  | BaseAttributes
+  deriving stock (Show, Ord, Eq, Enum, Bounded)
+
+data BatchRequest = BatchRequest
+  { outcomes :: [Outcomes]
+  , cases :: [InputCase]
+  }
+  deriving stock (Show, Eq, Ord)
+
+data InputCase = InputCase
+  { id :: Id
+  , attributes :: Map Text FnLiteral
+  }
+  deriving stock (Show, Eq, Ord)
+
+data OutputCase = OutputCase
+  { id :: Id
+  , attributes :: Map Text FnLiteral
+  }
+  deriving stock (Show, Eq, Ord)
+
+data BatchResponse = BatchResponse
+  { cases :: [OutputCase]
+  , summary :: OutputSummary
+  }
+  deriving stock (Show, Eq, Ord)
+
+data OutputSummary = OutputSummary
+  { casesRead :: Int
+  , casesProcessed :: Int
+  , casesIgnored :: Int
+  , processorDurationSec :: Fixed E2
+  , casesPerSec :: Fixed E2
+  , processorQueuedSec :: Fixed E2
+  }
+  deriving stock (Show, Eq, Ord)
+
+-- ----------------------------------------------------------------------------
+-- Batch request json
+-- ----------------------------------------------------------------------------
+
+batchRequestDecoder :: Decoder BatchRequest
+batchRequestDecoder =
+  BatchRequest
+    <$> ACD.key "outcomes" (ACD.list outcomesDecoder)
+    <*> ACD.key "cases" (ACD.list inputCaseDecoder)
+
+outcomeStyleDecoder :: Decoder OutcomeStyle
+outcomeStyleDecoder =
+  ACD.text >>= \case
+    "value-only" -> pure ValueOnly
+    "decision-report" -> pure DecisionReport
+    "base-attributes" -> pure BaseAttributes
+    val -> fail $ "Unknown value " <> show val
+
+outcomeObjectDecoder :: Decoder OutcomeObject
+outcomeObjectDecoder =
+  OutcomeObject
+    <$> ACD.key "id" ACD.text
+    <*> ACD.maybeKey "showSilent" ACD.bool
+    <*> ACD.maybeKey "showInvisible" ACD.bool
+    <*> ACD.maybeKey "resolveIndecisionRelationships" ACD.bool
+    <*> ACD.maybeKey "knownOutcomeStyle" outcomeStyleDecoder
+    <*> ACD.maybeKey "unknownOutcomeStyle" outcomeStyleDecoder
+
+outcomesDecoder :: Decoder Outcomes
+outcomesDecoder =
+  (OutcomeAttribute <$> ACD.text)
+    <|> (OutcomePropertyObject <$> outcomeObjectDecoder)
+
+inputCaseDecoder :: Decoder InputCase
+inputCaseDecoder = do
+  caseId <- ACD.key "@id" ACD.int
+  attributes <- ACD.mapStrict fnLiteralDecoder
+  let
+    attributes' = Map.delete "@id" attributes
+  pure $ InputCase caseId attributes'
+
+fnLiteralDecoder :: Decoder FnLiteral
+fnLiteralDecoder =
+  (FnLitInt <$> ACD.integer)
+    <|> (FnLitDouble <$> ACD.double)
+    <|> (FnLitBool <$> ACD.bool)
+    <|> (parseTextAsFnLiteral <$> ACD.text)
+    <|> (FnArray <$> ACD.list fnLiteralDecoder)
+    <|> (FnObject <$> ACD.list (liftA2 (,) ACD.text fnLiteralDecoder))
+
+batchRequestEncoder :: BatchRequest -> Aeson.Value
+batchRequestEncoder br =
+  Aeson.object
+    [ "outcomes" .= fmap outcomesEncoder br.outcomes
+    ]
+
+outcomesEncoder :: Outcomes -> Aeson.Value
+outcomesEncoder (OutcomeAttribute t) = Aeson.String t
+outcomesEncoder (OutcomePropertyObject o) =
+  Aeson.object
+    [ "@id" .= o.id
+    , "showSilent" .= o.showSilent
+    , "showInvisible" .= o.showInvisible
+    , "resolveIndecisionRelationships" .= o.resolveIndecisionRelationships
+    , "knownOutcomeStyle" .= fmap outcomeStyleEncoder o.knownOutcomeStyle
+    , "unknownOutcomeStyle" .= fmap outcomeStyleEncoder o.unknownOutcomeStyle
+    ]
+
+outcomeStyleEncoder :: OutcomeStyle -> Aeson.Value
+outcomeStyleEncoder = \case
+  ValueOnly -> Aeson.String "value-only"
+  DecisionReport -> Aeson.String "decision-report"
+  BaseAttributes -> Aeson.String "base-attributes"
+
+-- ----------------------------------------------------------------------------
+-- Batch response json
+-- ----------------------------------------------------------------------------
+
+batchResponseDecoder :: Decoder BatchResponse
+batchResponseDecoder =
+  BatchResponse
+    <$> ACD.key "cases" (ACD.list casesDecoder)
+    <*> ACD.key "summary" summaryDecoder
+
+casesDecoder :: Decoder OutputCase
+casesDecoder = do
+  caseId <- ACD.key "@id" ACD.int
+  attributes <- ACD.mapStrict fnLiteralDecoder
+  let
+    attributes' = Map.delete "@id" attributes
+  pure $ OutputCase caseId attributes'
+
+summaryDecoder :: Decoder OutputSummary
+summaryDecoder =
+  OutputSummary
+    <$> ACD.key "casesRead" ACD.int
+    <*> ACD.key "casesProcessed" ACD.int
+    <*> ACD.key "casesIgnored" ACD.int
+    <*> ACD.key "processorDurationSec" (fmap toFixed ACD.scientific)
+    <*> ACD.key "processorCasesPerSec" (fmap toFixed ACD.scientific)
+    <*> ACD.key "processorQueuedSec" (fmap toFixed ACD.scientific)
+ where
+  toFixed = realToFrac @Scientific @Centi
+
+batchResponseEncoder :: BatchResponse -> Aeson.Value
+batchResponseEncoder br =
+  Aeson.object $
+    [ "cases" .= fmap outputCaseEncoder br.cases
+    , "summary" .= outputSummaryEncoder br.summary
+    ]
+
+outputSummaryEncoder :: OutputSummary -> Aeson.Value
+outputSummaryEncoder os =
+  Aeson.object
+    [ "casesRead" .= os.casesRead
+    , "casesProcessed" .= os.casesProcessed
+    , "casesIgnored" .= os.casesIgnored
+    , "processorDurationSec" .= toSci os.processorDurationSec
+    , "processorCasesPerSec" .= toSci os.casesPerSec
+    , "processorQueuedSec" .= toSci os.processorQueuedSec
+    ]
+ where
+  toSci = realToFrac @Centi @Scientific
+
+outputCaseEncoder :: OutputCase -> Aeson.Value
+outputCaseEncoder oc =
+  Aeson.object $
+    [ "@id" .= oc.id
+    ]
+      <> [ (Aeson.fromText k .= v)
+         | (k, v) <- Map.assocs oc.attributes
+         ]
+
+-- ----------------------------------------------------------------------------
+-- Final FromJSON/ToJSON instances
+-- ----------------------------------------------------------------------------
+
+instance FromJSON BatchRequest where
+  parseJSON = ACD.fromDecoder batchRequestDecoder
+
+instance ToJSON BatchRequest where
+  toJSON = batchRequestEncoder
+
+instance ToJSON BatchResponse where
+  toJSON = batchResponseEncoder
+
+instance FromJSON BatchResponse where
+  parseJSON = ACD.fromDecoder batchResponseDecoder

--- a/jl4-decision-service/test/SchemaSpec.hs
+++ b/jl4-decision-service/test/SchemaSpec.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module SchemaSpec (spec) where
+
+import Data.Proxy
+import Servant.OpenApi
+import Test.Hspec
+import Test.QuickCheck (Arbitrary (..))
+import qualified Test.QuickCheck as Q
+import Test.QuickCheck.Instances ()
+
+import Backend.Api
+import qualified Data.Text as Text
+import Schema ()
+import Servant.API (FromHttpApiData (..))
+import Server
+import qualified Test.Hspec.QuickCheck as Hspec
+import Test.QuickCheck.Property
+
+spec :: Spec
+spec = do
+  describe "Schema" do
+    describe "json" do
+      validateEveryToJSON (Proxy @Api)
+    describe "Param Schema" do
+      describe "FnLiteral" do
+        Hspec.prop "Int" $ \(n :: Integer) ->
+          parseQueryParam (Text.pack $ show n) === Right (FnLitInt n)
+        Hspec.prop "Bool" $ \(n :: Bool) ->
+          parseQueryParam (Text.pack $ show n) === Right (FnLitBool n)
+
+-- ----------------------------------------------------------------------------
+-- Arbitrary instances that allow us to verify that the JSON
+-- instances and OpenAPI documentation agree on the schema.
+-- ----------------------------------------------------------------------------
+
+instance Arbitrary FnLiteral where
+  arbitrary =
+    Q.frequency
+      [ (1, FnLitBool <$> arbitrary)
+      , (4, FnLitDouble <$> arbitrary)
+      , (4, FnLitString <$> arbitrary)
+      , (4, FnLitInt <$> arbitrary)
+      , -- , (1, FnArray <$> arbitrary)
+        -- , (1, FnObject <$> arbitrary)
+        (1, pure FnUnknown)
+      , (1, pure FnUncertain)
+      ]
+
+instance Arbitrary Reasoning where
+  arbitrary = Reasoning <$> arbitrary
+
+instance Arbitrary ReasonNode where
+  arbitrary = ReasonNode <$> arbitrary <*> arbitrary
+
+-- | The code for this instance is taken from 'Arbitrary1 containers-Data.Tree.Tree'.
+-- See https://hackage.haskell.org/package/QuickCheck-2.15.0.1/docs/src/Test.QuickCheck.Arbitrary.html#line-901
+instance Arbitrary ReasoningTree where
+  arbitrary = Q.sized $ \n -> do
+    k <- Q.chooseInt (0, n)
+    go k
+   where
+    go n = do
+      -- n is the size of the trees.
+      node <- arbitrary
+      pars <- arbPartition (n - 1) -- can go negative!
+      forest <- mapM go pars
+      return $
+        ReasoningTree
+          { payload = node
+          , children = forest
+          }
+
+    arbPartition :: Int -> Q.Gen [Int]
+    arbPartition k = case compare k 1 of
+      LT -> pure []
+      EQ -> pure [1]
+      GT -> do
+        first <- Q.chooseInt (1, k)
+        rest <- arbPartition $ k - first
+        Q.shuffle (first : rest)
+
+instance Arbitrary ResponseWithReason where
+  arbitrary = ResponseWithReason <$> arbitrary <*> pure emptyTree
+
+instance Arbitrary EvaluatorError where
+  arbitrary = Q.oneof [InterpreterError <$> arbitrary]
+
+instance Arbitrary SimpleResponse where
+  arbitrary =
+    Q.oneof
+      [ SimpleResponse <$> arbitrary
+      , SimpleError <$> arbitrary
+      ]
+
+instance Arbitrary Parameters where
+  arbitrary = Parameters <$> arbitrary
+
+instance Arbitrary Parameter where
+  arbitrary = Parameter <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+instance Arbitrary Function where
+  arbitrary = Server.Function <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+instance Arbitrary EvalBackend where
+  arbitrary = Q.chooseEnum (minBound, maxBound)
+
+instance Arbitrary FunctionImplementation where
+  arbitrary =
+    Server.FunctionImplementation <$> arbitrary <*> arbitrary
+
+instance Arbitrary FnArguments where
+  arbitrary =
+    Server.FnArguments <$> arbitrary <*> arbitrary
+
+instance Arbitrary SimpleFunction where
+  arbitrary = SimpleFunction <$> arbitrary <*> arbitrary
+
+instance Arbitrary OutcomeStyle where
+  arbitrary = Q.chooseEnum (ValueOnly, BaseAttributes)
+
+instance Arbitrary OutcomeObject where
+  arbitrary =
+    OutcomeObject
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance Arbitrary BatchRequest where
+  arbitrary =
+    BatchRequest
+      <$> arbitrary
+      <*> arbitrary
+
+instance Arbitrary BatchResponse where
+  arbitrary =
+    BatchResponse
+      <$> arbitrary
+      <*> arbitrary
+
+instance Arbitrary Outcomes where
+  arbitrary = Q.oneof [OutcomeAttribute <$> arbitrary, OutcomePropertyObject <$> arbitrary]
+
+instance Arbitrary InputCase where
+  arbitrary = InputCase <$> arbitrary <*> arbitrary
+
+instance Arbitrary OutputCase where
+  arbitrary =
+    OutputCase
+      <$> arbitrary
+      <*> arbitrary
+
+instance Arbitrary OutputSummary where
+  arbitrary =
+    OutputSummary
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary

--- a/jl4-decision-service/test/Spec.hs
+++ b/jl4-decision-service/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/jl4/examples/ok/qualified.l4
+++ b/jl4/examples/ok/qualified.l4
@@ -1,0 +1,13 @@
+
+DECLARE Inputs
+  HAS
+    walks IS A BOOLEAN
+    drinks IS A BOOLEAN
+    eats IS A BOOLEAN
+
+GIVEN i IS Inputs
+GIVETH A BOOLEAN
+DECIDE `qualifies` i IF
+     i's walks
+ AND    i's drinks
+     OR i's eats

--- a/jl4/examples/ok/qualified.l4
+++ b/jl4/examples/ok/qualified.l4
@@ -7,7 +7,7 @@ DECLARE Inputs
 
 GIVEN i IS Inputs
 GIVETH A BOOLEAN
-DECIDE `qualifies` i IF
+DECIDE `compute_qualifies` i IF
      i's walks
  AND    i's drinks
      OR i's eats

--- a/jl4/examples/ok/rodentsAndVermin.l4
+++ b/jl4/examples/ok/rodentsAndVermin.l4
@@ -1,0 +1,57 @@
+
+DECLARE Inputs
+  HAS
+    `Loss or Damage.caused by rodents` IS A BOOLEAN
+    `Loss or Damage.caused by insects` IS A BOOLEAN
+    `Loss or Damage.caused by vermin` IS A BOOLEAN
+    `Loss or Damage.caused by birds` IS A BOOLEAN
+    `Loss or Damage.to Contents` IS A BOOLEAN
+    `any other exclusion applies` IS A BOOLEAN
+    `a household appliance` IS A BOOLEAN
+    `a swimming pool` IS A BOOLEAN
+    `a plumbing, heating, or air conditioning system` IS A BOOLEAN
+    `Loss or Damage.ensuing covered loss` IS A BOOLEAN
+
+GIVEN i IS Inputs
+GIVETH A BOOLEAN
+DECIDE `insurance covered` i IF
+    `not covered if`
+         `loss or damage by animals`
+     AND NOT               `damage to contents and caused by birds`
+                OR         `ensuing covered loss`
+                    AND NOT `exclusion apply`
+ WHERE
+    `not covered if` MEANS GIVEN x YIELD x
+
+    `loss or damage by animals` MEANS
+        i's `Loss or Damage.caused by rodents`
+     OR i's `Loss or Damage.caused by insects`
+     OR i's `Loss or Damage.caused by vermin`
+     OR i's `Loss or Damage.caused by birds`
+
+    `damage to contents and caused by birds` MEANS
+         i's `Loss or Damage.to Contents`
+     AND i's `Loss or Damage.caused by birds`
+
+    `ensuing covered loss` MEANS
+        i's `Loss or Damage.ensuing covered loss`
+
+    `exclusion apply` MEANS
+        i's `any other exclusion applies`
+     OR i's `a household appliance`
+     OR i's `a swimming pool`
+     OR i's `a plumbing, heating, or air conditioning system`
+
+#EVAL `insurance covered` OF
+        Inputs
+        WITH
+            `Loss or Damage.caused by rodents` IS FALSE
+            `Loss or Damage.caused by insects` IS FALSE
+            `Loss or Damage.caused by vermin` IS FALSE
+            `Loss or Damage.caused by birds` IS FALSE
+            `Loss or Damage.to Contents` IS FALSE
+            `any other exclusion applies` IS FALSE
+            `a household appliance` IS FALSE
+            `a swimming pool` IS FALSE
+            `a plumbing, heating, or air conditioning system` IS FALSE
+            `Loss or Damage.ensuing covered loss` IS FALSE

--- a/jl4/examples/ok/tests/qualified.ep.golden
+++ b/jl4/examples/ok/tests/qualified.ep.golden
@@ -1,0 +1,13 @@
+
+DECLARE Inputs
+  HAS
+    walks IS A BOOLEAN
+    drinks IS A BOOLEAN
+    eats IS A BOOLEAN
+
+GIVEN i IS Inputs
+GIVETH A BOOLEAN
+DECIDE `qualifies` i IF
+     i's walks
+ AND    i's drinks
+     OR i's eats

--- a/jl4/examples/ok/tests/qualified.ep.golden
+++ b/jl4/examples/ok/tests/qualified.ep.golden
@@ -7,7 +7,7 @@ DECLARE Inputs
 
 GIVEN i IS Inputs
 GIVETH A BOOLEAN
-DECIDE `qualifies` i IF
+DECIDE `compute_qualifies` i IF
      i's walks
  AND    i's drinks
      OR i's eats

--- a/jl4/examples/ok/tests/qualified.golden
+++ b/jl4/examples/ok/tests/qualified.golden
@@ -1,0 +1,2 @@
+Parsing successful
+Typechecking successful

--- a/jl4/examples/ok/tests/rodentsAndVermin.ep.golden
+++ b/jl4/examples/ok/tests/rodentsAndVermin.ep.golden
@@ -1,0 +1,57 @@
+
+DECLARE Inputs
+  HAS
+    `Loss or Damage.caused by rodents` IS A BOOLEAN
+    `Loss or Damage.caused by insects` IS A BOOLEAN
+    `Loss or Damage.caused by vermin` IS A BOOLEAN
+    `Loss or Damage.caused by birds` IS A BOOLEAN
+    `Loss or Damage.to Contents` IS A BOOLEAN
+    `any other exclusion applies` IS A BOOLEAN
+    `a household appliance` IS A BOOLEAN
+    `a swimming pool` IS A BOOLEAN
+    `a plumbing, heating, or air conditioning system` IS A BOOLEAN
+    `Loss or Damage.ensuing covered loss` IS A BOOLEAN
+
+GIVEN i IS Inputs
+GIVETH A BOOLEAN
+DECIDE `insurance covered` i IF
+    `not covered if`
+         `loss or damage by animals`
+     AND NOT               `damage to contents and caused by birds`
+                OR         `ensuing covered loss`
+                    AND NOT `exclusion apply`
+ WHERE
+    `not covered if` MEANS GIVEN x YIELD x
+
+    `loss or damage by animals` MEANS
+        i's `Loss or Damage.caused by rodents`
+     OR i's `Loss or Damage.caused by insects`
+     OR i's `Loss or Damage.caused by vermin`
+     OR i's `Loss or Damage.caused by birds`
+
+    `damage to contents and caused by birds` MEANS
+         i's `Loss or Damage.to Contents`
+     AND i's `Loss or Damage.caused by birds`
+
+    `ensuing covered loss` MEANS
+        i's `Loss or Damage.ensuing covered loss`
+
+    `exclusion apply` MEANS
+        i's `any other exclusion applies`
+     OR i's `a household appliance`
+     OR i's `a swimming pool`
+     OR i's `a plumbing, heating, or air conditioning system`
+
+#EVAL `insurance covered` OF
+        Inputs
+        WITH
+            `Loss or Damage.caused by rodents` IS FALSE
+            `Loss or Damage.caused by insects` IS FALSE
+            `Loss or Damage.caused by vermin` IS FALSE
+            `Loss or Damage.caused by birds` IS FALSE
+            `Loss or Damage.to Contents` IS FALSE
+            `any other exclusion applies` IS FALSE
+            `a household appliance` IS FALSE
+            `a swimming pool` IS FALSE
+            `a plumbing, heating, or air conditioning system` IS FALSE
+            `Loss or Damage.ensuing covered loss` IS FALSE

--- a/jl4/examples/ok/tests/rodentsAndVermin.golden
+++ b/jl4/examples/ok/tests/rodentsAndVermin.golden
@@ -1,0 +1,5 @@
+Parsing successful
+Typechecking successful
+rodentsAndVermin.l4:45:7-57:59:
+  FALSE
+

--- a/jl4/jl4.cabal
+++ b/jl4/jl4.cabal
@@ -114,7 +114,7 @@ executable jl4-lsp
     focus ^>=1.0.3.2,
     fuzzy,
     generics-sop,
-    hashable ^>=1.5.0.0,
+    hashable >=1.4.0.0,
     hls-graph ^>=2.9.0.0,
     hw-fingertree,
     jl4,

--- a/jl4/lsp/LSP/Core/Shake.hs
+++ b/jl4/lsp/LSP/Core/Shake.hs
@@ -145,7 +145,7 @@ import System.FilePath hiding (makeRelative)
 import System.Time.Extra
 import UnliftIO (MonadUnliftIO (withRunInIO))
 import qualified "list-t" ListT
-import L4.Lexer
+import L4.Parser.SrcSpan
 import L4.Syntax
 
 data Log

--- a/jl4/lsp/LSP/L4/Base.hs
+++ b/jl4/lsp/LSP/L4/Base.hs
@@ -6,3 +6,4 @@ import L4.Parser as L4
 import L4.Print as L4
 import L4.Syntax as L4
 import L4.TypeCheck as L4
+import L4.Parser.SrcSpan as L4

--- a/jl4/src/L4/Annotation.hs
+++ b/jl4/src/L4/Annotation.hs
@@ -8,7 +8,7 @@ module L4.Annotation where
 
 import Base
 import qualified Base.Text as Text
-import L4.Lexer ( SrcRange (..) )
+import L4.Parser.SrcSpan
 
 import qualified Control.Monad.Extra as Extra
 import Data.Default

--- a/jl4/src/L4/Citations.hs
+++ b/jl4/src/L4/Citations.hs
@@ -19,6 +19,7 @@ import qualified System.File.OsPath as Path
 import qualified HaskellWorks.Data.IntervalMap.FingerTree as IVMap
 import qualified Data.Csv as Csv
 
+import L4.Parser.SrcSpan  as Lexer
 import qualified L4.Lexer as Lexer
 
 -- | obtain a valid relative file path from the ref-src annos

--- a/jl4/src/L4/Evaluate.hs
+++ b/jl4/src/L4/Evaluate.hs
@@ -5,7 +5,7 @@ import Base
 import qualified Base.Map as Map
 import L4.Annotation
 import L4.Evaluate.Value
-import L4.Lexer (SrcRange)
+import L4.Parser.SrcSpan (SrcRange)
 import L4.Syntax
 import qualified L4.TypeCheck as TypeCheck
 

--- a/jl4/src/L4/FindDefinition.hs
+++ b/jl4/src/L4/FindDefinition.hs
@@ -3,7 +3,7 @@ module L4.FindDefinition where
 
 import Base
 import L4.Annotation
-import L4.Lexer (SrcPos(..), SrcRange(..), inRange)
+import L4.Parser.SrcSpan (SrcPos(..), SrcRange(..), inRange)
 import L4.Syntax
 import L4.TypeCheck
 

--- a/jl4/src/L4/HoverInfo.hs
+++ b/jl4/src/L4/HoverInfo.hs
@@ -3,7 +3,8 @@ module L4.HoverInfo where
 
 import Base
 import L4.Annotation
-import L4.Lexer (PosToken(..), SrcPos(..), SrcRange(..), inRange)
+import L4.Lexer (PosToken(..))
+import L4.Parser.SrcSpan (SrcPos(..), SrcRange(..), inRange)
 import L4.Syntax
 import L4.TypeCheck
 

--- a/jl4/src/L4/Main.hs
+++ b/jl4/src/L4/Main.hs
@@ -5,11 +5,13 @@ import qualified Base.Text as Text
 
 import Options.Applicative as Options
 
-import L4.Lexer (SrcRange, prettySrcRange)
+import L4.Parser.SrcSpan (SrcRange, prettySrcRange)
 import L4.Parser
 import L4.TypeCheck
 import L4.ExactPrint
 import L4.Annotation
+import qualified Generics.SOP as SOP
+import L4.Syntax
 
 data Options =
   MkOptions
@@ -50,6 +52,15 @@ parseFiles :: [FilePath] -> IO ()
 parseFiles =
   traverse_ (\ file -> parseFile program file =<< Text.readFile file)
 
+parseAndCheck :: FilePath -> Text -> Either CliError (Program Resolved)
+parseAndCheck file input =
+  case execProgramParser file input of
+    Left errs -> Left $ CliParserError file errs
+    Right (prog, _) ->
+      case doCheckProgram prog of
+        CheckResult {errors = [], program = p} -> Right p
+        ch -> Left $ CliCheckError file ch
+
 -- | Parse, typecheck and exact-print a program.
 checkAndExactPrintFile :: String -> Text -> Text
 checkAndExactPrintFile file input =
@@ -67,13 +78,6 @@ checkAndExactPrintFile file input =
         CheckResult {errors} ->
           Text.unlines (map (\ err -> cliErrorMessage file (rangeOf err) (prettyCheckErrorWithContext err)) errors)
 
-cliErrorMessage :: FilePath -> Maybe SrcRange -> [Text] -> Text
-cliErrorMessage fp mrange msg =
-  Text.unlines
-    ( prettySrcRange (Just fp) mrange <> ":"
-    : map ("  " <>) msg
-    )
-
 -- | Parse a source file and exact-print the result.
 exactprintProgram :: String -> Text -> Text
 exactprintProgram file input =
@@ -83,3 +87,28 @@ exactprintProgram file input =
       case exactprint prog of
         Left epError -> prettyTraverseAnnoError epError
         Right ep -> ep
+
+-- ----------------------------------------------------------------------------
+-- Error Handling
+-- ----------------------------------------------------------------------------
+
+data CliError
+  = CliParserError FilePath (NonEmpty PError)
+  | CliCheckError FilePath CheckResult
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (SOP.Generic)
+
+prettyCliError :: CliError -> Text
+prettyCliError = \case
+  CliParserError file perrors ->
+    "While parsing " <> Text.pack file <> ":" <>
+    Text.unlines (fmap (.message) $ toList perrors)
+  CliCheckError file CheckResult{errors} ->
+    Text.unlines (map (\ err -> cliErrorMessage file (rangeOf err) (prettyCheckErrorWithContext err)) errors)
+
+cliErrorMessage :: FilePath -> Maybe SrcRange -> [Text] -> Text
+cliErrorMessage fp mrange msg =
+  Text.unlines
+    ( prettySrcRange (Just fp) mrange <> ":"
+    : map ("  " <>) msg
+    )

--- a/jl4/src/L4/Parser.hs
+++ b/jl4/src/L4/Parser.hs
@@ -65,6 +65,7 @@ import L4.Lexer as L
 import qualified L4.Parser.ResolveAnnotation as Resolve
 import qualified L4.ParserCombinators as P
 import L4.Syntax
+import L4.Parser.SrcSpan
 
 type Parser = StateT PState (Parsec Void TokenStream)
 
@@ -1204,9 +1205,7 @@ execParserForTokens p file input ts =
 
 runLexer :: FilePath -> Text -> Either (NonEmpty PError) [PosToken]
 runLexer file input =
-  case execLexer file input of
-    Left errs -> Left $ fmap (mkPError "lexer") errs
-    Right ts -> pure ts
+  execLexer file input
 
 -- ----------------------------------------------------------------------------
 -- JL4 Program parser
@@ -1241,29 +1240,6 @@ parseFile p file input =
 
 parseTest :: Show a => Parser a -> Text -> IO ()
 parseTest p = parseFile p ""
-
--- ----------------------------------------------------------------------------
--- Parser error messages
--- ----------------------------------------------------------------------------
-
-data PError
-  = PError
-    { message :: Text
-    , start :: SrcPos
-    , origin :: Text
-    }
-  deriving (Show, Eq, Ord)
-
-mkPError :: Text -> (Text, SourcePos) -> PError
-mkPError orig (m, s) =
-  PError
-    { message = m
-    , start = MkSrcPos
-        { line = unPos $ sourceLine s
-        , column = unPos $ sourceColumn s
-        }
-    , origin = orig
-    }
 
 -- ----------------------------------------------------------------------------
 -- jl4 specific annotation helpers

--- a/jl4/src/L4/Parser/ResolveAnnotation.hs
+++ b/jl4/src/L4/Parser/ResolveAnnotation.hs
@@ -31,7 +31,6 @@ import Base
 
 import qualified Generics.SOP as SOP
 import L4.Annotation
-import L4.Lexer
 import L4.Syntax
 import L4.Parser.SrcSpan
 

--- a/jl4/src/L4/Parser/SrcSpan.hs
+++ b/jl4/src/L4/Parser/SrcSpan.hs
@@ -2,9 +2,8 @@ module L4.Parser.SrcSpan where
 
 import Base
 
-import L4.Lexer
-
 import qualified Generics.SOP as SOP
+import qualified Base.Text as Text
 
 -- ----------------------------------------------------------------------------
 -- SrcSpan
@@ -46,3 +45,61 @@ rangeAfter s1 s2 =
 
 prettySrcSpan :: SrcSpan -> Text
 prettySrcSpan (MkSrcSpan p1 p2) = prettySrcPos p1 <> prettyPartialSrcPos p1 p2
+
+-- ----------------------------------------------------------------------------
+-- SrcRange
+-- ----------------------------------------------------------------------------
+
+-- | A range of source positions. We store the length of a range as well.
+data SrcRange =
+  MkSrcRange
+    { start   :: !SrcPos -- inclusive
+    , end     :: !SrcPos -- inclusive
+    , length  :: !Int
+    }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (ToExpr, NFData)
+
+
+-- TODO: eventually, we may want to take sufficient info so that we can print the file path
+-- for "external" ranges, but not ranges in the current file.
+prettySrcRange :: Maybe FilePath -> Maybe SrcRange -> Text
+prettySrcRange fp Nothing = prettyFilePath fp <> "<unknown range>"
+prettySrcRange fp (Just (MkSrcRange p1 p2 _)) = prettyFilePath fp <> prettySrcPos p1 <> prettyPartialSrcPos p1 p2
+
+prettyFilePath :: Maybe FilePath -> Text
+prettyFilePath Nothing   = ""
+prettyFilePath (Just fp) = Text.pack fp <> ":"
+
+-- ----------------------------------------------------------------------------
+-- SrcPos
+-- ----------------------------------------------------------------------------
+
+
+-- | A single source position. Line and column numbers are 1-based.
+data SrcPos =
+  MkSrcPos
+    {
+    -- filename :: !FilePath
+      line     :: !Int
+    , column   :: !Int
+    }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (ToExpr, NFData)
+
+-- | We ignore the file name, because we assume this has already been checked.
+inRange :: SrcPos -> SrcRange -> Bool
+inRange (MkSrcPos l c) (MkSrcRange (MkSrcPos l1 c1) (MkSrcPos l2 c2) _) =
+     (l, c) >= (l1, c1)
+  && (l, c) <= (l2, c2)
+
+
+prettySrcPos :: SrcPos -> Text
+prettySrcPos (MkSrcPos l c) = Text.show l <> ":" <> Text.show c
+
+prettyPartialSrcPos :: SrcPos -> SrcPos -> Text
+prettyPartialSrcPos (MkSrcPos rl rc) p@(MkSrcPos l c)
+  | rl == l && rc == c = ""
+  | rl == l            = "-" <> Text.show c
+  | otherwise          = "-" <> prettySrcPos p
+

--- a/jl4/src/L4/Print.hs
+++ b/jl4/src/L4/Print.hs
@@ -245,8 +245,7 @@ instance LayoutPrinter a => LayoutPrinter (Expr a) where
     AppNamed   _ n namedExpr _ ->
           printWithLayout n
       <+> "WITH"
-      <> line
-      <> indent 2 (align (vcat (fmap printWithLayout namedExpr)))
+      <+> hang 2 (align (vcat (fmap printWithLayout namedExpr)))
     IfThenElse _ cond then' else' ->
       vcat
         [ "IF" <+> printWithLayout cond

--- a/jl4/src/L4/Syntax.hs
+++ b/jl4/src/L4/Syntax.hs
@@ -395,6 +395,14 @@ deriving anyclass instance ToConcreteNodes PosToken (GivethSig Name)
 deriving anyclass instance ToConcreteNodes PosToken (GivenSig Name)
 deriving anyclass instance ToConcreteNodes PosToken (Directive Name)
 
+
+deriving anyclass instance ToConcreteNodes PosToken (Program Resolved)
+
+-- Generic instance does not apply because we exclude the level.
+instance ToConcreteNodes PosToken (Section Resolved) where
+  toNodes (MkSection ann _lvl name maka decls) =
+    flattenConcreteNodes ann [toNodes name, toNodes maka, toNodes decls]
+
 deriving anyclass instance ToConcreteNodes PosToken (TopDecl Resolved)
 deriving anyclass instance ToConcreteNodes PosToken (Assume Resolved)
 deriving anyclass instance ToConcreteNodes PosToken (Declare Resolved)

--- a/jl4/src/L4/TypeCheck.hs
+++ b/jl4/src/L4/TypeCheck.hs
@@ -77,7 +77,8 @@ import qualified Base.Map as Map
 import qualified Base.Set as Set
 import qualified Base.Text as Text
 import L4.Annotation
-import L4.Lexer (PosToken(..), prettySrcRange)
+import L4.Lexer (PosToken(..))
+import L4.Parser.SrcSpan (prettySrcRange)
 import L4.Print (prettyLayout, quotedName)
 import L4.Syntax
 import L4.TypeCheck.Environment as X

--- a/jl4/src/L4/TypeCheck/Environment.hs
+++ b/jl4/src/L4/TypeCheck/Environment.hs
@@ -5,6 +5,7 @@ import Base
 import qualified Base.Map as Map
 import L4.Annotation
 import L4.Lexer
+import L4.Parser.SrcSpan
 import L4.Syntax
 import L4.TypeCheck.Types
 

--- a/jl4/src/L4/TypeCheck/Types.hs
+++ b/jl4/src/L4/TypeCheck/Types.hs
@@ -3,7 +3,7 @@ module L4.TypeCheck.Types where
 
 import Base
 import L4.Annotation (HasSrcRange(..))
-import L4.Lexer (SrcRange(..))
+import L4.Parser.SrcSpan (SrcRange(..))
 import L4.Syntax
 import L4.TypeCheck.With
 

--- a/jl4/tests/Main.hs
+++ b/jl4/tests/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import Base
 import qualified L4.Annotation as JL4
 import qualified L4.Evaluate as JL4
-import qualified L4.Lexer as JL4
+import qualified L4.Parser.SrcSpan as JL4
 import qualified L4.Main as JL4
 import L4.Parser (execProgramParser)
 import qualified L4.Parser as Parser

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -3,6 +3,7 @@
   imports = [
     ./jl4-web/configuration.nix
     ./jl4-lsp/configuration.nix
+    ./jl4-decision-service/configuration.nix
     ./jl4-websessions/configuration.nix
     ./module.nix
   ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,4 +6,5 @@
   jl4-web = pkgs.callPackage ./jl4-web/package.nix { };
   jl4-lsp = pkgs.callPackage ./jl4-lsp/package.nix { };
   jl4-websessions = pkgs.callPackage ./jl4-websessions/package.nix { };
+  jl4-decision-service = pkgs.callPackage ./jl4-decision-service/package.nix { };
 }

--- a/nix/jl4-decision-service/configuration.nix
+++ b/nix/jl4-decision-service/configuration.nix
@@ -1,0 +1,62 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+{
+  options.services.jl4-decision-service = {
+    path = lib.mkOption {
+      type = lib.types.str;
+      default = "/decision/";
+      description = "path relative to the domain the decision-service will answer on";
+    };
+    port = lib.mkOption {
+      type = lib.types.int;
+      default = 8001;
+      description = "port of localhost to run the websocket server of the jl4-decision-service on";
+    };
+  };
+
+  config.services.nginx.virtualHosts.${config.networking.domain}.locations = {
+    ${config.services.jl4-decision-service.path}.proxyPass =
+      "http://localhost:${toString config.services.jl4-decision-service.port}/";
+  };
+
+  config.systemd.services.jl4-decision-service = {
+    enable = true;
+    description = "jl4-decision-service";
+    after = [ "network.target" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.callPackage ./package.nix { }}/bin/jl4-decision-service-exe \
+          --port ${toString config.services.jl4-decision-service.port} \
+          --serverName ${config.networking.domain + config.services.jl4-decision-service.path}
+      '';
+      Restart = "always";
+
+      # Security
+      DynamicUser = true;
+      NoNewPrivileges = true;
+      # Sandboxing
+      ProtectSystem = "full";
+      ProtectHome = true;
+      PrivateTmp = true;
+      PrivateDevices = true;
+      PrivateUsers = true;
+      ProtectHostname = true;
+      ProtectClock = true;
+      ProtectKernelTunables = true;
+      ProtectKernelModules = true;
+      ProtectKernelLogs = true;
+      ProtectControlGroups = true;
+      RestrictAddressFamilies = [ "AF_UNIX AF_INET AF_INET6" ];
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      PrivateMounts = true;
+    };
+  };
+}

--- a/nix/jl4-decision-service/package.nix
+++ b/nix/jl4-decision-service/package.nix
@@ -1,0 +1,12 @@
+{ haskell, lib, ... }:
+let
+  hlib = haskell.lib.compose;
+  hpkgs = haskell.packages.ghc98.override {
+    overrides = lib.composeExtensions
+      (import ../jl4-lsp/hs-overlay.nix)
+      (hself: _: { jl4 = hlib.doJailbreak (hself.callCabal2nix "jl4" ../../jl4 {}); })
+      ;
+  };
+  jl4-decision-service = hpkgs.callCabal2nix "jl4-decision-service" ../../jl4-decision-service { };
+in
+hlib.justStaticExecutables (hlib.doJailbreak jl4-decision-service)

--- a/nix/jl4-lsp/hs-overlay.nix
+++ b/nix/jl4-lsp/hs-overlay.nix
@@ -1,0 +1,4 @@
+hself: hsuper: {
+  megaparsec = hsuper.callHackage "megaparsec" "9.7.0" { };
+  text-rope = hsuper.callHackage "text-rope" "0.3" { };
+}

--- a/nix/jl4-lsp/package.nix
+++ b/nix/jl4-lsp/package.nix
@@ -2,10 +2,7 @@
 let
   hlib = haskell.lib.compose;
   hpkgs = haskell.packages.ghc98.override {
-    overrides = hself: hsuper: {
-      megaparsec = hsuper.callHackage "megaparsec" "9.7.0" { };
-      text-rope = hsuper.callHackage "text-rope" "0.3" { };
-    };
+    overrides = import ./hs-overlay.nix;
   };
   jl4 = hpkgs.callCabal2nix "jl4" ../../jl4 { };
 in

--- a/nix/jl4-web/package.nix
+++ b/nix/jl4-web/package.nix
@@ -6,14 +6,20 @@
   importNpmLock,
   pkg-config,
   libsecret,
+  lib,
   ...
 }:
-buildNpmPackage {
+buildNpmPackage rec {
   pname = "jl4-web";
   version = "0-latest";
-  src = ../../.;
-  npmDeps = importNpmLock { npmRoot = ../../.; };
-  npmWorkspace = ../../.;
+  src =  lib.sources.sourceByRegex ../../. [
+      "^ts-apps.*"
+      "^ts-shared.*"
+      "^package-lock.json$"
+      "^package.json$"
+  ]; 
+  npmDeps = importNpmLock { npmRoot = src; };
+  npmWorkspace = src;
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libsecret.dev ];
   buildPhase = ''
@@ -44,6 +50,5 @@ buildNpmPackage {
   installPhase = ''
     mv build $out
   '';
-  npmFlags = [ ];
   npmConfigHook = importNpmLock.npmConfigHook;
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -8,6 +8,8 @@ pkgs.mkShell {
     pkgs.haskell.packages.ghc98.haskell-language-server
     pkgs.cabal-install
     pkgs.zlib
+    pkgs.xz
+    pkgs.pkg-config
     pkgs.nodejs
     pkgs.typescript
     pkgs.nixos-anywhere


### PR DESCRIPTION
This ports the web-service from the smucclaw/dsl repository.
As such, it contains a couple of design decision which made sense for
the dsl repo, but do not make a lot of sense right now.

For now, I deliberately decided to keep old code around, for the
non-zero chance that we might need this code again.

In short, this adds a REST service where you can add scenarios/functions
which can later be evaluated using REST endpoints.
As Jl4 does not support some of the features simala or gml do support,
we have some arbitrary restrictions:

* No floating point numbers
* No objects
* No uncertain
* No unknown

There will also be no reasoning tree, as Jl4 doesn't have the tracing
feature of simala, nor the explanation part of gml.

Additionally, the Jl4 endpoint can not handle missing values, and will
always throw an error when trying to invoke a function without all
required values.

We additionally ship a swagger-ui which is served under:

* GET /swagger-ui
* GET /swagger.json


--- 

Adds some semi-related refactorings, since I wanted to reuse the `parseAndCheck` function and disliked that the Lexer doesn't return `PError`. 
So, please review the commits individually.