### PR TITLE
Viz: Fix issue from prev PR with background of the bool var node obscuring the border

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/bool-var.svelte
@@ -10,14 +10,14 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
 </script>
 
 <!-- Need to use data.value instead of value to maintain reactivity -->
-<div class="svelte-flow__node-basic bool-var-node-border">
+<div
+  class={[
+    'svelte-flow__node-basic bool-var-node-border',
+    ...data.value.getClasses(),
+  ]}
+>
   <Handle type="target" position={defaultSFHandlesInfo.targetPosition} />
-  <div
-    class={[
-      'label-wrapper-for-content-bearing-sf-node',
-      ...data.value.getClasses(),
-    ]}
-  >
+  <div class="label-wrapper-for-content-bearing-sf-node">
     {data.name.label}
   </div>
   <Handle type="source" position={defaultSFHandlesInfo.sourcePosition} />


### PR DESCRIPTION
The background of the bool var node was such that it was obscuring the border at the corners. This PR fixes that.

<img width="635" alt="image" src="https://github.com/user-attachments/assets/5e08f37a-037f-4850-be7e-5e92e77ad1e2" />
