### PR TITLE
Viz: Enable highlighting / unhighlighting *multiple* lin paths. And other misc PathsList and algebraic-graphs improvements.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12682,7 +12682,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.0.2.tgz",
       "integrity": "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -12693,7 +12692,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-1.0.0.tgz",
       "integrity": "sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tailwind-merge": "3.0.2"
@@ -14240,6 +14238,7 @@
         "lodash": "^4.17.21",
         "lucide-svelte": "^0.477.0",
         "runed": "^0.23.3",
+        "tailwind-variants": "^1.0.0",
         "ts-pattern": "^5.6.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6479,32 +6479,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bits-ui": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-1.3.6.tgz",
-      "integrity": "sha512-0Ee7Ox5KqIBdio/+TG387Xlj6QJ0S7tHVS2K4DYiBHxBRbm6ni13i/pOoNDjeME6NOGUZxbSe4dNZIW3pGlxZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.6.4",
-        "@floating-ui/dom": "^1.6.7",
-        "@internationalized/date": "^3.5.6",
-        "esm-env": "^1.1.2",
-        "runed": "^0.23.2",
-        "svelte-toolbelt": "^0.7.1",
-        "tabbable": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "pnpm": ">=8.7.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/huntabyte"
-      },
-      "peerDependencies": {
-        "svelte": "^5.11.0"
-      }
-    },
     "node_modules/bl": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -14251,7 +14225,7 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@types/lodash": "^4.17.14",
         "autoprefixer": "^10.4.20",
-        "bits-ui": "^1.3.6",
+        "bits-ui": "^1.3.12",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.13.0",
@@ -14283,6 +14257,32 @@
       },
       "peerDependencies": {
         "svelte": "^5.16.0"
+      }
+    },
+    "ts-apps/decision-logic-visualizer/node_modules/bits-ui": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-1.3.13.tgz",
+      "integrity": "sha512-0ysKdvHBIArfFBe+MYVAvu5OANOsivk+UJftdiW+e6lGHzf+EW/TZpLh69Vf0n8pYTjkH+33CHlVIImxTZRIMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.4",
+        "@floating-ui/dom": "^1.6.7",
+        "@internationalized/date": "^3.5.6",
+        "esm-env": "^1.1.2",
+        "runed": "^0.23.2",
+        "svelte-toolbelt": "^0.7.1",
+        "tabbable": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/huntabyte"
+      },
+      "peerDependencies": {
+        "svelte": "^5.11.0"
       }
     },
     "ts-apps/decision-logic-visualizer/node_modules/postcss": {

--- a/ts-apps/decision-logic-visualizer/package.json
+++ b/ts-apps/decision-logic-visualizer/package.json
@@ -84,6 +84,7 @@
     "lodash": "^4.17.21",
     "lucide-svelte": "^0.477.0",
     "runed": "^0.23.3",
+    "tailwind-variants": "^1.0.0",
     "ts-pattern": "^5.6.1"
   }
 }

--- a/ts-apps/decision-logic-visualizer/package.json
+++ b/ts-apps/decision-logic-visualizer/package.json
@@ -52,7 +52,7 @@
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@types/lodash": "^4.17.14",
     "autoprefixer": "^10.4.20",
-    "bits-ui": "^1.3.6",
+    "bits-ui": "^1.3.12",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.13.0",

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/base-adjacency-map.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/base-adjacency-map.ts
@@ -78,11 +78,12 @@ export abstract class BaseAMGraph<A extends Ord<A>> {
   /** Stringifies the internal representation. Currently for internal use. */
   toString(): string {
     const vertices = this.getVertices()
+    const stringifiedVertices = `vertices [${vertices.join(', ')}]`
     const edges = this.getAllEdges().map((edge) => `<${edge.toString()}>`)
 
     if (vertices.length === 0) return 'empty'
-    if (edges.length === 0) return `vertices [${vertices.join(', ')}]`
-    return `edges [${edges.join(', ')}]`
+    if (edges.length === 0) return stringifiedVertices
+    return `${stringifiedVertices}\n edges [${edges.join(', ')}]`
   }
 
   dispose() {

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
@@ -76,6 +76,11 @@ export abstract class Dag<A extends Ord<A>>
     )
   }
 
+  /**
+   * Constructs the induced subgraph by removing vertices that do not satisfy `p`.
+   */
+  induce(p: (a: A) => boolean): DirectedAcyclicGraph<A> {
+    return this.bind((a) => (p(a) ? vertex(a) : empty<A>()))
   }
 
   /** Errors if not a DAG */

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
@@ -9,6 +9,7 @@ import {
 import * as GY from 'graphology'
 import { topologicalSort } from 'graphology-dag'
 import { match, P } from 'ts-pattern'
+import _ from 'lodash'
 
 /*
 TODO: There is currently a fair bit of code duplication
@@ -77,10 +78,21 @@ export abstract class Dag<A extends Ord<A>>
   }
 
   /**
-   * Constructs the induced subgraph by removing vertices that do not satisfy `p`.
+   * Constructs the induced subgraph by removing vertices that do not satisfy `predicate`.
    */
-  induce(p: (a: A) => boolean): DirectedAcyclicGraph<A> {
-    return this.bind((a) => (p(a) ? vertex(a) : empty<A>()))
+  induce(predicate: (a: A) => boolean): DirectedAcyclicGraph<A> {
+    return this.bind((a) => (predicate(a) ? vertex(a) : empty<A>()))
+  }
+
+  partition(predicate: (a: A) => boolean): {
+    induced: DirectedAcyclicGraph<A>
+    complement: DirectedAcyclicGraph<A>
+  } {
+    const complementPred = _.negate(predicate)
+    return {
+      induced: this.induce(predicate),
+      complement: this.induce(complementPred),
+    }
   }
 
   /** Errors if not a DAG */

--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
@@ -158,6 +158,12 @@ export function overlay<A extends Ord<A>>(
   return new Overlay(x, y)
 }
 
+export function isOverlay<A extends Ord<A>>(
+  g: DirectedAcyclicGraph<A>
+): g is Overlay<A> {
+  return g instanceof Overlay
+}
+
 export class Overlay<A extends Ord<A>> extends Dag<A> {
   constructor(
     readonly left: DirectedAcyclicGraph<A>,
@@ -177,6 +183,14 @@ export class Overlay<A extends Ord<A>> extends Dag<A> {
     const { adjMap, edgeAttrs } = mergeDirectedGraphs(left, right)
     super(adjMap, edgeAttrs)
   }
+
+  getLeft() {
+    return this.left
+  }
+
+  getRight() {
+    return this.right
+  }
 }
 
 export function connect<A extends Ord<A>>(
@@ -184,6 +198,12 @@ export function connect<A extends Ord<A>>(
   y: DirectedAcyclicGraph<A>
 ): DirectedAcyclicGraph<A> {
   return new Connect(x, y)
+}
+
+export function isConnect<A extends Ord<A>>(
+  g: DirectedAcyclicGraph<A>
+): g is Connect<A> {
+  return g instanceof Connect
 }
 
 export class Connect<A extends Ord<A>> extends Dag<A> {
@@ -198,6 +218,15 @@ export class Connect<A extends Ord<A>> extends Dag<A> {
     )
     super(adjMap, edgeAttributes)
   }
+
+  getFrom() {
+    return this.from
+  }
+
+  getTo() {
+    return this.to
+  }
+}
 }
 
 /**************************************

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -40,7 +40,7 @@
           </div>
           <ToggleGroupItem
             value={`${pathIndex}`}
-            class="rounded-lg border-1 p-2 max-w-fit hover:bg-accent text-xs text-left"
+            class="rounded-lg border-1 p-2 max-w-fit hover:border-sky-700 hover:bg-stone-50 text-xs text-left"
           >
             {path.toPretty(context)}
           </ToggleGroupItem>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
-  import { type PathListDisplayerProps } from './svelteflow-types.js'
+  import type { PathListDisplayerProps } from './svelteflow-types.js'
+  import { Toggle } from '$lib/ui-primitives/toggle/index.js'
 
   /************************
        Lir
@@ -18,23 +19,32 @@
     {#each node.getPaths(context) as path, pathIndex}
       <li class="grid grid-cols-[max-content_1fr] gap-x-2 items-center">
         <!-- Row number / path index -->
-        <div class="font-semibold px-3 max-w-[25px] text-right">
+        <div class="px-3 max-w-[25px] text-right">
           {pathIndex + 1}
         </div>
         <!-- TODO: Refactor the hover CSS to use our css vars -->
-        <button
-          class="rounded-md border-1 p-2 max-w-fit hover:bg-sky-100 text-xs text-left"
-          onmouseenter={() =>
-            path.highlightCorrespondingPathInLadderGraph(context)}
-          onmouseleave={() =>
-            path.unhighlightCorrespondingPathInLadderGraph(context)}
+        <Toggle
+          pressed={path.is$Selected()}
+          class="rounded-md border-1 p-2 max-w-fit text-xs text-left"
+          onPressedChange={(pressed: boolean) => {
+            if (pressed) {
+              path.highlightCorrespondingPathInLadderGraph(context)
+            } else {
+              path.unhighlightCorrespondingPathInLadderGraph(context)
+            }
+          }}
         >
           {path.toPretty(context)}
-        </button>
+        </Toggle>
       </li>
     {/each}
   </ul>
 </section>
+
+<!-- onmouseenter={() =>
+  path.highlightCorrespondingPathInLadderGraph(context)}
+onmouseleave={() =>
+  path.unhighlightCorrespondingPathInLadderGraph(context)} -->
 
 <style>
   .paths-list-content-wrapper {

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -40,7 +40,7 @@
           </div>
           <ToggleGroupItem
             value={`${pathIndex}`}
-            class="rounded-lg border-1 p-2 max-w-fit hover:border-sky-700 hover:bg-stone-50 text-xs text-left"
+            class="rounded-lg border-1 hover:border-2 data-[state=on]:border-2 p-2 max-w-fit data-[state=on]:border-sky-600 hover:border-sky-600 hover:bg-transparent text-xs text-left"
           >
             {path.toPretty(context)}
           </ToggleGroupItem>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -25,7 +25,7 @@
         <!-- TODO: Refactor the hover CSS to use our css vars -->
         <Toggle
           pressed={path.is$Selected()}
-          class="rounded-md border-1 p-2 max-w-fit text-xs text-left"
+          class="rounded-lg border-1 p-2 max-w-fit hover:bg-accent text-xs text-left"
           onPressedChange={(pressed: boolean) => {
             if (pressed) {
               path.highlightCorrespondingPathInLadderGraph(context)

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -1,43 +1,53 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
   import type { PathListDisplayerProps } from './svelteflow-types.js'
-  import { Toggle } from '$lib/ui-primitives/toggle/index.js'
+  import {
+    ToggleGroup,
+    ToggleGroupItem,
+  } from '$lib/ui-primitives/toggle-group/index.js'
 
   /************************
        Lir
   *************************/
 
-  const { context, node }: PathListDisplayerProps = $props()
+  const { context, node: pathsListLirNode }: PathListDisplayerProps = $props()
 
   onDestroy(() => {
-    node.dispose(context)
+    pathsListLirNode.dispose(context)
   })
+
+  const paths = pathsListLirNode.getPaths(context)
 </script>
 
 <section class="paths-list-content-wrapper">
-  <ul class="space-y-1">
-    {#each node.getPaths(context) as path, pathIndex}
-      <li class="grid grid-cols-[max-content_1fr] gap-x-2 items-center">
-        <!-- Row number / path index -->
-        <div class="px-3 max-w-[25px] text-right">
-          {pathIndex + 1}
-        </div>
-        <Toggle
-          pressed={path.is$Selected()}
-          class="rounded-lg border-1 p-2 max-w-fit hover:bg-accent text-xs text-left"
-          onPressedChange={(pressed: boolean) => {
-            if (pressed) {
-              path.highlightCorrespondingPathInLadderGraph(context)
-            } else {
-              path.unhighlightCorrespondingPathInLadderGraph(context)
-            }
-          }}
-        >
-          {path.toPretty(context)}
-        </Toggle>
-      </li>
-    {/each}
-  </ul>
+  <ToggleGroup
+    type="multiple"
+    onValueChange={(value: string[]) => {
+      const selectedPathLirIds = value
+        .map((v) => parseInt(v)) // the `value` for this component must be a string
+        .map((pathIndex) => paths[pathIndex].getId())
+      console.log('onvalueChange', value)
+      console.log('onValueChange', selectedPathLirIds)
+      pathsListLirNode.highlightPaths(context, selectedPathLirIds)
+    }}
+  >
+    <ul class="space-y-1">
+      {#each paths as path, pathIndex}
+        <li class="grid grid-cols-[max-content_1fr] gap-x-2 items-center">
+          <!-- Row number / path index -->
+          <div class="px-3 max-w-[25px] text-right">
+            {pathIndex + 1}
+          </div>
+          <ToggleGroupItem
+            value={`${pathIndex}`}
+            class="rounded-lg border-1 p-2 max-w-fit hover:bg-accent text-xs text-left"
+          >
+            {path.toPretty(context)}
+          </ToggleGroupItem>
+        </li>
+      {/each}
+    </ul>
+  </ToggleGroup>
 </section>
 
 <style>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -22,7 +22,6 @@
         <div class="px-3 max-w-[25px] text-right">
           {pathIndex + 1}
         </div>
-        <!-- TODO: Refactor the hover CSS to use our css vars -->
         <Toggle
           pressed={path.is$Selected()}
           class="rounded-lg border-1 p-2 max-w-fit hover:bg-accent text-xs text-left"
@@ -40,11 +39,6 @@
     {/each}
   </ul>
 </section>
-
-<!-- onmouseenter={() =>
-  path.highlightCorrespondingPathInLadderGraph(context)}
-onmouseleave={() =>
-  path.unhighlightCorrespondingPathInLadderGraph(context)} -->
 
 <style>
   .paths-list-content-wrapper {

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
@@ -10,7 +10,7 @@ import type {
 } from '$lib/layout-ir/core.js'
 import type {
   DeclLirNode,
-  PathListLirNode,
+  PathsListLirNode,
 } from '$lib/layout-ir/ladder-lir.svelte.js'
 import { emptyEdgeLabel, EmptyEdgeStyles } from '../../algebraic-graphs/edge.js'
 import * as SF from '@xyflow/svelte'
@@ -49,7 +49,7 @@ export interface BaseLadderFlowDisplayerProps extends DisplayerProps {
 }
 
 export interface PathListDisplayerProps extends DisplayerProps {
-  node: PathListLirNode
+  node: PathsListLirNode
 }
 
 /************************************************

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -103,7 +103,6 @@ export class FunDeclLirNode extends DefaultLirNode implements LirNode {
 
 export class PathsListLirNode extends DefaultLirNode implements LirNode {
   private paths: Array<LirId>
-  private highlightedPaths: LirId[] = []
 
   constructor(
     nodeInfo: LirNodeInfo,
@@ -136,10 +135,6 @@ export class PathsListLirNode extends DefaultLirNode implements LirNode {
       new HighlightedEdgeStyles(),
       graphToHighlight
     )
-  }
-
-  getHighlightedPaths() {
-    return this.highlightedPaths
   }
 
   protected setStylesOnLadderSubgraph(
@@ -175,17 +170,11 @@ export class PathsListLirNode extends DefaultLirNode implements LirNode {
  * compatible and incompatible linearized paths
  */
 export class LinPathLirNode extends DefaultLirNode implements LirNode {
-  #is$Selected: boolean = $state(false)
-
   constructor(
     nodeInfo: LirNodeInfo,
     protected rawPath: DirectedAcyclicGraph<LirId>
   ) {
     super(nodeInfo)
-  }
-
-  is$Selected() {
-    return this.#is$Selected
   }
 
   /** To be called only by the PathsListLirNode */

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -437,8 +437,8 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
 
   /**************************************
       Zen mode,
-    which is currently being treated as 
-    being equivalent to whether 
+    which is currently being treated as
+    being equivalent to whether
     explanatory annotations are visible
   ***************************************/
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -129,12 +129,18 @@ export class PathsListLirNode extends DefaultLirNode implements LirNode {
  * compatible and incompatible linearized paths
  */
 export class LinPathLirNode extends DefaultLirNode implements LirNode {
+  #is$Selected: boolean = $state(false)
+
   constructor(
     nodeInfo: LirNodeInfo,
     protected ladderGraph: LadderGraphLirNode,
     protected rawPath: DirectedAcyclicGraph<LirId>
   ) {
     super(nodeInfo)
+  }
+
+  is$Selected() {
+    return this.#is$Selected
   }
 
   protected setStylesOnCorrespondingPathInLadderGraph(

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -294,7 +294,7 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
   /** This will have to be updated if (and only if) we change the structure of the graph.
    * No need to update it, tho, if changing edge attributes.
    */
-  #rawPaths?: DirectedAcyclicGraph<LirId>[]
+  #pathsList?: PathsListLirNode
   #environment: Environment
 
   constructor(nodeInfo: LirNodeInfo, dag: DirectedAcyclicGraph<LirId>) {
@@ -348,21 +348,19 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
   // TODO: differentiate between subgraph that is compatible with the updated env and subgraph that isn't
   /** Get list of all simple paths through the Dag */
   getPathsList(context: LirContext) {
-    const makePathsList = (rawPaths: DirectedAcyclicGraph<LirId>[]) => {
+    if (!this.#pathsList) {
+      const rawPaths = this.#dag.getAllPaths()
       const paths = rawPaths.map(
         (rawPath) => new LinPathLirNode(this.makeNodeInfo(context), rawPath)
       )
-      return new PathsListLirNode(
+      this.#pathsList = new PathsListLirNode(
         this.makeNodeInfo(context),
         this,
-        paths as Array<LinPathLirNode>
+        paths
       )
     }
 
-    if (!this.#rawPaths) {
-      this.#rawPaths = this.#dag.getAllPaths()
-    }
-    return makePathsList(this.#rawPaths)
+    return this.#pathsList
   }
 
   getOverallSource(context: LirContext): undefined | SourceLirNode {

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle-group/index.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle-group/index.ts
@@ -1,0 +1,10 @@
+import Root from './toggle-group.svelte'
+import Item from './toggle-group-item.svelte'
+
+export {
+  Root,
+  Item,
+  //
+  Root as ToggleGroup,
+  Item as ToggleGroupItem,
+}

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle-group/toggle-group-item.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle-group/toggle-group-item.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { ToggleGroup as ToggleGroupPrimitive } from 'bits-ui'
+  import { getToggleGroupCtx } from './toggle-group.svelte'
+  import { cn } from '$lib/utils.js'
+  import { type ToggleVariants, toggleVariants } from '../toggle/index.js'
+
+  let {
+    ref = $bindable(null),
+    value = $bindable(),
+    class: className,
+    size,
+    variant,
+    ...restProps
+  }: ToggleGroupPrimitive.ItemProps & ToggleVariants = $props()
+
+  const ctx = getToggleGroupCtx()
+</script>
+
+<ToggleGroupPrimitive.Item
+  bind:ref
+  class={cn(
+    toggleVariants({
+      variant: ctx.variant || variant,
+      size: ctx.size || size,
+    }),
+    className
+  )}
+  {value}
+  {...restProps}
+/>

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle-group/toggle-group.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle-group/toggle-group.svelte
@@ -1,0 +1,41 @@
+<script lang="ts" module>
+  import { getContext, setContext } from 'svelte'
+  import type { ToggleVariants } from '../toggle/index.js'
+  export function setToggleGroupCtx(props: ToggleVariants) {
+    setContext('toggleGroup', props)
+  }
+
+  export function getToggleGroupCtx() {
+    return getContext<ToggleVariants>('toggleGroup')
+  }
+</script>
+
+<script lang="ts">
+  import { ToggleGroup as ToggleGroupPrimitive } from 'bits-ui'
+  import { cn } from '$lib/utils.js'
+
+  let {
+    ref = $bindable(null),
+    value = $bindable(),
+    class: className,
+    size = 'default',
+    variant = 'default',
+    ...restProps
+  }: ToggleGroupPrimitive.RootProps & ToggleVariants = $props()
+
+  setToggleGroupCtx({
+    variant,
+    size,
+  })
+</script>
+
+<!--
+Discriminated Unions + Destructing (required for bindable) do not
+get along, so we shut typescript up by casting `value` to `never`.
+-->
+<ToggleGroupPrimitive.Root
+  bind:value={value as never}
+  bind:ref
+  class={cn('flex items-center justify-center gap-1', className)}
+  {...restProps}
+/>

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle/index.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle/index.ts
@@ -1,0 +1,13 @@
+import Root from './toggle.svelte'
+export {
+  toggleVariants,
+  type ToggleSize,
+  type ToggleVariant,
+  type ToggleVariants,
+} from './toggle.svelte'
+
+export {
+  Root,
+  //
+  Root as Toggle,
+}

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle/toggle.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/toggle/toggle.svelte
@@ -1,0 +1,51 @@
+<script lang="ts" module>
+  import { type VariantProps, tv } from 'tailwind-variants'
+
+  export const toggleVariants = tv({
+    base: 'ring-offset-background hover:bg-muted hover:text-muted-foreground focus-visible:ring-ring data-[state=on]:bg-accent data-[state=on]:text-accent-foreground inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        outline:
+          'border-input hover:bg-accent hover:text-accent-foreground border bg-transparent',
+      },
+      size: {
+        default: 'h-10 min-w-10 px-3',
+        sm: 'h-9 min-w-9 px-2.5',
+        lg: 'h-11 min-w-11 px-5',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  })
+
+  export type ToggleVariant = VariantProps<typeof toggleVariants>['variant']
+  export type ToggleSize = VariantProps<typeof toggleVariants>['size']
+  export type ToggleVariants = VariantProps<typeof toggleVariants>
+</script>
+
+<script lang="ts">
+  import { Toggle as TogglePrimitive } from 'bits-ui'
+  import { cn } from '$lib/utils.js'
+
+  let {
+    ref = $bindable(null),
+    pressed = $bindable(false),
+    class: className,
+    size = 'default',
+    variant = 'default',
+    ...restProps
+  }: TogglePrimitive.RootProps & {
+    variant?: ToggleVariant
+    size?: ToggleSize
+  } = $props()
+</script>
+
+<TogglePrimitive.Root
+  bind:ref
+  bind:pressed
+  class={cn(toggleVariants({ variant, size }), className)}
+  {...restProps}
+/>

--- a/ts-apps/decision-logic-visualizer/src/lib/utils.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/utils.ts
@@ -41,3 +41,15 @@ export interface HasId {
 export type Styles = {
   [val: string]: CSSProperties | Styles
 }
+
+/*****************************
+      Shadcn-Svelte Utils
+******************************/
+
+import type { ClassValue } from 'clsx'
+import { clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -165,11 +165,6 @@
   }
 }
 
-/* TODO: NEED TO DEBUG THIS */
-/* Needs to be specified because 
-Tailwind v4 doesn't automatically check for a tailwind.config.js file */
-/* @config "../tailwind.config.js"; */
-
 /*************************************
   Utility SF styles
 *************************************/

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -165,6 +165,11 @@
   }
 }
 
+/* TODO: NEED TO DEBUG THIS */
+/* Needs to be specified because 
+Tailwind v4 doesn't automatically check for a tailwind.config.js file */
+/* @config "../tailwind.config.js"; */
+
 /*************************************
   Utility SF styles
 *************************************/

--- a/ts-apps/decision-logic-visualizer/src/tests/alga-dag.test.ts
+++ b/ts-apps/decision-logic-visualizer/src/tests/alga-dag.test.ts
@@ -6,31 +6,8 @@ import {
   connect,
   connectNodeToSource,
   connectSinkToNode,
-} from '../lib/algebraic-graphs/dag.js' // Adjust the import path accordingly
-import type { Ord, HasId } from '$lib/utils.js'
-import { ComparisonResult } from '$lib/utils.js'
-
-class NumberWrapper implements Ord<NumberWrapper>, HasId {
-  constructor(private value: number) {}
-
-  isEqualTo(other: NumberWrapper): boolean {
-    return other instanceof NumberWrapper && this.value === other.value
-  }
-
-  compare(other: NumberWrapper): ComparisonResult {
-    if (this.value < other.value) return ComparisonResult.LessThan
-    if (this.value > other.value) return ComparisonResult.GreaterThan
-    return ComparisonResult.Equal
-  }
-
-  getId(): string {
-    return this.value.toString()
-  }
-
-  toString(): string {
-    return `NWrapper ${this.value}`
-  }
-}
+} from '../lib/algebraic-graphs/dag.js'
+import { NumberWrapper } from './number-wrapper.js'
 
 /*******************
       Overlay

--- a/ts-apps/decision-logic-visualizer/src/tests/alga-dag.test.ts
+++ b/ts-apps/decision-logic-visualizer/src/tests/alga-dag.test.ts
@@ -10,6 +10,8 @@ import {
 } from '../lib/algebraic-graphs/dag.js'
 import { NumberWrapper } from './number-wrapper.js'
 
+const nws = [0, 1, 2, 3, 4, 5, 6].map((n) => new NumberWrapper(n))
+
 /*******************
       Overlay
 ********************/
@@ -333,7 +335,28 @@ describe('DAG - toString', () => {
     const nw1 = new NumberWrapper(1)
     const nw2 = new NumberWrapper(2)
     const dag = connect(vertex(nw1), vertex(nw2))
-    expect(dag.toString()).toBe('edges [<NWrapper 1,NWrapper 2>]')
+    expect(dag.toString()).toBe(
+      'vertices [NWrapper 1, NWrapper 2]\n edges [<NWrapper 1,NWrapper 2>]'
+    )
+  })
+})
+
+/********************************************************************
+  Note that the raw vertices
+  can't just be a member of our pseudo Eq and Ord
+  --- must also have the kind of referential equality that you want
+**********************************************************************/
+
+describe('the kind of equality in this alga mini-lib', () => {
+  test('Alga: not enough for raw vertices to be pseudo Eq -- must also have the kind of referential equality you want', () => {
+    const dag = pathFromValues([
+      new NumberWrapper(1),
+      new NumberWrapper(2),
+      new NumberWrapper(3),
+    ])
+    const mappedDag = dag.gmap((a) => new NumberWrapper(a.getValueAsNumber()))
+
+    expect(mappedDag.isEqualTo(dag)).toBeFalsy()
   })
 })
 
@@ -341,7 +364,7 @@ describe('DAG - toString', () => {
        gmap (Graph Map)
 *******************************************/
 
-// TODO: I really should randomly generate graphs, or aat least make a couple of different test graphs
+// TODO: I really should randomly generate graphs, or at least make a couple of different test graphs
 
 describe('DAG - gmap (Graph Map)', () => {
   test('gmap with id should return the same (structurally speaking) graph', () => {
@@ -357,22 +380,12 @@ describe('DAG - gmap (Graph Map)', () => {
   })
 
   test('gmap with a function should apply to all vertices', () => {
-    const vertices = [
-      new NumberWrapper(1),
-      new NumberWrapper(2),
-      new NumberWrapper(3),
-    ]
+    const vertices = [nws[1], nws[2], nws[3]]
     const dag = pathFromValues(vertices)
 
-    const mappedDag = dag.gmap(
-      (a) => new NumberWrapper(a.getValueAsNumber() + 1)
-    )
+    const mappedDag = dag.gmap((a) => nws[a.getValueAsNumber() + 1])
 
-    const expectedVertices = [
-      new NumberWrapper(2),
-      new NumberWrapper(3),
-      new NumberWrapper(4),
-    ]
+    const expectedVertices = [nws[2], nws[3], nws[4]]
     const expectedDag = pathFromValues(expectedVertices)
 
     expect(mappedDag.isEqualTo(expectedDag)).toBeTruthy()
@@ -400,6 +413,15 @@ describe('DAG - gmap (Graph Map)', () => {
 
 describe('DAG - bind (FlatMap)', () => {
   test('bind with `vertex` function should replace vertices', () => {
+    const dag = pathFromValues([nws[1], nws[2], nws[3]])
+
+    const boundDag = dag.bind((a) => vertex(nws[a.getValueAsNumber() * 2]))
+
+    const expectedDag = pathFromValues([nws[2], nws[4], nws[6]])
+
+    expect(boundDag.isEqualTo(expectedDag)).toBeTruthy()
+  })
+})
     const dag = pathFromValues([
       new NumberWrapper(1),
       new NumberWrapper(2),

--- a/ts-apps/decision-logic-visualizer/src/tests/number-wrapper.ts
+++ b/ts-apps/decision-logic-visualizer/src/tests/number-wrapper.ts
@@ -14,6 +14,10 @@ export class NumberWrapper implements Ord<NumberWrapper>, HasId {
     return ComparisonResult.Equal
   }
 
+  getValueAsNumber() {
+    return this.value
+  }
+
   getId(): string {
     return this.value.toString()
   }

--- a/ts-apps/jl4-web/src/style.css
+++ b/ts-apps/jl4-web/src/style.css
@@ -12,6 +12,8 @@
 @import 'tailwindcss';
 /* ladder lib's css needs to come before tailwind import */
 
+/* Needs to be specified because 
+Tailwind v4 doesn't automatically check for a tailwind.config.js file */
 @config "../tailwind.config.js";
 
 /* Shadcn theme */


### PR DESCRIPTION
- [x] Deps: Add shadcn-svelte Toggle and ToggleGroup
- [x] Enable highlighting / unhighlighting *multiple* lin paths
- [x]  Cache the PathsListLirNode instead of just caching the raw paths
- [x] Fix the bug that Andres pointed out, by exploiting how (G, +, ε) is an idempotent monoid
- [x] Unrelated to PathsList: Add more alga functionality (`foldg`, `buildg`, `bind`, `gmap`, `induce`) for future dag needs -- was easy to add, and we'll almost certainly need these in the future.

I'll implement 'use edge labels when pretty printing the linearized paths' in another PR.

I ended up just leaving the alga stuff in here, even though it's not related to pathslist, because the PR isn't too big (the shadcn svelte stuff is a copy-paste) and the commits weren't the cleanest / easiest to move