### PR TITLE
Quick fix: Modify jl4-web middleware handler to not show error message when it shouldn't, following the strategy taken in the vscode extn

### DIFF
--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -236,13 +236,17 @@
         /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
         executeCommand: async (command: any, args: any, next: any) => {
           logger.debug(`trying to execute command ${command}`)
-          const response = await next(command, args)
+          const responseFromLangServer = await next(command, args)
 
           logger.debug(
-            `received response from language server ${JSON.stringify(response)}`
+            `received response from language server ${JSON.stringify(responseFromLangServer)}`
           )
+          if (responseFromLangServer === null) {
+            logger.info('language server returned `null`, so doing nothing')
+            return
+          }
 
-          const decoded = decodeVizInfo(response)
+          const decoded = decodeVizInfo(responseFromLangServer)
           // TODO: Can improve this later
           switch (decoded._tag) {
             case 'Right':
@@ -265,7 +269,7 @@
               }
               break
             case 'Left':
-              errorMessage = `Internal error: Failed to decode response. ${decoded?.left}`
+              errorMessage = `Internal error: Failed to decode response. Please report this to the JL4 developers. ${decoded?.left}`
               break
           }
         },


### PR DESCRIPTION
I was going to say it would be better if we had more informative or explicit response types from the language server. (My a priori thought was: Checking for whether the response is null and doing nothing if it's null seems fragile, or at least, makes it hard to tell if that should indeed be the desired behavior.)

But then I saw that the LSP spec actually seems to mandate this?

> The result property of the ResponseMessage should be set to null in this case to signal a successful request.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#:~:text=If%20a%20request%20doesn't,to%20signal%20a%20successful%20request.
