### PR TITLE
Improve type synonym expansion.

### DIFF
--- a/jl4/examples/ok/tests/typesynonms.ep.golden
+++ b/jl4/examples/ok/tests/typesynonms.ep.golden
@@ -25,3 +25,29 @@ odd  MEANS GIVEN x YIELD x MODULO 2 EQUALS 1
 
 GIVETH LL OF A NumPredicate
 example3 MEANS LIST (LIST even, odd)
+
+GIVETH A BOOLEAN
+example4 MEANS even 3
+
+#EVAL example4
+
+DECLARE Transformer a IS A FUNCTION FROM Predicate a TO Predicate a
+DECLARE NumPredicateTransformer IS A Transformer OF NUMBER
+
+negate MEANS
+  GIVEN p YIELD GIVEN x YIELD NOT p x
+
+-- It is still a weakness of the current language that
+-- we do not have full currying and no truly first-class
+-- higher-order functions.
+--
+-- We cannot directly apply negate. We have to introduce
+-- an intermediate name.
+
+GIVETH A NumPredicate
+odd2 MEANS negate even
+
+GIVETH A BOOLEAN
+example5 MEANS odd2 3
+
+#EVAL example5

--- a/jl4/examples/ok/tests/typesynonms.golden
+++ b/jl4/examples/ok/tests/typesynonms.golden
@@ -1,2 +1,8 @@
 Parsing successful
 Typechecking successful
+typesynonms.l4:32:7-15:
+  FALSE
+
+typesynonms.l4:53:7-15:
+  TRUE
+

--- a/jl4/examples/ok/typesynonms.l4
+++ b/jl4/examples/ok/typesynonms.l4
@@ -25,3 +25,29 @@ odd  MEANS GIVEN x YIELD x MODULO 2 EQUALS 1
 
 GIVETH LL OF A NumPredicate
 example3 MEANS LIST (LIST even, odd)
+
+GIVETH A BOOLEAN
+example4 MEANS even 3
+
+#EVAL example4
+
+DECLARE Transformer a IS A FUNCTION FROM Predicate a TO Predicate a
+DECLARE NumPredicateTransformer IS A Transformer OF NUMBER
+
+negate MEANS
+  GIVEN p YIELD GIVEN x YIELD NOT p x
+
+-- It is still a weakness of the current language that
+-- we do not have full currying and no truly first-class
+-- higher-order functions.
+--
+-- We cannot directly apply negate. We have to introduce
+-- an intermediate name.
+
+GIVETH A NumPredicate
+odd2 MEANS negate even
+
+GIVETH A BOOLEAN
+example5 MEANS odd2 3
+
+#EVAL example5

--- a/jl4/src/L4/TypeCheck.hs
+++ b/jl4/src/L4/TypeCheck.hs
@@ -1349,7 +1349,12 @@ matchFunTy  isProjection r t args =
       where
         nonts = length onts
         nargs = length args
-    _ -> do
+    TyApp _ann n ts -> do
+      mt' <- tryExpandTypeSynonym n ts
+      maybe illegalAppError (\ t' -> matchFunTy isProjection r t' args) mt'
+    _ -> illegalAppError
+  where
+    illegalAppError = do
       -- We are trying to apply a non-function.
       addError (IllegalApp r t (length args))
       rargs <- fst . unzip <$> traverse inferExpr args


### PR DESCRIPTION
Fixes #233.

The problem was that type synonym expansion is being done in unify, but for the purposes of generating error messages, we check function applications using a specialised function, in which we did not perform type synonym expansion.