### PR TITLE
Viz: Add explanatory labels / annotations for edges and vertices

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/adjacency-map-directed-graph.ts
@@ -66,6 +66,7 @@ export class DirectedAMGraph<A extends Ord<A>>
 
   // Getting / setting edge attributes
 
+  /** Get a *cloned* EdgeAttributes */
   getAttributesForEdge<T extends Edge<A>>(edge: T): EdgeAttributes {
     const edgeKey = makeEdgeKey(edge)
     const attrs = this.edgeAttributes.get(edgeKey)

--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -13,6 +13,7 @@ import {
   SinkLirNode,
   LadderGraphLirNode,
   anyOfBundlingNodeAnno,
+  augmentEdgesWithExplanatoryLabel,
 } from '../layout-ir/ladder-lir.svelte.js'
 import type { DirectedAcyclicGraph } from '../algebraic-graphs/dag.js'
 /* IMPT: Cannot currently use $lib for the following import,
@@ -46,6 +47,7 @@ export const VizDeclLirSource: LirSource<IRDecl, DeclLirNode> = {
 */
 export const LadderGraphLirSource: LirSource<IRExpr, LadderGraphLirNode> = {
   toLir(nodeInfo: LirNodeInfo, expr: IRExpr): LadderGraphLirNode {
+    // 1. Get structure of the graph
     const overallSource = vertex(new SourceLirNode(nodeInfo).getId())
     const overallSink = vertex(new SinkLirNode(nodeInfo).getId())
 
@@ -56,7 +58,12 @@ export const LadderGraphLirSource: LirSource<IRExpr, LadderGraphLirNode> = {
       .overlay(middle)
       .overlay(middle.getSink().connect(overallSink))
 
-    return new LadderGraphLirNode(nodeInfo, dag)
+    const ladderGraph = new LadderGraphLirNode(nodeInfo, dag)
+
+    // 2. Augment with explanatory edge labels (TODO: Not sure this shld happen here)
+    augmentEdgesWithExplanatoryLabel(nodeInfo.context, ladderGraph)
+
+    return ladderGraph
   },
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -13,7 +13,6 @@ import {
   SinkLirNode,
   LadderGraphLirNode,
   anyOfBundlingNodeAnno,
-  emptyBundlingNodeAnno
 } from '../layout-ir/ladder-lir.svelte.js'
 import type { DirectedAcyclicGraph } from '../algebraic-graphs/dag.js'
 /* IMPT: Cannot currently use $lib for the following import,
@@ -117,7 +116,9 @@ function transform(
     .with({ $type: 'Or' }, (orExpr) => {
       const children = orExpr.args.map((n) => transform(nodeInfo, n))
 
-      const overallSource = vertex(new SourceLirNode(nodeInfo, anyOfBundlingNodeAnno.annotation).getId())
+      const overallSource = vertex(
+        new SourceLirNode(nodeInfo, anyOfBundlingNodeAnno.annotation).getId()
+      )
       const overallSink = vertex(new SinkLirNode(nodeInfo).getId())
 
       const leftEdges = children.map((child) =>

--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -9,10 +9,10 @@ import {
   BoolVarLirNode,
   NotStartLirNode,
   NotEndLirNode,
-  SourceLirNode,
+  SourceNoAnnoLirNode,
+  SourceWithOrAnnoLirNode,
   SinkLirNode,
   LadderGraphLirNode,
-  anyOfBundlingNodeAnno,
   augmentEdgesWithExplanatoryLabel,
 } from '../layout-ir/ladder-lir.svelte.js'
 import type { DirectedAcyclicGraph } from '../algebraic-graphs/dag.js'
@@ -48,7 +48,7 @@ export const VizDeclLirSource: LirSource<IRDecl, DeclLirNode> = {
 export const LadderGraphLirSource: LirSource<IRExpr, LadderGraphLirNode> = {
   toLir(nodeInfo: LirNodeInfo, expr: IRExpr): LadderGraphLirNode {
     // 1. Get structure of the graph
-    const overallSource = vertex(new SourceLirNode(nodeInfo).getId())
+    const overallSource = vertex(new SourceNoAnnoLirNode(nodeInfo).getId())
     const overallSink = vertex(new SinkLirNode(nodeInfo).getId())
 
     const middle = transform(nodeInfo, expr)
@@ -124,7 +124,10 @@ function transform(
       const children = orExpr.args.map((n) => transform(nodeInfo, n))
 
       const overallSource = vertex(
-        new SourceLirNode(nodeInfo, anyOfBundlingNodeAnno.annotation).getId()
+        new SourceWithOrAnnoLirNode(
+          nodeInfo,
+          nodeInfo.context.getOrBundlingNodeLabel()
+        ).getId()
       )
       const overallSink = vertex(new SinkLirNode(nodeInfo).getId())
 

--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -12,6 +12,8 @@ import {
   SourceLirNode,
   SinkLirNode,
   LadderGraphLirNode,
+  anyOfBundlingNodeAnno,
+  emptyBundlingNodeAnno
 } from '../layout-ir/ladder-lir.svelte.js'
 import type { DirectedAcyclicGraph } from '../algebraic-graphs/dag.js'
 /* IMPT: Cannot currently use $lib for the following import,
@@ -115,7 +117,7 @@ function transform(
     .with({ $type: 'Or' }, (orExpr) => {
       const children = orExpr.args.map((n) => transform(nodeInfo, n))
 
-      const overallSource = vertex(new SourceLirNode(nodeInfo).getId())
+      const overallSource = vertex(new SourceLirNode(nodeInfo, anyOfBundlingNodeAnno.annotation).getId())
       const overallSink = vertex(new SinkLirNode(nodeInfo).getId())
 
       const leftEdges = children.map((child) =>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -330,10 +330,7 @@ Misc SF UI TODOs:
     <!-- TODO: Make a standalone wrapper over the collapsible component, as suggested by https://bits-ui.com/docs/components/collapsible  -->
     <Collapsible.Root
       onOpenChange={() => {
-        // Need the timeout to synchronize the fit view properly (probably because we use window.requestAnimationFrame in doFitView?)
-        setTimeout(() => {
-          doFitView()
-        }, 10)
+        window.requestAnimationFrame(doFitView)
       }}
     >
       <Collapsible.Trigger class="flex items-center justify-end w-full gap-2">

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -328,11 +328,8 @@ Misc SF UI TODOs:
   <!-- TODO: Move the following into a lin paths container component -->
   <div class="paths-container">
     <!-- TODO: Make a standalone wrapper over the collapsible component, as suggested by https://bits-ui.com/docs/components/collapsible  -->
-    <Collapsible.Root
-      onOpenChange={() => {
-        window.requestAnimationFrame(doFitView)
-      }}
-    >
+    <!-- Using setTimeout instead of window requestAnimationFrame because it can take time to generate the paths list the first time round -->
+    <Collapsible.Root onOpenChange={() => setTimeout(doFitView, 10)}>
       <Collapsible.Trigger class="flex items-center justify-end w-full gap-2">
         <!-- TODO: Improve the button styles -->
         <button

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -14,6 +14,7 @@
     SvelteFlow,
     Background,
     Controls,
+    ControlButton,
     ConnectionLineType,
     useNodesInitialized,
     useSvelteFlow,
@@ -314,7 +315,12 @@ Misc SF UI TODOs:
       onnodedragstop={onNodeDragStop}
     >
       <!-- disabling show lock because it didn't seem to do anything for me --- might need to adjust some other setting too -->
-      <Controls position="bottom-right" showLock={false} />
+      <Controls position="bottom-right" showLock={false}>
+        <ControlButton onclick={() => ladderGraph.toggleZenModeStatus(context)}>
+          <!-- TODO: Make our own menu to get more real estate and use a Switch component -->
+          <div class="text-[0.7rem]">Zen</div>
+        </ControlButton>
+      </Controls>
       <Background />
     </SvelteFlow>
   </div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -318,7 +318,7 @@ Misc SF UI TODOs:
       <Controls position="bottom-right" showLock={false}>
         <ControlButton onclick={() => ladderGraph.toggleZenModeStatus(context)}>
           <!-- TODO: Make our own menu to get more real estate and use a Switch component -->
-          <div class="text-[0.7rem]">Zen</div>
+          <div class="text-[0.7rem] p-1">Zen</div>
         </ControlButton>
       </Controls>
       <Background />

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
@@ -115,18 +115,18 @@ export function ladderLirNodeToSfNode(
         data: defaultData,
       }
     })
-    .with(P.instanceOf(SourceLirNode), () => {
+    .with(P.instanceOf(SourceLirNode), (n: SourceLirNode) => {
       return {
         ...defaults,
         type: sourceNodeType,
-        data: defaultData,
+        data: { ...defaultData, ...n.getData(context) },
       }
     })
-    .with(P.instanceOf(SinkLirNode), () => {
+    .with(P.instanceOf(SinkLirNode), (n: SinkLirNode) => {
       return {
         ...defaults,
         type: sinkNodeType,
-        data: defaultData,
+        data: { ...defaultData, ...n.getData(context) },
       }
     })
     .exhaustive()

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
@@ -7,10 +7,12 @@ import { LadderGraphLirNode } from '$lib/layout-ir/ladder-lir.svelte.js'
 /* IMPT: Cannot currently use $lib for the following import,
 because of how the functions were defined */
 import {
+  type SourceLirNode,
+  isBoolVarLirNode,
   BoolVarLirNode,
   NotStartLirNode,
   NotEndLirNode,
-  SourceLirNode,
+  isSourceLirNode,
   SinkLirNode,
 } from '$lib/layout-ir/ladder-lir.svelte.js'
 import {
@@ -94,7 +96,7 @@ export function ladderLirNodeToSfNode(
   }
 
   return match(node)
-    .with(P.instanceOf(BoolVarLirNode), (n: BoolVarLirNode) => {
+    .with(P.when(isBoolVarLirNode), (n: BoolVarLirNode) => {
       return {
         ...defaults,
         type: boolVarNodeType,
@@ -115,7 +117,7 @@ export function ladderLirNodeToSfNode(
         data: defaultData,
       }
     })
-    .with(P.instanceOf(SourceLirNode), (n: SourceLirNode) => {
+    .with(P.when(isSourceLirNode), (n: SourceLirNode) => {
       return {
         ...defaults,
         type: sourceNodeType,

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
@@ -2,17 +2,21 @@ import type { LirContext, LirId } from '$lib/layout-ir/core.js'
 import type {
   LadderLirNode,
   LadderLirEdge,
+  SourceNoAnnoLirNode,
+  SourceWithOrAnnoLirNode,
 } from '$lib/layout-ir/ladder-lir.svelte.js'
-import { LadderGraphLirNode } from '$lib/layout-ir/ladder-lir.svelte.js'
+import {
+  isSourceNoAnnoLirNode,
+  isSourceWithOrAnnoLirNode,
+  LadderGraphLirNode,
+} from '$lib/layout-ir/ladder-lir.svelte.js'
 /* IMPT: Cannot currently use $lib for the following import,
 because of how the functions were defined */
 import {
-  type SourceLirNode,
   isBoolVarLirNode,
   BoolVarLirNode,
   NotStartLirNode,
   NotEndLirNode,
-  isSourceLirNode,
   SinkLirNode,
 } from '$lib/layout-ir/ladder-lir.svelte.js'
 import {
@@ -21,7 +25,8 @@ import {
   boolVarNodeType,
   notStartNodeType,
   notEndNodeType,
-  sourceNodeType,
+  sourceNoAnnoNodeType,
+  sourceWithOrAnnoNodeType,
   sinkNodeType,
   ladderEdgeType,
 } from './svelteflow-types.js'
@@ -117,10 +122,17 @@ export function ladderLirNodeToSfNode(
         data: defaultData,
       }
     })
-    .with(P.when(isSourceLirNode), (n: SourceLirNode) => {
+    .with(P.when(isSourceNoAnnoLirNode), (n: SourceNoAnnoLirNode) => {
       return {
         ...defaults,
-        type: sourceNodeType,
+        type: sourceNoAnnoNodeType,
+        data: { ...defaultData, ...n.getData() },
+      }
+    })
+    .with(P.when(isSourceWithOrAnnoLirNode), (n: SourceWithOrAnnoLirNode) => {
+      return {
+        ...defaults,
+        type: sourceWithOrAnnoNodeType,
         data: { ...defaultData, ...n.getData() },
       }
     })

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/ladder-lir-to-sf.ts
@@ -119,14 +119,14 @@ export function ladderLirNodeToSfNode(
       return {
         ...defaults,
         type: sourceNodeType,
-        data: { ...defaultData, ...n.getData(context) },
+        data: { ...defaultData, ...n.getData() },
       }
     })
     .with(P.instanceOf(SinkLirNode), (n: SinkLirNode) => {
       return {
         ...defaults,
         type: sinkNodeType,
-        data: { ...defaultData, ...n.getData(context) },
+        data: { ...defaultData, ...n.getData() },
       }
     })
     .exhaustive()
@@ -147,6 +147,7 @@ export function ladderLirEdgeToSfEdge(
     id: edge.getId(),
     type: ladderEdgeType,
     data: {
+      context,
       label,
       edgeStyles: graph.getEdgeStyles(context, edge).getStyleString(),
     },

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/layout.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/layout.ts
@@ -2,7 +2,7 @@ import dagre from '@dagrejs/dagre'
 import type { Edge } from '@xyflow/svelte'
 import { Position } from '@xyflow/svelte'
 import {
-  isSFGroupingNode,
+  isSFBundlingNode,
   type LadderSFNodeWithDims,
 } from './svelteflow-types.js'
 
@@ -70,7 +70,7 @@ export function getLayoutedElements(
       // TODO: Clean up code below
       // Shift the dagre node position (anchor=center center) for NON-grouping nodes to the top left
       // so it matches the React Flow node anchor point (top left).
-      position: isSFGroupingNode(node)
+      position: isSFBundlingNode(node)
         ? {
             x: nodeWithPosition.x,
             y: nodeWithPosition.y,

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
@@ -4,7 +4,6 @@
     // EdgeLabel,
   } from '@xyflow/svelte'
   import type { LadderEdgeProps } from '../svelteflow-types.js'
-  import { defaultLadderEdgeAttrs } from '../svelteflow-types.js'
 
   let {
     sourceX,
@@ -13,7 +12,7 @@
     targetX,
     targetY,
     targetPosition,
-    data = defaultLadderEdgeAttrs,
+    data,
   }: LadderEdgeProps = $props()
 </script>
 
@@ -24,7 +23,9 @@
   {targetX}
   {targetY}
   {targetPosition}
-  label={data.label}
+  label={data.context.getVizConfig().displayExplanatoryAnnotations
+    ? data.label.toUpperCase()
+    : undefined}
   pathOptions={{ curvature: 1 }}
   style={data.edgeStyles}
 />

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
@@ -23,9 +23,7 @@
   {targetX}
   {targetY}
   {targetPosition}
-  label={data?.context.getVizConfig().displayExplanatoryAnnotations
-    ? data.label
-    : undefined}
+  label={data?.context.shouldEnableZenMode() ? undefined : data?.label}
   pathOptions={{ curvature: 1 }}
   style={data?.edgeStyles}
 />

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-edges/ladder-edge.svelte
@@ -23,11 +23,11 @@
   {targetX}
   {targetY}
   {targetPosition}
-  label={data.context.getVizConfig().displayExplanatoryAnnotations
-    ? data.label.toUpperCase()
+  label={data?.context.getVizConfig().displayExplanatoryAnnotations
+    ? data.label
     : undefined}
   pathOptions={{ curvature: 1 }}
-  style={data.edgeStyles}
+  style={data?.edgeStyles}
 />
 
 <!-- 

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-sink.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-sink.svelte
@@ -17,7 +17,11 @@ TODO: reduce code duplication between this and SourceSFNode
     style="opacity:0;"
     position={defaultSFHandlesInfo.sourcePosition}
   />
-  <div class="node-annotation">{data.annotation}</div>
+  <div class="node-annotation">
+    {data.context.getVizConfig().displayExplanatoryAnnotations
+      ? data.annotation
+      : ''}
+  </div>
   <!-- The bit of text is there to improve the layouting -->
   <div style="opacity:0">-</div>
   <Handle

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-sink.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-sink.svelte
@@ -17,7 +17,7 @@ TODO: reduce code duplication between this and SourceSFNode
     style="opacity:0;"
     position={defaultSFHandlesInfo.sourcePosition}
   />
-  {#if data.context.getVizConfig().displayExplanatoryAnnotations}
+  {#if !data.context.shouldEnableZenMode()}
     <div class="node-annotation">
       {data.annotation}
     </div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-sink.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-sink.svelte
@@ -1,17 +1,28 @@
 <!--
-TODO: maybe reduce code duplication between this and SourceSFNode
+TODO: reduce code duplication between this and SourceSFNode
 -->
 <script lang="ts">
   import { Handle } from '@xyflow/svelte'
-  import type { NodeProps, Node } from '@xyflow/svelte'
-  import { defaultSFHandlesInfo } from '../svelteflow-types.js'
-  // eslint-disable-next-line no-empty-pattern
-  let {}: NodeProps<Node> = $props()
+  import {
+    type BundlingNodeDisplayerProps,
+    defaultSFHandlesInfo,
+  } from '../svelteflow-types.js'
+
+  let { data }: BundlingNodeDisplayerProps = $props()
 </script>
 
-<div class="grouping-node">
-  <Handle type="source" position={defaultSFHandlesInfo.sourcePosition} />
+<div class="bundling-node relative">
+  <Handle
+    type="source"
+    style="opacity:0;"
+    position={defaultSFHandlesInfo.sourcePosition}
+  />
+  <div class="node-annotation">{data.annotation}</div>
   <!-- The bit of text is there to improve the layouting -->
   <div style="opacity:0">-</div>
-  <Handle type="target" position={defaultSFHandlesInfo.targetPosition} />
+  <Handle
+    type="target"
+    style="opacity:0.3;"
+    position={defaultSFHandlesInfo.targetPosition}
+  />
 </div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-sink.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-sink.svelte
@@ -17,11 +17,11 @@ TODO: reduce code duplication between this and SourceSFNode
     style="opacity:0;"
     position={defaultSFHandlesInfo.sourcePosition}
   />
-  <div class="node-annotation">
-    {data.context.getVizConfig().displayExplanatoryAnnotations
-      ? data.annotation
-      : ''}
-  </div>
+  {#if data.context.getVizConfig().displayExplanatoryAnnotations}
+    <div class="node-annotation">
+      {data.annotation}
+    </div>
+  {/if}
   <!-- The bit of text is there to improve the layouting -->
   <div style="opacity:0">-</div>
   <Handle

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-source.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-source.svelte
@@ -15,9 +15,11 @@
     position={defaultSFHandlesInfo.sourcePosition}
   />
   <div class="node-annotation">
-    {data.context.getVizConfig().displayExplanatoryAnnotations
-      ? data.annotation
-      : ''}
+    {#if !data.context.shouldEnableZenMode()}
+      <div class="node-annotation">
+        {data.annotation}
+      </div>
+    {/if}
   </div>
   <!-- The bit of text is there to improve the layouting -->
   <div style="opacity:0;">-</div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-source.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-source.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
   import { Handle } from '@xyflow/svelte'
   import type { NodeProps, Node } from '@xyflow/svelte'
-  import { defaultSFHandlesInfo } from '../svelteflow-types.js'
-  // eslint-disable-next-line no-empty-pattern
-  let {}: NodeProps<Node> = $props()
+  import {
+    type BundlingNodeDisplayerProps,
+    defaultSFHandlesInfo,
+  } from '../svelteflow-types.js'
+
+  let { data }: BundlingNodeDisplayerProps = $props()
 </script>
 
-<div class="grouping-node">
-  <Handle type="source" position={defaultSFHandlesInfo.sourcePosition} />
+<div class="bundling-node relative">
+  <Handle
+    type="source"
+    style="opacity:0;"
+    position={defaultSFHandlesInfo.sourcePosition}
+  />
+  <div class="node-annotation">{data.annotation}</div>
   <!-- The bit of text is there to improve the layouting -->
   <div style="opacity:0;">-</div>
-  <Handle type="target" position={defaultSFHandlesInfo.targetPosition} />
+  <Handle
+    type="target"
+    style="opacity:0.3;"
+    position={defaultSFHandlesInfo.targetPosition}
+  />
 </div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-source.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bundling-source.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Handle } from '@xyflow/svelte'
-  import type { NodeProps, Node } from '@xyflow/svelte'
   import {
     type BundlingNodeDisplayerProps,
     defaultSFHandlesInfo,
@@ -15,7 +14,11 @@
     style="opacity:0;"
     position={defaultSFHandlesInfo.sourcePosition}
   />
-  <div class="node-annotation">{data.annotation}</div>
+  <div class="node-annotation">
+    {data.context.getVizConfig().displayExplanatoryAnnotations
+      ? data.annotation
+      : ''}
+  </div>
   <!-- The bit of text is there to improve the layouting -->
   <div style="opacity:0;">-</div>
   <Handle

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
@@ -116,18 +116,20 @@ export const sfNodeTypes: SF.NodeTypes = {
 }
 
 /************************************************
-          Stuff for SF Node data
+        SF Node data, displayer props
 *************************************************/
 
-export interface SFHandlesInfo {
-  sourcePosition: SF.Position
-  targetPosition: SF.Position
+// Displayer props
+
+export interface BoolVarDisplayerProps {
+  data: BoolVarDisplayerData
 }
 
-export const defaultSFHandlesInfo: SFHandlesInfo = {
-  sourcePosition: SF.Position.Right,
-  targetPosition: SF.Position.Left,
+export interface BundlingNodeDisplayerProps {
+  data: BundlingNodeDisplayerData
 }
+
+// Node data
 
 // TODO: Not sure we need this after all
 export interface LadderSFNodeData {
@@ -140,8 +142,24 @@ export interface BoolVarDisplayerData extends LadderSFNodeData {
   value: BoolVal
 }
 
-export interface BoolVarDisplayerProps {
-  data: BoolVarDisplayerData
+export interface BundlingNodeDisplayerData extends LadderSFNodeData {
+  /** Currently used for the explanatory labels */
+  annotation: string
+}
+
+/************************************************
+        SF Node handles
+*************************************************/
+
+export interface SFHandlesInfo {
+  sourcePosition: SF.Position
+  targetPosition: SF.Position
+}
+
+// TODO: Improve how this is used -- took a shortcut here
+export const defaultSFHandlesInfo: SFHandlesInfo = {
+  sourcePosition: SF.Position.Right,
+  targetPosition: SF.Position.Left,
 }
 
 /************************************************

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
@@ -78,7 +78,8 @@ export interface Dimensions {
 export const boolVarNodeType = 'boolVarNode' as const
 export const notStartNodeType = 'notStartNode' as const
 export const notEndNodeType = 'notEndNode' as const
-export const sourceNodeType = 'sourceNode' as const
+export const sourceNoAnnoNodeType = 'sourceNoAnnoNode' as const
+export const sourceWithOrAnnoNodeType = 'sourceWithOrAnnoNode' as const
 export const sinkNodeType = 'sinkNode' as const
 
 export type SFNode<T extends string> = SF.Node & { type: T }
@@ -90,17 +91,18 @@ export const isBoolVarSFNode = (
   node: SF.Node
 ): node is SFNode<typeof boolVarNodeType> => isSFNode(node, boolVarNodeType)
 
-export type SFSourceNode = SFNode<typeof sourceNodeType>
+export type SFSourceNoAnnoNode = SFNode<typeof sourceNoAnnoNodeType>
 export type SFSinkNode = SFNode<typeof sinkNodeType>
 
-export const isSFSourceNode = (node: SF.Node): node is SFSourceNode =>
-  isSFNode(node, sourceNodeType)
+export const isSFSourceNoAnnoNode = (
+  node: SF.Node
+): node is SFSourceNoAnnoNode => isSFNode(node, sourceNoAnnoNodeType)
 export const isSFSinkNode = (node: SF.Node): node is SFSinkNode =>
   isSFNode(node, sinkNodeType)
 export const isSFBundlingNode = (
   node: SF.Node
-): node is SFSourceNode | SFSinkNode =>
-  isSFSourceNode(node) || isSFSinkNode(node)
+): node is SFSourceNoAnnoNode | SFSinkNode =>
+  isSFSourceNoAnnoNode(node) || isSFSinkNode(node)
 
 /************************************************
            Custom node type map
@@ -111,7 +113,8 @@ export const sfNodeTypes: SF.NodeTypes = {
   boolVarNode: BoolVarSFNode,
   notStartNode: NotStartSFNode,
   notEndNode: NotEndSFNode,
-  sourceNode: SourceSFNode,
+  sourceNoAnnoNode: SourceSFNode,
+  sourceWithOrAnnoNode: SourceSFNode,
   sinkNode: SinkSFNode,
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
@@ -199,5 +199,5 @@ export interface LadderEdgeData extends LadderEdgeAttrs {
 }
 
 export interface LadderEdgeProps extends SF.EdgeProps {
-  data: LadderEdgeData
+  data?: LadderEdgeData
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
@@ -194,6 +194,10 @@ export const defaultLadderEdgeAttrs = {
   edgeStyles: new EmptyEdgeStyles().getStyleString(),
 }
 
+export interface LadderEdgeData extends LadderEdgeAttrs {
+  context: LirContext
+}
+
 export interface LadderEdgeProps extends SF.EdgeProps {
-  data?: LadderEdgeAttrs
+  data: LadderEdgeData
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
@@ -199,5 +199,9 @@ export interface LadderEdgeData extends LadderEdgeAttrs {
 }
 
 export interface LadderEdgeProps extends SF.EdgeProps {
+  /** `data` has to be optional because of current SF limitations.
+   * But I've been told by a SF developer that this will be improved in the future
+   * (i.e., we should be able to specify that it's non-optional in the future)
+   */
   data?: LadderEdgeData
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
@@ -97,7 +97,7 @@ export const isSFSourceNode = (node: SF.Node): node is SFSourceNode =>
   isSFNode(node, sourceNodeType)
 export const isSFSinkNode = (node: SF.Node): node is SFSinkNode =>
   isSFNode(node, sinkNodeType)
-export const isSFGroupingNode = (
+export const isSFBundlingNode = (
   node: SF.Node
 ): node is SFSourceNode | SFSinkNode =>
   isSFSourceNode(node) || isSFSinkNode(node)

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
@@ -158,10 +158,19 @@ export abstract class DefaultLirNode
 ***********************************************/
 
 export interface VizConfig {
+  constants: {
+    readonly EXPLANATORY_AND_EDGE_LABEL: string
+    readonly OR_BUNDLING_NODE_LABEL: string
+  }
   shouldEnableZenMode: boolean
 }
 
 const defaultVizConfig: VizConfig = {
+  constants: {
+    EXPLANATORY_AND_EDGE_LABEL: 'AND',
+    /** aka anyOfBundlingNodeAnno.annotation */
+    OR_BUNDLING_NODE_LABEL: 'ANY OF',
+  },
   shouldEnableZenMode: false,
 }
 
@@ -196,7 +205,11 @@ export class LirContext {
     this.#nodes.delete(id)
   }
 
-  /* Viz Config */
+  /***************
+     Viz Config 
+  ****************/
+
+  // Zen mode
 
   shouldEnableZenMode() {
     return this.config.shouldEnableZenMode
@@ -208,6 +221,18 @@ export class LirContext {
 
   disableZenMode() {
     this.config.shouldEnableZenMode = false
+  }
+
+  // Constants
+  // (The rough thought for now is, if we want to change these,
+  // we'd make and pass in a different Context. But not sure.)
+
+  getExplanatoryAndEdgeLabel() {
+    return this.config.constants.EXPLANATORY_AND_EDGE_LABEL
+  }
+
+  getOrBundlingNodeLabel() {
+    return this.config.constants.OR_BUNDLING_NODE_LABEL
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
@@ -154,6 +154,18 @@ export abstract class DefaultLirNode
 }
 
 /*********************************************
+       Viz Config
+***********************************************/
+
+export interface VizConfig {
+  displayExplanatoryAnnotations: boolean
+}
+
+const defaultVizConfig = {
+  displayExplanatoryAnnotations: true,
+} as const
+
+/*********************************************
        LirContext
 ***********************************************/
 
@@ -170,7 +182,7 @@ export class LirContext {
   /** Can contain both FlowLirNodes and non-FlowLirNodes */
   #nodes: Map<LirId, LirNode> = new Map()
 
-  constructor() {}
+  constructor(private config: VizConfig = defaultVizConfig) {}
 
   get(id: LirId) {
     return this.#nodes.get(id)
@@ -182,6 +194,14 @@ export class LirContext {
 
   clear(id: LirId) {
     this.#nodes.delete(id)
+  }
+
+  getVizConfig() {
+    return this.config
+  }
+
+  setVizConfig(newConfig: Partial<VizConfig>) {
+    this.config = { ...this.config, ...newConfig }
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
@@ -158,12 +158,12 @@ export abstract class DefaultLirNode
 ***********************************************/
 
 export interface VizConfig {
-  displayExplanatoryAnnotations: boolean
+  shouldEnableZenMode: boolean
 }
 
-const defaultVizConfig = {
-  displayExplanatoryAnnotations: true,
-} as const
+const defaultVizConfig: VizConfig = {
+  shouldEnableZenMode: false,
+}
 
 /*********************************************
        LirContext
@@ -196,12 +196,18 @@ export class LirContext {
     this.#nodes.delete(id)
   }
 
-  getVizConfig() {
-    return this.config
+  /* Viz Config */
+
+  shouldEnableZenMode() {
+    return this.config.shouldEnableZenMode
   }
 
-  setVizConfig(newConfig: Partial<VizConfig>) {
-    this.config = { ...this.config, ...newConfig }
+  enableZenMode() {
+    this.config.shouldEnableZenMode = true
+  }
+
+  disableZenMode() {
+    this.config.shouldEnableZenMode = false
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -369,9 +369,9 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
     styles: EdgeStyles
   ) {
     const attrs = this.#dag.getAttributesForEdge(edge)
-    const newAttrs = new DefaultEdgeAttributes().merge(attrs)
-    newAttrs.setStyles(styles)
-    this.#dag.setEdgeAttributes(edge, newAttrs)
+    // Ok to mutate because getAttributesForEdge returns a cloned object
+    attrs.setStyles(styles)
+    this.#dag.setEdgeAttributes(edge, attrs)
 
     this.getRegistry().publish(context, this.getId())
   }
@@ -386,9 +386,8 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
     label: string
   ) {
     const attrs = this.#dag.getAttributesForEdge(edge)
-    const newAttrs = new DefaultEdgeAttributes().merge(attrs)
-    newAttrs.setLabel(label)
-    this.#dag.setEdgeAttributes(edge, newAttrs)
+    attrs.setLabel(label)
+    this.#dag.setEdgeAttributes(edge, attrs)
 
     this.getRegistry().publish(context, this.getId())
   }

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -385,7 +385,11 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
     edge: T,
     label: string
   ) {
-    this.#dag.getAttributesForEdge(edge).setLabel(label)
+    const attrs = this.#dag.getAttributesForEdge(edge)
+    const newAttrs = new DefaultEdgeAttributes().merge(attrs)
+    newAttrs.setLabel(label)
+    this.#dag.setEdgeAttributes(edge, newAttrs)
+
     this.getRegistry().publish(context, this.getId())
   }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -12,11 +12,7 @@ import type { LirId, LirNode, LirNodeInfo } from './core.js'
 import { LirContext, DefaultLirNode } from './core.js'
 import type { Ord } from '$lib/utils.js'
 import { ComparisonResult } from '$lib/utils.js'
-import {
-  isEmpty,
-  isVertex,
-  type DirectedAcyclicGraph,
-} from '../algebraic-graphs/dag.js'
+import { isVertex, type DirectedAcyclicGraph } from '../algebraic-graphs/dag.js'
 import {
   type Edge,
   DirectedEdge,

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -22,7 +22,10 @@ import {
   type EdgeAttributes,
   DefaultEdgeAttributes,
 } from '../algebraic-graphs/edge.js'
-import type { Dimensions } from '$lib/displayers/flow/svelteflow-types.js'
+import type {
+  Dimensions,
+  BundlingNodeDisplayerData,
+} from '$lib/displayers/flow/svelteflow-types.js'
 import { match } from 'ts-pattern'
 
 /*
@@ -548,6 +551,13 @@ export class NotEndLirNode extends BaseFlowLirNode implements FlowLirNode {
     Bundling Flow Lir Node
 *******************************/
 
+export type BundlingNodeAnno = Pick<BundlingNodeDisplayerData, 'annotation'>
+
+export const emptyBundlingNodeAnno: BundlingNodeAnno = { annotation: '' }
+export const anyOfBundlingNodeAnno: BundlingNodeAnno = {
+  annotation: 'any of',
+}
+
 export function isBundlingFlowLirNode(
   node: FlowLirNode
 ): node is BundlingFlowLirNode {
@@ -560,12 +570,30 @@ export function isBundlingFlowLirNode(
  */
 export type BundlingFlowLirNode = SourceLirNode | SinkLirNode
 
-export class SourceLirNode extends BaseFlowLirNode implements FlowLirNode {
+abstract class BaseBundlingFlowLirNode extends BaseFlowLirNode {
   constructor(
     nodeInfo: LirNodeInfo,
-    position: Position = DEFAULT_INITIAL_POSITION
+    protected readonly annotation: BundlingNodeDisplayerData['annotation'],
+    position: Position
   ) {
     super(nodeInfo, position)
+  }
+
+  getData(_context: LirContext) {
+    return { annotation: this.annotation }
+  }
+}
+
+export class SourceLirNode
+  extends BaseBundlingFlowLirNode
+  implements FlowLirNode
+{
+  constructor(
+    nodeInfo: LirNodeInfo,
+    annotation: BundlingNodeDisplayerData['annotation'] = emptyBundlingNodeAnno.annotation,
+    position: Position = DEFAULT_INITIAL_POSITION
+  ) {
+    super(nodeInfo, annotation, position)
   }
 
   toPretty() {
@@ -577,12 +605,16 @@ export class SourceLirNode extends BaseFlowLirNode implements FlowLirNode {
   }
 }
 
-export class SinkLirNode extends BaseFlowLirNode implements FlowLirNode {
+export class SinkLirNode
+  extends BaseBundlingFlowLirNode
+  implements FlowLirNode
+{
   constructor(
     nodeInfo: LirNodeInfo,
+    annotation: BundlingNodeDisplayerData['annotation'] = emptyBundlingNodeAnno.annotation,
     position: Position = DEFAULT_INITIAL_POSITION
   ) {
-    super(nodeInfo, position)
+    super(nodeInfo, annotation, position)
   }
 
   toPretty() {

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -611,6 +611,7 @@ export function isSourceLirNode(node: LadderLirNode): node is SourceLirNode {
 abstract class BaseBundlingFlowLirNode extends BaseFlowLirNode {
   constructor(
     nodeInfo: LirNodeInfo,
+    /** TODO: Think about whether to have the param be a `data` plain object / record instead */
     protected readonly annotation: BundlingNodeDisplayerData['annotation'],
     position: Position
   ) {
@@ -745,6 +746,7 @@ export function augmentEdgesWithExplanatoryLabel(
   ladderGraph: LadderGraphLirNode
 ) {
   const edges = ladderGraph.getEdges(context)
+
   const isEdgeToAddAndLabel = (edge: LadderLirEdge) => {
     const edgeU = context.get(edge.getU()) as LadderLirNode
     const edgeV = context.get(edge.getV()) as LadderLirNode
@@ -764,8 +766,8 @@ export function augmentEdgesWithExplanatoryLabel(
         isSourceWithOrAnnoLirNode(edgeV))
     )
   }
-  const edgesToAddLabel = edges.filter(isEdgeToAddAndLabel)
 
+  const edgesToAddLabel = edges.filter(isEdgeToAddAndLabel)
   edgesToAddLabel.forEach((edge) => {
     ladderGraph.setEdgeLabel(
       context,

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -412,6 +412,25 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
     this.getRegistry().publish(context, this.getId())
   }
 
+  /**************************************
+      Zen mode,
+    which is currently being treated as 
+    being equivalent to whether 
+    explanatory annotations are visible
+  ***************************************/
+
+  zenModeIsEnabled(context: LirContext) {
+    return !context.getVizConfig().displayExplanatoryAnnotations
+  }
+
+  toggleZenModeStatus(context: LirContext) {
+    const explanatoryAnnoAreDisplayed = !this.zenModeIsEnabled(context)
+    context.setVizConfig({
+      displayExplanatoryAnnotations: !explanatoryAnnoAreDisplayed,
+    })
+    this.getRegistry().publish(context, this.getId())
+  }
+
   /*****************************
             Misc
   ******************************/

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -645,7 +645,7 @@ export class SourceNoAnnoLirNode
   }
 
   toString(): string {
-    return 'SOURCE_LIR_NODE'
+    return 'SOURCE_NO_ANNO_LIR_NODE'
   }
 }
 
@@ -672,7 +672,7 @@ export class SourceWithOrAnnoLirNode
   }
 
   toString(): string {
-    return 'SOURCE_LIR_NODE'
+    return 'SOURCE_WITH_OR_ANNO_LIR_NODE'
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -661,7 +661,7 @@ export class SourceWithOrAnnoLirNode
 {
   constructor(
     nodeInfo: LirNodeInfo,
-    annotation: BundlingNodeDisplayerData['annotation'] = emptyBundlingNodeAnno.annotation,
+    annotation: BundlingNodeDisplayerData['annotation'],
     position: Position = DEFAULT_INITIAL_POSITION
   ) {
     super(nodeInfo, annotation, position)

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -590,9 +590,6 @@ export class NotEndLirNode extends BaseFlowLirNode implements FlowLirNode {
 export type BundlingNodeAnno = Pick<BundlingNodeDisplayerData, 'annotation'>
 
 export const emptyBundlingNodeAnno: BundlingNodeAnno = { annotation: '' }
-export const anyOfBundlingNodeAnno: BundlingNodeAnno = {
-  annotation: 'any of',
-}
 
 export function isBundlingFlowLirNode(
   node: LadderLirNode

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -432,15 +432,14 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
     explanatory annotations are visible
   ***************************************/
 
-  zenModeIsEnabled(context: LirContext) {
-    return !context.getVizConfig().displayExplanatoryAnnotations
-  }
-
   toggleZenModeStatus(context: LirContext) {
-    const explanatoryAnnoAreDisplayed = !this.zenModeIsEnabled(context)
-    context.setVizConfig({
-      displayExplanatoryAnnotations: !explanatoryAnnoAreDisplayed,
-    })
+    const currZenModeStatus = context.shouldEnableZenMode()
+    if (currZenModeStatus) {
+      context.disableZenMode()
+    } else {
+      context.enableZenMode()
+    }
+
     this.getRegistry().publish(context, this.getId())
   }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -748,7 +748,7 @@ export function augmentEdgesWithExplanatoryLabel(
   const edgesToAddLabel = edges.filter(isEdgeToAddAndLabel)
 
   // TODO: Think abt where this const should be put
-  const EXPLANATORY_EDGE_LABEL = 'and'
+  const EXPLANATORY_EDGE_LABEL = 'AND'
   edgesToAddLabel.forEach((edge) => {
     ladderGraph.setEdgeLabel(context, edge, EXPLANATORY_EDGE_LABEL)
   })

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -54,13 +54,23 @@
   max-width: 40ch;
 }
 
-@utility grouping-node {
+/** For the source and sink bundling nodes */
+@utility bundling-node {
   @apply svelte-flow__node-basic;
-  /* Will lose the grouping node if make width 0 px */
+  /* Will lose the bundling node if width is 0 px */
   width: 1px;
   height: 1px;
+}
 
-  opacity: 0.3;
+@utility node-annotation {
+  position: absolute;
+  top: -25px; /* Adjust this value to control the vertical position */
+  left: 50%;
+  transform: translateX(-58%); /* Centers the text horizontally, ish */
+
+  @apply uppercase;
+  @apply text-lg leading-none;
+  @apply text-(--color-node-annotation);
 }
 
 /*************************************

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -69,7 +69,7 @@
   transform: translateX(-58%); /* Centers the text horizontally, ish */
 
   @apply uppercase;
-  @apply text-lg leading-none;
+  @apply text-base leading-none;
   @apply text-(--color-node-annotation);
 }
 

--- a/ts-apps/decision-logic-visualizer/static/style/themes/default.css
+++ b/ts-apps/decision-logic-visualizer/static/style/themes/default.css
@@ -4,6 +4,7 @@
   ****************************************/
 
   --color-node-text: #00004d;
+  --color-node-annotation: var(--color-zinc-400);
   --color-primary: #001188;
   --color-secondary: #2563eb;
   --color-button: #c7d2fe;

--- a/ts-apps/decision-logic-visualizer/static/style/themes/default.css
+++ b/ts-apps/decision-logic-visualizer/static/style/themes/default.css
@@ -4,7 +4,8 @@
   ****************************************/
 
   --color-node-text: #00004d;
-  --color-node-annotation: var(--color-zinc-400);
+  /* --color-zinc-400 */
+  --color-node-annotation: var(--color-node-text);
   --color-primary: #001188;
   --color-secondary: #2563eb;
   --color-button: #c7d2fe;

--- a/ts-apps/decision-logic-visualizer/static/style/themes/default.css
+++ b/ts-apps/decision-logic-visualizer/static/style/themes/default.css
@@ -4,7 +4,7 @@
   ****************************************/
 
   --color-node-text: #00004d;
-  /* --color-zinc-400 */
+  /* Another color to consider for node annotations? --color-zinc-400 */
   --color-node-annotation: var(--color-node-text);
   --color-primary: #001188;
   --color-secondary: #2563eb;


### PR DESCRIPTION
Depends on #245  -- please review that first.

This PR adds explanatory labels / annotations for the nodes and edges; whether these labels should be displayed can be toggled by the user.

The edge labels can also be used when pretty printing the linearized paths; that will be done in a different PR.
And in the future, we could display NLG annotations as node or edge labels too.

I considered trying to put the zen button above the fit view button, but I wasn't able to see a way to do that within 1 min.


<img width="1710" alt="image" src="https://github.com/user-attachments/assets/bf63402c-be0e-4278-8836-287cccc2241f" />


### The labels / annotations can be toggled with the zen button:

<img width="1158" alt="image" src="https://github.com/user-attachments/assets/f1ce93b8-f3cf-4d44-a6f8-98844fd98a40" />


### More examples

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/316707b2-8526-4c42-8837-b24e0b35024e" />

With NOT:

![image](https://github.com/user-attachments/assets/777d591d-0989-4f96-bd36-c69397c64111)



### Food for thought: We could also consider using, e.g., '&' instead of 'AND' for the edge label

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/bdfbd1ec-2ead-44dd-b20f-d6a17c376465" />
