### PR TITLE
Fix deployment issue with PR #226

### DIFF
--- a/ts-apps/jl4-web/src/error.html
+++ b/ts-apps/jl4-web/src/error.html
@@ -1,3 +1,0 @@
-<h1>Unknown Error</h1>
-<p>Code %sveltekit.status%</p>
-<p>%sveltekit.error.message%</p>

--- a/ts-apps/jl4-web/svelte.config.js
+++ b/ts-apps/jl4-web/svelte.config.js
@@ -13,7 +13,7 @@ const config = {
       // these options are set automatically — see below
       pages: "build",
       assets: "build",
-      fallback: "./src/error.html",
+      fallback: "index.html",
       precompress: false,
       strict: true,
     }),


### PR DESCRIPTION
Turns out that to produce the index.html (when set to no-ssr), I have to set `fallback` in sveltekit config to `index.html` and remove the previous fallback html page. The SvelteKit docs weren't super clear on this.

(btw I might be doing something wrong git-wise; let me know if so!)