### PR TITLE
Viz, Monaco, Webview: Make the updating of the FunDeclLirNode in response to cmd execution simpler and more robust. Do more to clean up resources and facilitate garbage collection.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14326,6 +14326,7 @@
         "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@^14.0.4",
         "monaco-editor-wrapper": "^6.4.0",
         "monaco-languageclient": "^9.4.0",
+        "runed": "^0.23.3",
         "vscode": "npm:@codingame/monaco-vscode-extension-api@^14.0.4",
         "vscode-languageclient": "^9.0.1",
         "vscode-ws-jsonrpc": "^3.4.0"
@@ -14455,6 +14456,7 @@
         "effect": "^3.11.0",
         "esbuild": "^0.24.2",
         "lodash": "^4.17.21",
+        "runed": "^0.23.3",
         "ts-pattern": "^5.6.2",
         "vscode-messenger": "^0.5.1",
         "vscode-messenger-webview": "^0.5.1"

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
@@ -92,6 +92,11 @@ export class DirectedAMGraph<A extends Ord<A>>
   _getEdgeAttributesMap() {
     return this.edgeAttributes
   }
+
+  dispose() {
+    super.dispose() // Clears the adj map
+    this.edgeAttributes.clear()
+  }
 }
 
 /*********************
@@ -154,6 +159,11 @@ export class Overlay<A extends Ord<A>> extends DirectedAMGraph<A> {
     const { adjMap, edgeAttrs } = mergeDirectedGraphs(left, right)
     super(adjMap, edgeAttrs)
   }
+
+  dispose() {
+    this.left.dispose()
+    this.right.dispose()
+  }
 }
 
 export class Connect<A extends Ord<A>> extends DirectedAMGraph<A> {
@@ -167,6 +177,11 @@ export class Connect<A extends Ord<A>> extends DirectedAMGraph<A> {
       to._getEdgeAttributesMap()
     )
     super(adjMap, edgeAttributes)
+  }
+
+  dispose() {
+    this.from.dispose()
+    this.to.dispose()
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/base-adjacency-map.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/base-adjacency-map.ts
@@ -84,4 +84,8 @@ export abstract class BaseAMGraph<A extends Ord<A>> {
     if (edges.length === 0) return `vertices [${vertices.join(', ')}]`
     return `edges [${edges.join(', ')}]`
   }
+
+  dispose() {
+    this.adjacencyMap.clear()
+  }
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
@@ -11,7 +11,7 @@ import { topologicalSort } from 'graphology-dag'
 import { match, P } from 'ts-pattern'
 
 /*
-TODO: There is currently a fair bit of code duplication 
+TODO: There is currently a fair bit of code duplication
 between the various kinds of alga graphs in this mini-lib
 (eg between this and adjacency-map-directed-graph.ts).
 Would be good to improve that.
@@ -96,8 +96,6 @@ export abstract class Dag<A extends Ord<A>>
     return pathsFromNeighbors.map((path) => [vertex, ...path])
   }
 
-  // TODO: The ret type should be Dag[], so tt
-  // it's easier to preserve metadata associated with the edges
   getAllPaths() {
     const source = this.getSource()
     const barePaths: Array<Array<A>> = match(source)

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -46,7 +46,18 @@
        Lir
   *************************/
 
-  const { context, node: declLirNode }: BaseLadderFlowDisplayerProps = $props()
+  const { context, node }: BaseLadderFlowDisplayerProps = $props()
+
+  /** `node` is reactive (because props are implicitly reactive),
+   * but `declLirNode` is not.
+   * So, if you want to render a new declLirNode,
+   * you'll need to destroy and re-mount the LadderFlow displayer.
+   *
+   * We could also work with the reactive `node` and update the sf graph
+   * whenever `node` changes --- I'm not sure offhand which is better.
+   * This was just the simpler route given what I already have.
+   */
+  const declLirNode = node
   const lir = getLirRegistryFromSvelteContext()
 
   /***********************************
@@ -117,6 +128,7 @@
 
     // Clean up when component is destroyed
     return () => {
+      declLirNode.dispose(context)
       unsub.unsubscribe()
     }
   })
@@ -252,10 +264,10 @@
   }
 </script>
 
-<!-- 
+<!--
 Misc SF UI TODOs:
 
-* Make it clearer that the bool var nodes are clickable 
+* Make it clearer that the bool var nodes are clickable
 (should at least change the cursor to a pointer on mouseover)
 -->
 

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -126,7 +126,24 @@
 
     const unsub = lir.subscribe(onLadderGraphNonPositionalChange)
 
-    // Clean up when component is destroyed
+    /** Clean up when component is destroyed.
+     *
+     * Why is this necessary? One simple reason has to do with the LirNodes and what happens when the visualization command is run.
+     * - For something to be eligible for garbage collection, it must not be reachable from a GC root.
+     * - The visualizer is structured so that there's a LirContext, with a mapping from LirIds to LirNodes,
+     *   that persists through, e.g., changes in the visualization calls from the language server.
+     *   In particular, this mapping from LirIds to LirNodes persists even when the LadderFlow component
+     *   is destroyed and re-created (which is what happens every time the 'visualize L4' LSP command is run).
+     * - So, when destroying a LaddderFlow component,
+     *   if we don't remove references to LirNodes that were used in the component from the LirContext,
+     *   those LirNodes will not be eligible for garbage collection.
+     *   I.e., every time you (e.g.) run the visualize L4 command, you'd be accumulating LirNodes in memory that will never be GC'd.
+     * - (Similar considerations might also apply, mutatis mutandis, to other actions that create LirNodes.)
+     *
+     * For future work: I've checked, via the Chrome memory profiler, that this seems to be making a difference
+     * when it comes to whether certain LirNodes stick around, but I haven't checked this for *every* potential LirNode.
+     * In particular, I might need to do more when it comes to the PathsList and PathLirNodes.
+     */
     return () => {
       declLirNode.dispose(context)
       unsub.unsubscribe()

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -113,8 +113,12 @@
       }
     )
 
-    lir.subscribe(onLadderGraphNonPositionalChange)
-    // TODO: Clean up subscribers --- add an onDestroy in core.ts
+    const unsub = lir.subscribe(onLadderGraphNonPositionalChange)
+
+    // Clean up when component is destroyed
+    return () => {
+      unsub.unsubscribe()
+    }
   })
 
   /*************************************

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte'
   import { type PathListDisplayerProps } from './types.svelte.js'
 
   /************************
@@ -6,6 +7,10 @@
   *************************/
 
   const { context, node }: PathListDisplayerProps = $props()
+
+  onDestroy(() => {
+    node.dispose(context)
+  })
 </script>
 
 <section class="paths-list-content-wrapper">

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
@@ -123,6 +123,8 @@ export interface LirNode {
 
   /** NON-pretty */
   toString(): string
+
+  dispose(context: LirContext): void
 }
 
 export abstract class DefaultLirNode
@@ -147,6 +149,8 @@ export abstract class DefaultLirNode
   }
 
   abstract toString(): string
+
+  abstract dispose(context: LirContext): void
 }
 
 /*********************************************
@@ -174,6 +178,10 @@ export class LirContext {
 
   set(node: LirNode) {
     this.#nodes.set(node.getId(), node)
+  }
+
+  clear(id: LirId) {
+    this.#nodes.delete(id)
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/environment.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/environment.ts
@@ -27,4 +27,9 @@ export class Environment {
   get(unique: Unique): Value | undefined {
     return this.#env[unique]
   }
+
+  dispose() {
+    this.#env = []
+    this.#coreferents = []
+  }
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -78,6 +78,12 @@ export class FunDeclLirNode extends DefaultLirNode implements LirNode {
     return [this.getBody(context)]
   }
 
+  dispose(context: LirContext) {
+    this.getChildren(context).map((n) => n.dispose(context))
+
+    context.clear(this.getId())
+  }
+
   toString(): string {
     return 'FUN_DECL_LIR_NODE'
   }
@@ -101,6 +107,15 @@ export class PathListLirNode extends DefaultLirNode implements LirNode {
 
   getChildren(context: LirContext) {
     return this.getPaths(context)
+  }
+
+  dispose(context: LirContext) {
+    // Dispose members
+    this.getChildren(context).map((n) => n.dispose(context))
+    this.paths = []
+
+    // Dispose self
+    context.clear(this.getId())
   }
 
   toString(): string {
@@ -149,6 +164,11 @@ export class LinPathLirNode extends DefaultLirNode implements LirNode {
       .getVertices()
       .map((id) => context.get(id))
       .filter((n) => !!n) as LadderLirNode[]
+  }
+
+  dispose(context: LirContext) {
+    this.rawPath.dispose()
+    context.clear(this.getId())
   }
 
   toPretty(context: LirContext) {
@@ -221,6 +241,10 @@ abstract class BaseFlowLirNode extends DefaultLirNode implements FlowLirNode {
 
   isEqualTo<T extends LirNode>(other: T) {
     return this.getId().isEqualTo(other.getId())
+  }
+
+  dispose(context: LirContext): void {
+    context.clear(this.getId())
   }
 
   abstract toPretty(context: LirContext): string
@@ -395,6 +419,13 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
 
   toString(): string {
     return 'LADDER_GRAPH_LIR_NODE'
+  }
+
+  dispose(context: LirContext) {
+    this.getVertices(context).map((n) => n.dispose(context))
+    this.#environment.dispose()
+    this.#dag.dispose()
+    context.clear(this.getId())
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -74,13 +74,6 @@ body {
 }
 
 /* TODO: Check if this class really can be used w/o @utility */
-.visualization-container {
-  min-height: 400px;
-  max-width: 96svw;
-  margin: 0 auto;
-}
-
-/* TODO: Check if this class really can be used w/o @utility */
 .button {
   background-color: var(--color-secondary);
   color: transparent;

--- a/ts-apps/jl4-web/package.json
+++ b/ts-apps/jl4-web/package.json
@@ -49,6 +49,7 @@
     "monaco-languageclient": "^9.4.0",
     "vscode": "npm:@codingame/monaco-vscode-extension-api@^14.0.4",
     "vscode-languageclient": "^9.0.1",
-    "vscode-ws-jsonrpc": "^3.4.0"
+    "vscode-ws-jsonrpc": "^3.4.0",
+    "runed": "^0.23.3"
   }
 }

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -288,6 +288,8 @@
   })
 
   onDestroy(() => {
+    // YM: I'm not sure that this is necessary --- just adding it for now because I've seen examples on GitHub that do this.
+    // I'll look into this more in the future.
     if (editor) {
       editor.dispose()
       editor = undefined

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -22,6 +22,7 @@
   import * as monaco from '@codingame/monaco-vscode-editor-api'
   import { debounce } from '$lib/utils'
   import * as Resizable from '$lib/components/ui/resizable/index.js'
+  import { watch } from 'runed'
 
   /***********************************
     Persistent-session-related vars
@@ -54,12 +55,14 @@
   let funName = $derived(
     declLirNode && (declLirNode as DeclLirNode).getFunName(context)
   )
-  // TODO: YM has some ideas for how to improve / clean this up
-  $effect(() => {
-    if (declLirNode) {
-      lirRegistry.setRoot(context, 'VizDecl' as LirRootType, declLirNode)
+  watch(
+    () => declLirNode,
+    () => {
+      if (declLirNode) {
+        lirRegistry.setRoot(context, 'VizDecl' as LirRootType, declLirNode)
+      }
     }
-  })
+  )
 
   /******************************
       VizInfo Payload Decoder

--- a/ts-apps/webview/package.json
+++ b/ts-apps/webview/package.json
@@ -59,6 +59,7 @@
     "lodash": "^4.17.21",
     "ts-pattern": "^5.6.2",
     "vscode-messenger": "^0.5.1",
-    "vscode-messenger-webview": "^0.5.1"
+    "vscode-messenger-webview": "^0.5.1",
+    "runed": "^0.23.3"
   }
 }

--- a/ts-apps/webview/src/routes/+page.svelte
+++ b/ts-apps/webview/src/routes/+page.svelte
@@ -69,9 +69,7 @@
 {#if declLirNode}
   <!-- TODO: Think more about whether to use #key -- which destroys and rebuilds the component --- or have flow-base work with the reactive node prop -->
   {#key declLirNode}
-    <div
-      class="slightly-shorter-than-full-viewport-height"
-    >
+    <div class="slightly-shorter-than-full-viewport-height">
       <LadderFlow {context} node={declLirNode} lir={lirRegistry} />
     </div>
   {/key}

--- a/ts-apps/webview/src/routes/+page.svelte
+++ b/ts-apps/webview/src/routes/+page.svelte
@@ -19,6 +19,7 @@
   import type { WebviewApi } from 'vscode-webview'
   import { Messenger } from 'vscode-messenger-webview'
   import { HOST_EXTENSION } from 'vscode-messenger-common'
+  import { watch } from 'runed'
 
   /**************************
       Set up Lir
@@ -35,11 +36,14 @@
   let funName = $derived(
     declLirNode && (declLirNode as DeclLirNode).getFunName(context)
   )
-  $effect(() => {
-    if (declLirNode) {
-      lirRegistry.setRoot(context, 'VizDecl' as LirRootType, declLirNode)
+  watch(
+    () => declLirNode,
+    () => {
+      if (declLirNode) {
+        lirRegistry.setRoot(context, 'VizDecl' as LirRootType, declLirNode)
+      }
     }
-  })
+  )
 
   /**************************
         VSCode


### PR DESCRIPTION
Problem: the monaco jl4-web can sometimes get sluggish and hog a ton of memory, especially when using the viz. This was making it hard to work on jl4-web.

This PR tries to address that by doing more to clean up resources and facilitate garage collection (there was a lot of low hanging fruit here, since I had made a conscious effort to avoid prematurely working on this kind of optimization). This should be especially helpful when it comes to the visualizer, because I had used a lot of immutable data and done a lot of copying instead of mutating in place.

Along the way, I also made the updating of the FunDeclLirNode in response to cmd execution  in `jl4-web` and `webview` simpler and more robust. That part of the codebase should hopefully also be easier for other people to understand now.