### PR TITLE
Add a way to list the linearized paths through the ladder graph, in a collapsible, scrollable panel. Highlight corresponding path in the ladder graph when mousing over linearized path.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3757,6 +3757,34 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3816,6 +3844,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.7.0.tgz",
+      "integrity": "sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4688,6 +4726,16 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "svelte": "^5.0.0",
         "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tailwindcss/cli": {
@@ -6429,6 +6477,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bits-ui": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-1.3.6.tgz",
+      "integrity": "sha512-0Ee7Ox5KqIBdio/+TG387Xlj6QJ0S7tHVS2K4DYiBHxBRbm6ni13i/pOoNDjeME6NOGUZxbSe4dNZIW3pGlxZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.4",
+        "@floating-ui/dom": "^1.6.7",
+        "@internationalized/date": "^3.5.6",
+        "esm-env": "^1.1.2",
+        "runed": "^0.23.2",
+        "svelte-toolbelt": "^0.7.1",
+        "tabbable": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/huntabyte"
+      },
+      "peerDependencies": {
+        "svelte": "^5.11.0"
       }
     },
     "node_modules/bl": {
@@ -8841,6 +8915,13 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -9868,6 +9949,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-svelte": {
+      "version": "0.477.0",
+      "resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.477.0.tgz",
+      "integrity": "sha512-w/zj6/CXTtTizIeo8SuWGYu0u45CJ7cD2AtNzIObVHZrWXNgaIIX/2cI25wybjSmYHIi4pub2TLv/kNPKiB3ww==",
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5.0.0-next.42"
       }
     },
     "node_modules/magic-string": {
@@ -12311,6 +12401,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-to-object": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
+      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
+      }
+    },
     "node_modules/supports-color": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
@@ -12535,6 +12635,27 @@
         }
       }
     },
+    "node_modules/svelte-toolbelt": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.7.1.tgz",
+      "integrity": "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/huntabyte"
+      ],
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "runed": "^0.23.2",
+        "style-to-object": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8.7.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0"
+      }
+    },
     "node_modules/svelte2tsx": {
       "version": "0.7.34",
       "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.34.tgz",
@@ -12549,6 +12670,13 @@
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
         "typescript": "^4.9.4 || ^5.0.0"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.0.6",
@@ -14072,6 +14200,7 @@
         "graphology": "^0.26.0",
         "graphology-dag": "^0.4.1",
         "lodash": "^4.17.21",
+        "lucide-svelte": "^0.477.0",
         "runed": "^0.23.3",
         "ts-pattern": "^5.6.1"
       },
@@ -14085,6 +14214,7 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@types/lodash": "^4.17.14",
         "autoprefixer": "^10.4.20",
+        "bits-ui": "^1.3.6",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.13.0",

--- a/ts-apps/decision-logic-visualizer/package.json
+++ b/ts-apps/decision-logic-visualizer/package.json
@@ -52,6 +52,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@types/lodash": "^4.17.14",
     "autoprefixer": "^10.4.20",
+    "bits-ui": "^1.3.6",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.13.0",
@@ -81,6 +82,7 @@
     "graphology": "^0.26.0",
     "graphology-dag": "^0.4.1",
     "lodash": "^4.17.21",
+    "lucide-svelte": "^0.477.0",
     "runed": "^0.23.3",
     "ts-pattern": "^5.6.1"
   }

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
@@ -1,7 +1,7 @@
 import type { Eq, Ord } from '$lib/utils.js'
 import {
   DirectedEdge,
-  stringifyEdge,
+  stringifyEdge as makeEdgeKey,
   type Edge,
   type EdgeAttributes,
   DefaultEdgeAttributes,
@@ -67,25 +67,26 @@ export class DirectedAMGraph<A extends Ord<A>>
   // Getting / setting edge attributes
 
   getAttributesForEdge<T extends Edge<A>>(edge: T): EdgeAttributes {
-    return (
-      this.edgeAttributes.get(stringifyEdge(edge)) ??
-      new DefaultEdgeAttributes()
-    )
+    console.log('ea map', this.edgeAttributes)
+    const edgeKey = makeEdgeKey(edge)
+    const attrs = this.edgeAttributes.get(edgeKey)
+    if (attrs) {
+      return attrs
+    } else {
+      this.edgeAttributes.set(edgeKey, new DefaultEdgeAttributes())
+      return this.edgeAttributes.get(edgeKey) as EdgeAttributes
+    }
   }
 
   /** Will error if the input edge does not exist.
-   *
-   * Merges the input attribute with any existing ones
    */
-  setEdgeAttribute<T extends Edge<A>>(edge: T, newAttr: EdgeAttributes) {
+  setEdgeAttributes<T extends Edge<A>>(edge: T, newAttr: EdgeAttributes) {
     if (!this.hasEdge(edge.getU(), edge.getV())) {
       throw new Error(
         `setEdgeAttribute: Edge (${edge.getU()}, ${edge.getV()}) does not exist`
       )
     }
-
-    const currAttributes = this.getAttributesForEdge(edge)
-    this.edgeAttributes.set(stringifyEdge(edge), currAttributes.merge(newAttr))
+    this.edgeAttributes.set(makeEdgeKey(edge), newAttr)
   }
 
   /** Internal */

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
@@ -67,7 +67,6 @@ export class DirectedAMGraph<A extends Ord<A>>
   // Getting / setting edge attributes
 
   getAttributesForEdge<T extends Edge<A>>(edge: T): EdgeAttributes {
-    console.log('ea map', this.edgeAttributes)
     const edgeKey = makeEdgeKey(edge)
     const attrs = this.edgeAttributes.get(edgeKey)
     if (attrs) {

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
@@ -71,10 +71,10 @@ export class DirectedAMGraph<A extends Ord<A>>
     const edgeKey = makeEdgeKey(edge)
     const attrs = this.edgeAttributes.get(edgeKey)
     if (attrs) {
-      return attrs
+      return attrs.clone()
     } else {
       this.edgeAttributes.set(edgeKey, new DefaultEdgeAttributes())
-      return this.edgeAttributes.get(edgeKey) as EdgeAttributes
+      return new DefaultEdgeAttributes() as EdgeAttributes
     }
   }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/edge.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/edge.ts
@@ -197,7 +197,7 @@ export function mergeEdgeAttributes(
 export interface EdgeStyles extends Eq<EdgeStyles> {
   $type: 'EmptyEdgeStyles' | 'HighlightedEdgeStyles'
 
-  getStrokeColor(): StrokeColorCSSVar
+  getStyleString(): string
 
   isEqualTo(other: EdgeStyles): boolean
 }
@@ -223,8 +223,8 @@ export class EmptyEdgeStyles implements EdgeStyles {
     return isEmptyEdgeStyles(other)
   }
 
-  getStrokeColor() {
-    return '--default-internal-stroke-color' as const
+  getStyleString(): EdgeStyleString {
+    return 'stroke: var(--default-internal-stroke-color) !important;' as const
   }
 }
 
@@ -236,13 +236,13 @@ export class HighlightedEdgeStyles implements EdgeStyles {
     return isHighlightedEdgeStyles(other)
   }
 
-  getStrokeColor() {
-    return '--color-highlighted-path-in-flow' as const
+  getStyleString(): EdgeStyleString {
+    return 'stroke: var(--color-highlighted-path-in-flow) !important; stroke-width: 3px;' as const
   }
 }
 
 export const emptyEdgeLabel = ''
 
-export type StrokeColorCSSVar =
-  | '--color-highlighted-path-in-flow'
-  | '--default-internal-stroke-color'
+export type EdgeStyleString =
+  | 'stroke: var(--color-highlighted-path-in-flow) !important; stroke-width: 3px;'
+  | 'stroke: var(--default-internal-stroke-color) !important;'

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/edge.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/edge.ts
@@ -117,6 +117,8 @@ export interface EdgeAttributes extends Eq<EdgeAttributes> {
   isEqualTo<T extends EdgeAttributes>(other: T): boolean
 
   merge(other: EdgeAttributes): EdgeAttributes
+
+  clone(): EdgeAttributes
 }
 
 export class DefaultEdgeAttributes implements EdgeAttributes {
@@ -130,6 +132,10 @@ export class DefaultEdgeAttributes implements EdgeAttributes {
       this.getStyles().isEqualTo(other.getStyles()) &&
       this.getLabel() === other.getLabel()
     )
+  }
+
+  clone(): EdgeAttributes {
+    return new DefaultEdgeAttributes(this.styles, this.label)
   }
 
   getStyles(): EdgeStyles {

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/edge.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/edge.ts
@@ -224,7 +224,7 @@ export class EmptyEdgeStyles implements EdgeStyles {
   }
 
   getStyleString(): EdgeStyleString {
-    return 'stroke: var(--default-internal-stroke-color) !important;' as const
+    return 'stroke: var(--default-stroke-color); stroke-width: var(--default-stroke-width);' as const
   }
 }
 
@@ -237,12 +237,12 @@ export class HighlightedEdgeStyles implements EdgeStyles {
   }
 
   getStyleString(): EdgeStyleString {
-    return 'stroke: var(--color-highlighted-path-in-flow) !important; stroke-width: 3px;' as const
+    return 'stroke: var(--color-highlighted-path-in-flow); stroke-width: var(--highlighted-stroke-width);' as const
   }
 }
 
 export const emptyEdgeLabel = ''
 
 export type EdgeStyleString =
-  | 'stroke: var(--color-highlighted-path-in-flow) !important; stroke-width: 3px;'
-  | 'stroke: var(--default-internal-stroke-color) !important;'
+  | 'stroke: var(--color-highlighted-path-in-flow); stroke-width: var(--highlighted-stroke-width);'
+  | 'stroke: var(--default-stroke-color); stroke-width: var(--default-stroke-width);'

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -285,7 +285,7 @@ Misc SF UI TODOs:
         // Need the timeout to synchronize the fit view properly (probably because we use window.requestAnimationFrame in doFitView?)
         setTimeout(() => {
           doFitView()
-        }, 20)
+        }, 10)
       }}
     >
       <Collapsible.Trigger class="flex items-center gap-2">

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -288,7 +288,7 @@ Misc SF UI TODOs:
         }, 10)
       }}
     >
-      <Collapsible.Trigger class="flex items-center gap-2">
+      <Collapsible.Trigger class="flex items-center justify-end w-full gap-2">
         <!-- TODO: Improve the button styles -->
         <button
           class="rounded-md border-1 px-2 py-1 text-sm hover:bg-sky-100 flex items-center gap-1"
@@ -297,7 +297,7 @@ Misc SF UI TODOs:
         </button>
       </Collapsible.Trigger>
       <Collapsible.Content class="pt-2">
-        <section>
+        <section class="paths-list-content-wrapper">
           <ul class="space-y-1">
             {#each ladderGraph.getLinearizedPaths(context) as path, pathIndex}
               <li class="grid grid-cols-[max-content_1fr] gap-x-2 items-center">
@@ -333,7 +333,7 @@ Misc SF UI TODOs:
     flex-direction: column;
     height: 100%;
     /* Gap between the flow and the paths list container */
-    row-gap: 20px;
+    row-gap: 6px;
   }
 
   .flow-container {
@@ -345,5 +345,12 @@ Misc SF UI TODOs:
     flex: 0 0 auto;
     max-height: 45%;
     overflow-y: auto;
+    padding-bottom: 6px;
+  }
+
+  .paths-list-content-wrapper {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 65ch;
   }
 </style>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -278,18 +278,24 @@ Misc SF UI TODOs:
   <!-- TODO: Add expand/collapse  -->
   <!-- TODO: Move the following into a lin paths container component -->
   <section class="paths-container">
-    <div class="flex flex-col gap-1">
-      {#each ladderGraph.getLinearizedPaths(context) as path}
-        <button
-          class="rounded-md border-1 p-2 max-w-fit hover:bg-sky-100 text-xs"
-          onmouseenter={() =>
-            path.highlightCorrespondingPathInLadderGraph(context)}
-          onmouseleave={() =>
-            path.unhighlightCorrespondingPathInLadderGraph(context)}
-        >
-          {path.toPretty(context)}
-        </button>
-      {/each}
+    <div class="flex flex-col">
+      <ul class="space-y-1">
+        {#each ladderGraph.getLinearizedPaths(context) as path, pathIndex}
+          <li class="grid grid-cols-6">
+            <!-- Row number / path index -->
+            <div class="font-semibold col-span-1">{pathIndex + 1}</div>
+            <button
+              class="col-span-5 rounded-md border-1 p-2 max-w-fit hover:bg-sky-100 text-xs"
+              onmouseenter={() =>
+                path.highlightCorrespondingPathInLadderGraph(context)}
+              onmouseleave={() =>
+                path.unhighlightCorrespondingPathInLadderGraph(context)}
+            >
+              {path.toPretty(context)}
+            </button>
+          </li>
+        {/each}
+      </ul>
     </div>
   </section>
 </div>
@@ -310,7 +316,7 @@ Misc SF UI TODOs:
     min-height: 0; /* Prevents overflow */
   }
 
-  /* .paths-container {
+  .paths-container {
     flex: 0 0 auto;
-  } */
+  }
 </style>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -33,13 +33,14 @@
   import { onMount } from 'svelte'
   import { Debounced, watch } from 'runed'
 
-  import '@xyflow/svelte/dist/style.css'
+  import '@xyflow/svelte/dist/style.css' // TODO: Prob remove this
   import type {
     BoolVarLirNode,
     LadderLirNode,
   } from '$lib/layout-ir/ladder-lir.svelte.js'
   import { Collapsible } from 'bits-ui'
   import List from 'lucide-svelte/icons/list'
+  import PathsList from './paths-list.svelte'
 
   /************************
        Lir
@@ -297,27 +298,7 @@ Misc SF UI TODOs:
         </button>
       </Collapsible.Trigger>
       <Collapsible.Content class="pt-2">
-        <section class="paths-list-content-wrapper">
-          <ul class="space-y-1">
-            {#each ladderGraph.getLinearizedPaths(context) as path, pathIndex}
-              <li class="grid grid-cols-[max-content_1fr] gap-x-2 items-center">
-                <!-- Row number / path index -->
-                <div class="font-semibold px-3 max-w-[25px] text-right">
-                  {pathIndex + 1}
-                </div>
-                <button
-                  class="rounded-md border-1 p-2 max-w-fit hover:bg-sky-100 text-xs text-left"
-                  onmouseenter={() =>
-                    path.highlightCorrespondingPathInLadderGraph(context)}
-                  onmouseleave={() =>
-                    path.unhighlightCorrespondingPathInLadderGraph(context)}
-                >
-                  {path.toPretty(context)}
-                </button>
-              </li>
-            {/each}
-          </ul>
-        </section>
+        <PathsList {context} node={ladderGraph.getPathsList(context)} />
       </Collapsible.Content>
     </Collapsible.Root>
   </div>
@@ -346,11 +327,5 @@ Misc SF UI TODOs:
     max-height: 45%;
     overflow-y: auto;
     padding-bottom: 6px;
-  }
-
-  .paths-list-content-wrapper {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 65ch;
   }
 </style>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -274,6 +274,24 @@ Misc SF UI TODOs:
       <Background />
     </SvelteFlow>
   </div>
+  <!-- Paths Section -->
+  <!-- TODO: Add expand/collapse  -->
+  <!-- TODO: Move the following into a lin paths container component -->
+  <section class="paths-container">
+    <div class="flex flex-col gap-1">
+      {#each ladderGraph.getLinearizedPaths(context) as path}
+        <button
+          class="rounded-md border-1 p-2 max-w-fit hover:bg-sky-100 text-xs"
+          onmouseenter={() =>
+            path.highlightCorrespondingPathInLadderGraph(context)}
+          onmouseleave={() =>
+            path.unhighlightCorrespondingPathInLadderGraph(context)}
+        >
+          {path.toPretty(context)}
+        </button>
+      {/each}
+    </div>
+  </section>
 </div>
 
 <!-- For debugging -->

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -38,6 +38,8 @@
     BoolVarLirNode,
     LadderLirNode,
   } from '$lib/layout-ir/ladder-lir.svelte.js'
+  import { Collapsible } from 'bits-ui'
+  import List from 'lucide-svelte/icons/list'
 
   /************************
        Lir
@@ -275,29 +277,50 @@ Misc SF UI TODOs:
     </SvelteFlow>
   </div>
   <!-- Paths Section -->
-  <!-- TODO: Add expand/collapse  -->
   <!-- TODO: Move the following into a lin paths container component -->
-  <section class="paths-container">
-    <div class="flex flex-col">
-      <ul class="space-y-1">
-        {#each ladderGraph.getLinearizedPaths(context) as path, pathIndex}
-          <li class="grid grid-cols-6">
-            <!-- Row number / path index -->
-            <div class="font-semibold col-span-1">{pathIndex + 1}</div>
-            <button
-              class="col-span-5 rounded-md border-1 p-2 max-w-fit hover:bg-sky-100 text-xs"
-              onmouseenter={() =>
-                path.highlightCorrespondingPathInLadderGraph(context)}
-              onmouseleave={() =>
-                path.unhighlightCorrespondingPathInLadderGraph(context)}
-            >
-              {path.toPretty(context)}
-            </button>
-          </li>
-        {/each}
-      </ul>
-    </div>
-  </section>
+  <div class="paths-container">
+    <!-- TODO: Make a standalone wrapper over the collapsible component, as suggested by https://bits-ui.com/docs/components/collapsible  -->
+    <Collapsible.Root
+      onOpenChange={() => {
+        // Need the timeout to synchronize the fit view properly (probably because we use window.requestAnimationFrame in doFitView?)
+        setTimeout(() => {
+          doFitView()
+        }, 20)
+      }}
+    >
+      <Collapsible.Trigger class="flex items-center gap-2">
+        <!-- TODO: Improve the button styles -->
+        <button
+          class="rounded-md border-1 px-2 py-1 text-sm hover:bg-sky-100 flex items-center gap-1"
+        >
+          <List /><span>List paths</span>
+        </button>
+      </Collapsible.Trigger>
+      <Collapsible.Content class="pt-2">
+        <section>
+          <ul class="space-y-1">
+            {#each ladderGraph.getLinearizedPaths(context) as path, pathIndex}
+              <li class="grid grid-cols-[max-content_1fr] gap-x-2 items-center">
+                <!-- Row number / path index -->
+                <div class="font-semibold px-3 max-w-[25px] text-right">
+                  {pathIndex + 1}
+                </div>
+                <button
+                  class="rounded-md border-1 p-2 max-w-fit hover:bg-sky-100 text-xs text-left"
+                  onmouseenter={() =>
+                    path.highlightCorrespondingPathInLadderGraph(context)}
+                  onmouseleave={() =>
+                    path.unhighlightCorrespondingPathInLadderGraph(context)}
+                >
+                  {path.toPretty(context)}
+                </button>
+              </li>
+            {/each}
+          </ul>
+        </section>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  </div>
 </div>
 
 <!-- For debugging -->
@@ -309,6 +332,8 @@ Misc SF UI TODOs:
     display: flex;
     flex-direction: column;
     height: 100%;
+    /* Gap between the flow and the paths list container */
+    row-gap: 20px;
   }
 
   .flow-container {
@@ -318,5 +343,7 @@ Misc SF UI TODOs:
 
   .paths-container {
     flex: 0 0 auto;
+    max-height: 45%;
+    overflow-y: auto;
   }
 </style>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
@@ -142,14 +142,13 @@ export function ladderLirEdgeToSfEdge(
   edge: LadderLirEdge
 ): SF.Edge {
   const label = graph.getEdgeLabel(context, edge)
-  const strokeColorCSSVar = graph.getEdgeStyles(context, edge).getStrokeColor()
 
   return {
     id: edge.getId(),
     type: ladderEdgeType,
     data: {
       label,
-      strokeColorCSSVar,
+      edgeStyles: graph.getEdgeStyles(context, edge).getStyleString(),
     },
     source: edge.getU().toString(),
     target: edge.getV().toString(),

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { type PathListDisplayerProps } from './types.svelte.js'
+
+  /************************
+       Lir
+  *************************/
+
+  const { context, node }: PathListDisplayerProps = $props()
+</script>
+
+<section class="paths-list-content-wrapper">
+  <ul class="space-y-1">
+    {#each node.getPaths(context) as path, pathIndex}
+      <li class="grid grid-cols-[max-content_1fr] gap-x-2 items-center">
+        <!-- Row number / path index -->
+        <div class="font-semibold px-3 max-w-[25px] text-right">
+          {pathIndex + 1}
+        </div>
+        <!-- TODO: Refactor the hover CSS to use our css vars -->
+        <button
+          class="rounded-md border-1 p-2 max-w-fit hover:bg-sky-100 text-xs text-left"
+          onmouseenter={() =>
+            path.highlightCorrespondingPathInLadderGraph(context)}
+          onmouseleave={() =>
+            path.unhighlightCorrespondingPathInLadderGraph(context)}
+        >
+          {path.toPretty(context)}
+        </button>
+      </li>
+    {/each}
+  </ul>
+</section>
+
+<style>
+  .paths-list-content-wrapper {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 65ch;
+  }
+</style>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
@@ -15,10 +15,6 @@
     targetPosition,
     data = defaultLadderEdgeAttrs,
   }: LadderEdgeProps = $props()
-
-  // stroke-width: 2px;
-  // TODO: try using a css class instead; might be able to avoid the !important that way
-  const pathStyle = `stroke: var(${data.strokeColorCSSVar}) !important;`
 </script>
 
 <BezierEdge
@@ -30,7 +26,7 @@
   {targetPosition}
   label={data.label}
   pathOptions={{ curvature: 1 }}
-  style={pathStyle}
+  style={data.edgeStyles}
 />
 
 <!-- 

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    BaseEdge,
     BezierEdge,
     // EdgeLabel,
   } from '@xyflow/svelte'
@@ -13,11 +14,13 @@
     targetX,
     targetY,
     targetPosition,
-    attrs: data = defaultLadderEdgeAttrs,
+    data = defaultLadderEdgeAttrs,
   }: LadderEdgeProps = $props()
 
-  const pathStyle = `stroke: var(${data.strokeColorCSSVar});`
-  // console.log(pathStyle)
+  // stroke-width: 2px;
+  // TODO: try using a css class instead; might be able to avoid the !important that way
+  const pathStyle = `stroke: var(${data.strokeColorCSSVar}) !important;`
+  console.log(pathStyle)
 </script>
 
 <BezierEdge

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
@@ -19,7 +19,6 @@
   // stroke-width: 2px;
   // TODO: try using a css class instead; might be able to avoid the !important that way
   const pathStyle = `stroke: var(${data.strokeColorCSSVar}) !important;`
-  console.log(pathStyle)
 </script>
 
 <BezierEdge

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {
-    BaseEdge,
     BezierEdge,
     // EdgeLabel,
   } from '@xyflow/svelte'

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/types.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/types.svelte.ts
@@ -13,7 +13,6 @@ import NotEndSFNode from './sf-custom-nodes/not-end.svelte'
 import SourceSFNode from './sf-custom-nodes/bundling-source.svelte'
 import SinkSFNode from './sf-custom-nodes/bundling-sink.svelte'
 import LadderEdge from './sf-custom-edges/ladder-edge.svelte'
-import type { StrokeColorCSSVar } from '../../algebraic-graphs/edge.js'
 import { emptyEdgeLabel, EmptyEdgeStyles } from '../../algebraic-graphs/edge.js'
 import type { LirId } from '$lib/layout-ir/core.js'
 
@@ -143,12 +142,12 @@ with their EdgeData */
  * and can have a label */
 export interface LadderEdgeAttrs extends Record<string, unknown> {
   label: string
-  strokeColorCSSVar: StrokeColorCSSVar
+  edgeStyles: string
 }
 
 export const defaultLadderEdgeAttrs = {
   label: emptyEdgeLabel,
-  strokeColorCSSVar: new EmptyEdgeStyles().getStrokeColor(),
+  edgeStyles: new EmptyEdgeStyles().getStyleString(),
 }
 
 export interface LadderEdgeProps extends SF.EdgeProps {

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/types.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/types.svelte.ts
@@ -152,5 +152,5 @@ export const defaultLadderEdgeAttrs = {
 }
 
 export interface LadderEdgeProps extends SF.EdgeProps {
-  attrs?: LadderEdgeAttrs
+  data?: LadderEdgeAttrs
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/types.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/types.svelte.ts
@@ -5,7 +5,10 @@ import type {
   DisplayerProps,
   LirContext,
 } from '$lib/layout-ir/core.js'
-import type { DeclLirNode } from '$lib/layout-ir/ladder-lir.svelte.js'
+import type {
+  DeclLirNode,
+  PathListLirNode,
+} from '$lib/layout-ir/ladder-lir.svelte.js'
 import * as SF from '@xyflow/svelte'
 import BoolVarSFNode from './sf-custom-nodes/bool-var.svelte'
 import NotStartSFNode from './sf-custom-nodes/not-start.svelte'
@@ -16,6 +19,17 @@ import LadderEdge from './sf-custom-edges/ladder-edge.svelte'
 import { emptyEdgeLabel, EmptyEdgeStyles } from '../../algebraic-graphs/edge.js'
 import type { LirId } from '$lib/layout-ir/core.js'
 
+export interface LadderSFGraph {
+  nodes: LadderSFNode[]
+  edges: LadderSFEdge[]
+  sfIdToLirId(sfId: string): LirId
+  lirIdToSFId(lirId: LirId): string
+}
+
+/************************************************
+        Displayer Props
+*************************************************/
+
 export interface LadderFlowDisplayerProps extends RootDisplayerProps {
   node: DeclLirNode
 }
@@ -24,11 +38,8 @@ export interface BaseLadderFlowDisplayerProps extends DisplayerProps {
   node: LadderFlowDisplayerProps['node']
 }
 
-export interface LadderSFGraph {
-  nodes: LadderSFNode[]
-  edges: LadderSFEdge[]
-  sfIdToLirId(sfId: string): LirId
-  lirIdToSFId(lirId: LirId): string
+export interface PathListDisplayerProps extends DisplayerProps {
+  node: PathListLirNode
 }
 
 /************************************************

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -34,7 +34,7 @@ is to make it easy to experiment with different displayers/renderers.
 */
 
 /*************************************************
-                Decl Lir Node 
+                Decl Lir Node
  *************************************************/
 
 export type DeclLirNode = FunDeclLirNode
@@ -84,7 +84,7 @@ export class FunDeclLirNode extends DefaultLirNode implements LirNode {
 }
 
 /*************************************************
-              Path Lir Node 
+              Path Lir Node
  *************************************************/
 
 // TODO: Might also need something like a container lir node for the Array<PathLirNode>
@@ -143,80 +143,7 @@ export class LinPathLirNode extends DefaultLirNode implements LirNode {
   }
 }
 
-// The more complicated version that differentiates between compatible and incompatible linearized paths
-// abstract class BasePathLirNode extends DefaultLirNode {
-//   constructor(
-//     nodeInfo: LirNodeInfo,
-//     protected rawPath: DirectedAcyclicGraph<LirId>
-//   ) {
-//     super(nodeInfo)
-//   }
-
-//   getVertices(context: LirContext) {
-//     return this.rawPath
-//       .getVertices()
-//       .map((id) => context.get(id))
-//       .filter((n) => !!n) as LadderLirNode[]
-//   }
-
-//   toPretty(context: LirContext) {
-//     return this.getVertices(context)
-//       .map((n) => n.toPretty(context))
-//       .join(' ')
-//   }
-// }
-//
-// /** For the first version, we'll take the LinearizedPaths to be wholly controlled by interactions on the ladder graph;
-//  * i.e., let's not worry about the linearized path -> ladder graph interactions for the v1,
-//  * and instead just focus on ladder graph -> linearized paths.
-//  *
-//  * The v1 could be as simple as:
-//  * - whenever new bindings are submitted on the ladder graph,
-//  *    re-compute (via `induce`) the subgraph that is compatible with the new env,
-//  *    then generate the linearized paths of that subgraph.
-//  */
-// export type LinPathLirNode = CompatiblePathLirNode | IncompatiblePathLirNode
-
-// export class CompatiblePathLirNode extends BasePathLirNode implements LirNode {
-//   constructor(
-//     nodeInfo: LirNodeInfo,
-//     protected rawPath: DirectedAcyclicGraph<LirId>
-//   ) {
-//     super(nodeInfo, rawPath)
-//   }
-
-//   toString() {
-//     return 'COMPATIBLE_PATH_LIR_NODE'
-//   }
-
-//   /** Note: This is styling for the *linearized* paths below the ladder graph,
-//    * as opposed to styles for paths *in* the ladder graph */
-//   getPathStyles() {
-//     console.error('TODO')
-//   }
-// }
-
-// export class IncompatiblePathLirNode
-//   extends BasePathLirNode
-//   implements LirNode
-// {
-//   constructor(
-//     nodeInfo: LirNodeInfo,
-//     protected rawPath: DirectedAcyclicGraph<LirId>
-//   ) {
-//     super(nodeInfo, rawPath)
-//   }
-
-//   toString() {
-//     return 'INCOMPATIBLE_PATH_LIR_NODE'
-//   }
-
-//   /** Note: This is styling for the *linearized* paths below the ladder graph,
-//    * as opposed to styles for paths *in* the ladder graph */
-//   getPathStyles() {
-//     console.error('TODO')
-//   }
-// }
+// TODO: Differentiate between compatible and incompatible linearized paths
 
 /******************************************************
                   Flow Lir Nodes
@@ -226,7 +153,7 @@ export class LinPathLirNode extends DefaultLirNode implements LirNode {
 // (and similarly with Flow Lir Edges)
 
 /* Why should Position be put on the Lir nodes, as opposed to being handled entirely at the SF Node level?
-  
+
 Main argument: for more complicated layouts,
 we'll want to be able to use info that's more readily available at the level of the Lir LadderGraph.
 */
@@ -291,7 +218,7 @@ will go through the LadderGraphLirNode.
 * and re-render on changes.
 *
 * State ownership:
-  - The Lir nodes only own, and publish changes to, state that's not about the positions 
+  - The Lir nodes only own, and publish changes to, state that's not about the positions
     or dimensions of the nodes.
   - For instance, we do not publish changes to the position of the nodes/edges --- that is state that
     is owned by SvelteFlow.

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -228,7 +228,14 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
     return this.#dag.getAttributesForEdge(edge)
   }
 
-  // TODO: Think more abt whether we really need the following edge related methods
+  /** internal helper method */
+  protected setEdgeAttributes<T extends Edge<LirId>>(
+    _context: LirContext,
+    edge: T,
+    attrs: EdgeAttributes
+  ) {
+    this.#dag.setEdgeAttributes(edge, attrs)
+  }
 
   getEdgeStyles<T extends Edge<LirId>>(
     _context: LirContext,
@@ -242,7 +249,11 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
     edge: T,
     styles: EdgeStyles
   ) {
-    this.#dag.getAttributesForEdge(edge).setStyles(styles)
+    const attrs = this.#dag.getAttributesForEdge(edge)
+    const newAttrs = new DefaultEdgeAttributes().merge(attrs)
+    newAttrs.setStyles(styles)
+    this.#dag.setEdgeAttributes(edge, newAttrs)
+
     this.getRegistry().publish(context, this.getId())
   }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -87,7 +87,26 @@ export class FunDeclLirNode extends DefaultLirNode implements LirNode {
               Path Lir Node
  *************************************************/
 
-// TODO: Might also need something like a container lir node for the Array<PathLirNode>
+export class PathListLirNode extends DefaultLirNode implements LirNode {
+  private paths: Array<LirId>
+
+  constructor(nodeInfo: LirNodeInfo, paths: Array<LinPathLirNode>) {
+    super(nodeInfo)
+    this.paths = paths.map((n) => n.getId())
+  }
+
+  getPaths(context: LirContext) {
+    return this.paths.map((id) => context.get(id)) as Array<LinPathLirNode>
+  }
+
+  getChildren(context: LirContext) {
+    return this.getPaths(context)
+  }
+
+  toString(): string {
+    return 'PATH_LIST_LIR_NODE'
+  }
+}
 
 /** The simplest version of the LinPathLirNode -- no distinguishing between
  * compatible and incompatible linearized paths
@@ -276,14 +295,18 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
   }
 
   // TODO: differentiate between subgraph that is compatible with the updated env and subgraph that isn't
-  /** Get all simple paths through the Dag */
-  getLinearizedPaths(context: LirContext) {
-    return this.#dag
+  /** Get list of all simple paths through the Dag */
+  getPathsList(context: LirContext) {
+    const paths = this.#dag
       .getAllPaths()
       .map(
         (rawPath) =>
           new LinPathLirNode(this.makeNodeInfo(context), this, rawPath)
       )
+    return new PathListLirNode(
+      this.makeNodeInfo(context),
+      paths as Array<LinPathLirNode>
+    )
   }
 
   /*****************************

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -103,9 +103,4 @@ body {
     font-optical-sizing: auto;
     font-style: normal;
   }
-
-  .svelte-flow__edge .svelte-flow__edge-path {
-    --default-internal-stroke-color: var(--stroke-color, var(--color-primary));
-    stroke: var(--default-internal-stroke-color) !important;
-  }
 }

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -73,12 +73,14 @@ body {
   margin: 0;
 }
 
+/* TODO: Check if this class really can be used w/o @utility */
 .visualization-container {
   min-height: 400px;
   max-width: 96svw;
   margin: 0 auto;
 }
 
+/* TODO: Check if this class really can be used w/o @utility */
 .button {
   background-color: var(--color-secondary);
   color: transparent;

--- a/ts-apps/decision-logic-visualizer/src/tests/alga-edge-attributes.test.ts
+++ b/ts-apps/decision-logic-visualizer/src/tests/alga-edge-attributes.test.ts
@@ -34,7 +34,7 @@ describe('Edge Attributes - Setting and Getting', () => {
 
     // Set attributes on the edge from nw1 to nw2
     const edge = new DirectedEdge(nw1, nw2)
-    g.setEdgeAttribute(edge, edgeAttrs)
+    g.setEdgeAttributes(edge, edgeAttrs)
 
     // Get the attributes
     const retrievedAttrs = g.getAttributesForEdge(edge)
@@ -55,7 +55,7 @@ describe('Edge Attributes - Setting and Getting', () => {
     edgeAttrs.setLabel('Non-existent Edge')
     const edge = new DirectedEdge(nw1, nw3)
 
-    expect(() => g.setEdgeAttribute(edge, edgeAttrs)).toThrowError(
+    expect(() => g.setEdgeAttributes(edge, edgeAttrs)).toThrowError(
       `setEdgeAttribute: Edge (${edge.u}, ${edge.v}) does not exist`
     )
   })
@@ -103,14 +103,14 @@ describe('Edge Attributes - Graph Operations', () => {
     const g1 = vertex(nw1).connect(vertex(nw2))
     const attr1 = new DefaultEdgeAttributes()
     attr1.setLabel('Label1')
-    g1.setEdgeAttribute(edge, attr1)
+    g1.setEdgeAttributes(edge, attr1)
 
     const g2 = vertex(nw1).connect(vertex(nw2))
     const attr2 = new DefaultEdgeAttributes(
       new HighlightedEdgeStyles(),
       'Label2'
     )
-    g2.setEdgeAttribute(edge, attr2)
+    g2.setEdgeAttributes(edge, attr2)
 
     const overlaid = g1.overlay(g2)
 
@@ -133,12 +133,12 @@ describe('Edge Attributes - Graph Operations', () => {
     const g1 = vertex(nw1).connect(vertex(nw2))
     const attr1 = new DefaultEdgeAttributes()
     attr1.setLabel('Edge1')
-    g1.setEdgeAttribute(edge1, attr1)
+    g1.setEdgeAttributes(edge1, attr1)
 
     const g2 = vertex(nw1).connect(vertex(nw3))
     const attr2 = new DefaultEdgeAttributes()
     attr2.setLabel('Edge2')
-    g2.setEdgeAttribute(edge2, attr2)
+    g2.setEdgeAttributes(edge2, attr2)
 
     // Connect g1 and g2
     const connected = g1.connect(g2)
@@ -159,12 +159,12 @@ describe('Edge Attributes - Graph Operations', () => {
 
     const g1 = vertex(nw1).connect(vertex(nw2))
     const attr1 = new DefaultEdgeAttributes(new EmptyEdgeStyles(), 'Label1')
-    g1.setEdgeAttribute(edge, attr1)
+    g1.setEdgeAttributes(edge, attr1)
 
     // Create g2 with edge nw1 -> nw2, set attribute attr2
     const g2 = vertex(nw1).connect(vertex(nw2))
     const attr2 = new DefaultEdgeAttributes(new HighlightedEdgeStyles())
-    g2.setEdgeAttribute(edge, attr2)
+    g2.setEdgeAttributes(edge, attr2)
 
     const overlaid = g1.overlay(g2)
 

--- a/ts-apps/decision-logic-visualizer/src/tests/alga-edge-attributes.test.ts
+++ b/ts-apps/decision-logic-visualizer/src/tests/alga-edge-attributes.test.ts
@@ -13,8 +13,8 @@ import { NumberWrapper } from './number-wrapper.js'
 describe('Edge Attributes - DefaultEdgeAttributes', () => {
   test('DefaultEdgeAttributes have fallback / default styles and empty label', () => {
     const attrs = new DefaultEdgeAttributes()
-    expect(attrs.getStyles().getStrokeColor()).toBe(
-      '--default-internal-stroke-color'
+    expect(attrs.getStyles().getStyleString()).toBe(
+      new EmptyEdgeStyles().getStyleString()
     )
     expect(attrs.getLabel()).toBe(emptyEdgeLabel)
   })
@@ -39,8 +39,8 @@ describe('Edge Attributes - Setting and Getting', () => {
     // Get the attributes
     const retrievedAttrs = g.getAttributesForEdge(edge)
     expect(retrievedAttrs.getLabel()).toBe('Test Edge')
-    expect(retrievedAttrs.getStyles().getStrokeColor()).toBe(
-      new HighlightedEdgeStyles().getStrokeColor()
+    expect(retrievedAttrs.getStyles().getStyleString()).toBe(
+      new HighlightedEdgeStyles().getStyleString()
     )
   })
 
@@ -72,8 +72,8 @@ describe('Edge Attributes - Merging', () => {
     const mergedAttrs = attrs1.merge(attrs2)
 
     expect(mergedAttrs.getLabel()).toBe('Label2')
-    expect(mergedAttrs.getStyles().getStrokeColor()).toBe(
-      styles2.getStrokeColor()
+    expect(mergedAttrs.getStyles().getStyleString()).toBe(
+      styles2.getStyleString()
     )
   })
 
@@ -87,8 +87,8 @@ describe('Edge Attributes - Merging', () => {
     const mergedAttrs = attrs1.merge(attrs2)
 
     expect(mergedAttrs.getLabel()).toBe('Label2')
-    expect(mergedAttrs.getStyles().getStrokeColor()).toBe(
-      styles2.getStrokeColor()
+    expect(mergedAttrs.getStyles().getStyleString()).toBe(
+      styles2.getStyleString()
     )
   })
 })
@@ -117,8 +117,8 @@ describe('Edge Attributes - Graph Operations', () => {
     // Get edge attributes from overlaid graph
     const resultAttr = overlaid.getAttributesForEdge(edge)
     expect(resultAttr.getLabel()).toBe('Label2')
-    expect(resultAttr.getStyles().getStrokeColor()).toBe(
-      attr2.getStyles().getStrokeColor()
+    expect(resultAttr.getStyles().getStyleString()).toBe(
+      attr2.getStyles().getStyleString()
     )
   })
 

--- a/ts-apps/decision-logic-visualizer/static/style/themes/default.css
+++ b/ts-apps/decision-logic-visualizer/static/style/themes/default.css
@@ -1,13 +1,24 @@
 :root {
+  /***************************************
+             Colors
+  ****************************************/
+
   --color-node-text: #00004d;
   --color-primary: #001188;
   --color-secondary: #2563eb;
   --color-button: #c7d2fe;
   --color-button-hover: #a5b4fc;
 
+  /***************************************
+          Border radius
+  ****************************************/
+
   --theme-border-radius: 5px;
 
-  /* TODO: Need to check the colors against some color palette generator */
+  /***************************************
+        Highlighted vs normal paths 
+  ****************************************/
+
   /* Stroke width */
   --default-stroke-width: 1px;
   --highlighted-stroke-width: calc(var(--default-stroke-width) + 2px);
@@ -17,7 +28,15 @@
   --color-highlighted-path-in-flow: var(--color-sky-600);
   /* TODO: Should check the colors against some color palette generator */
 
+  /***************************************
+      Compatible vs incompatible paths 
+  ****************************************/
+
   --color-incompatible-path: var(--color-zinc-300);
+
+  /***************************************
+         BoolValue: True vs False 
+  ****************************************/
 
   --color-true-value: var(--color-lime-200);
   --color-false-value: var(--color-rose-200);

--- a/ts-apps/decision-logic-visualizer/static/style/themes/default.css
+++ b/ts-apps/decision-logic-visualizer/static/style/themes/default.css
@@ -8,7 +8,8 @@
   --theme-border-radius: 5px;
 
   /* TODO: Need to check the colors against some color palette generator */
-  --color-highlighted-path-in-flow: #047857;
+  --color-highlighted-path-in-flow: oklch(0.828 0.111 230.318);
+  /* Tailwind sky 300 */
 
   --color-incompatible-path: oklch(0.871 0.006 286.286);
   /* Tailwind zinc 300 */

--- a/ts-apps/decision-logic-visualizer/static/style/themes/default.css
+++ b/ts-apps/decision-logic-visualizer/static/style/themes/default.css
@@ -21,6 +21,7 @@
 
   /* Stroke width */
   --default-stroke-width: 1px;
+  /* TODO: Think about whether the default should be 2px */
   --highlighted-stroke-width: calc(var(--default-stroke-width) + 2px);
 
   /* Stroke color */

--- a/ts-apps/decision-logic-visualizer/static/style/themes/default.css
+++ b/ts-apps/decision-logic-visualizer/static/style/themes/default.css
@@ -8,7 +8,14 @@
   --theme-border-radius: 5px;
 
   /* TODO: Need to check the colors against some color palette generator */
+  /* Stroke width */
+  --default-stroke-width: 1px;
+  --highlighted-stroke-width: calc(var(--default-stroke-width) + 2px);
+
+  /* Stroke color */
+  --default-stroke-color: var(--color-primary);
   --color-highlighted-path-in-flow: var(--color-sky-600);
+  /* TODO: Should check the colors against some color palette generator */
 
   --color-incompatible-path: var(--color-zinc-300);
 

--- a/ts-apps/decision-logic-visualizer/static/style/themes/default.css
+++ b/ts-apps/decision-logic-visualizer/static/style/themes/default.css
@@ -8,7 +8,7 @@
   --theme-border-radius: 5px;
 
   /* TODO: Need to check the colors against some color palette generator */
-  --color-highlighted-path-in-flow: var(--color-sky-300);
+  --color-highlighted-path-in-flow: var(--color-sky-600);
 
   --color-incompatible-path: var(--color-zinc-300);
 


### PR DESCRIPTION
<img width="791" alt="image" src="https://github.com/user-attachments/assets/d2c8c592-7cfb-4397-824b-33fd8acf2b0f" />

<img width="790" alt="image" src="https://github.com/user-attachments/assets/beb0a63a-2cb5-476c-9390-ca53c55d3aee" />

<img width="784" alt="image" src="https://github.com/user-attachments/assets/96503215-ded9-40e2-85ae-0469cbe3d564" />

Did not bother highlighting the border of the vertices, since the highlight effect seems clear enough


Tasks:

- [x] Improve edge attrs internal code
- [x] Improve the paths list CSS code (e.g. prob remove all the flex stuff) and code structure somewhat (though more remains to be done here)
- [x] add a 'List paths' button and tuck paths list in a collapsible panel
- [x] do fit view on flow whenever the panel expands or collapses
- [x] Horizontally center the paths in the paths list
- [x] Improve the aesthetics / edge styles of the highlight effect
- [x] Factor paths list container out into another component

For next time:
- Refactor the synchronization of the fit view with the onopenchange to not use a setTimeOut
- factor collapsible out into its own componetn, as suggested by bits ui docs
- improve the styling of the paths list and the list paths button
- the default linearization / pretty printing of the paths in the paths list will be improved (will add 'and', 'or' etc) when I add edge labels
- Might want to make the list paths button smaller
- Might want to make font size for the paths smaller