### PR TITLE
Viz: Refactor the dlv / Ladder Flow component to do the displaying of the FunName, instead of requiring that consumers do it. I.e., move the abstraction boundary a level up

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -299,7 +299,8 @@ Misc SF UI TODOs:
 
 <!-- The consumer containing div must set the height to, e.g., 96svh if that's what's wanted -->
 <div class="overall-container">
-  <div class="flow-container" style={`height:100%; opacity: ${flowOpacity}`}>
+  <h1>{declLirNode.getFunName(context)}</h1>
+  <div class="flow-container" style={`opacity: ${flowOpacity}`}>
     <SvelteFlow
       bind:nodes={NODES}
       bind:edges={EDGES}
@@ -349,7 +350,16 @@ Misc SF UI TODOs:
 <!-- <button onclick={doLayout}>Do layout</button>
 <button onclick={doLayoutAndFitView}>Do layout and fit view</button> -->
 
-<style>
+<style lang="postcss">
+  @reference 'tailwindcss';
+  /* Would be better to reference our stylesheet so we can use our theme vars if necessary,
+  but there are complications that have to do with how the stylesheet is exported for consumers.
+  Maybe the thing to do in the future is to have a common theme stylesheet that is shared among the lib and consumers? */
+
+  h1 {
+    @apply text-2xl font-semibold text-center mt-1;
+  }
+
   .overall-container {
     display: flex;
     flex-direction: column;

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -33,9 +33,9 @@
   >
     <ul class="space-y-1">
       {#each paths as path, pathIndex}
-        <li class="grid grid-cols-[max-content_1fr] gap-x-2 items-center">
+        <li class="grid grid-cols-[max-content_1fr] gap-x-3 items-center">
           <!-- Row number / path index -->
-          <div class="px-3 max-w-[25px] text-right">
+          <div class="px-2 max-w-[25px] text-right">
             {pathIndex + 1}
           </div>
           <ToggleGroupItem

--- a/ts-apps/decision-logic-visualizer/src/routes/+page.svelte
+++ b/ts-apps/decision-logic-visualizer/src/routes/+page.svelte
@@ -21,7 +21,7 @@
   const example1 = {
     $type: 'FunDecl' as const,
     id: { id: 100 },
-    name: { label: 'Example1', unique: 1 },
+    name: { label: 'Example 1', unique: 1 },
     params: [],
     body: {
       $type: 'And' as const,
@@ -75,7 +75,7 @@
   const example2 = {
     $type: 'FunDecl' as const,
     id: { id: 200 },
-    name: { label: 'Example2', unique: 5 },
+    name: { label: 'Example 2', unique: 5 },
     params: [],
     body: {
       $type: 'And' as const,
@@ -182,14 +182,12 @@
   </h2>
 </section>
 <section id="example 1" class="example w-3/4 mx-auto space-y-4">
-  <h3 class="text-2xl font-semibold">Example 1</h3>
   <div class="viz-container-with-height">
     <Flow {context} node={funDeclLirNode} lir={lirRegistry} />
   </div>
 </section>
 <!-- TODO: Use a svelte snippet to reduce code duplication -->
 <section id="example 2" class="example w-3/4 mx-auto my-2 space-y-4">
-  <h3 class="text-2xl font-semibold">Example 2</h3>
   <div class="viz-container-with-height">
     <Flow {context} node={declLirNode2} lir={lirRegistry} />
   </div>

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -47,9 +47,6 @@
   const nodeInfo = { registry: lirRegistry, context }
 
   let declLirNode: DeclLirNode | undefined = $state(undefined)
-  let funName = $derived(
-    declLirNode && (declLirNode as DeclLirNode).getFunName(context)
-  )
 
   /******************************
       VizInfo Payload Decoder
@@ -336,9 +333,6 @@ DECIDE \`is a British citizen (variant)\` IS
   <Resizable.Handle style="width: 10px;" />
   <Resizable.Pane>
     <div id="jl4-webview" class="h-full bg-white">
-      <div class="header">
-        <h1>{funName}</h1>
-      </div>
       {#if declLirNode}
         <!-- TODO: Think more about whether to use #key -- which destroys and rebuilds the component --- or have flow-base work with the reactive node prop -->
         {#key declLirNode}
@@ -354,24 +348,8 @@ DECIDE \`is a British citizen (variant)\` IS
   </Resizable.Pane>
 </Resizable.PaneGroup>
 
-<style lang="postcss">
-  @reference "tailwindcss"
-
-  .header {
-    padding-top: 3px;
-    padding-bottom: 8px;
-  }
-
+<style>
   .slightly-shorter-than-full-viewport-height {
-    height: 95svh;
-  }
-
-  h1 {
-    margin-top: 10px;
-    padding-bottom: 2px;
-    font-size: 1.5rem;
-    line-height: 1.1rem;
-    font-weight: 700;
-    text-align: center;
+    height: 96svh;
   }
 </style>

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -350,6 +350,6 @@ DECIDE \`is a British citizen (variant)\` IS
 
 <style>
   .slightly-shorter-than-full-viewport-height {
-    height: 96svh;
+    height: 98svh;
   }
 </style>

--- a/ts-apps/webview/src/routes/+page.svelte
+++ b/ts-apps/webview/src/routes/+page.svelte
@@ -75,6 +75,6 @@
   TODO: Use calc or smtg like that to make the intent clearer
   */
   .slightly-shorter-than-full-viewport-height {
-    height: 96svh;
+    height: 98svh;
   }
 </style>

--- a/ts-apps/webview/src/routes/+page.svelte
+++ b/ts-apps/webview/src/routes/+page.svelte
@@ -28,9 +28,6 @@
   const nodeInfo = { registry: lirRegistry, context }
 
   let declLirNode: DeclLirNode | undefined = $state(undefined)
-  let funName = $derived(
-    declLirNode && (declLirNode as DeclLirNode).getFunName(context)
-  )
 
   /**************************
         VSCode
@@ -64,8 +61,6 @@
   })
 </script>
 
-<h1>{funName}</h1>
-
 {#if declLirNode}
   <!-- TODO: Think more about whether to use #key -- which destroys and rebuilds the component --- or have flow-base work with the reactive node prop -->
   {#key declLirNode}
@@ -81,14 +76,5 @@
   */
   .slightly-shorter-than-full-viewport-height {
     height: 96svh;
-  }
-
-  h1 {
-    margin-top: 10px;
-    padding-bottom: 2px;
-    font-size: 1.5rem;
-    line-height: 1.1rem;
-    font-weight: 700;
-    text-align: center;
   }
 </style>


### PR DESCRIPTION
* Closes #215 
* Tweak paths list css: improve the horizontal gap between path index and path button when there's a lot of paths

----

For some reason, the 'List paths' button appears closer to the window edge in the monaco than in the VSCode.
(Prob because there's some kind of padding around the whole component in the webview?)
I might try to look into this more when I improve the paths related css, though it's probably not too important.

![image](https://github.com/user-attachments/assets/01bfee4c-23f0-41eb-bb2b-0338d2fff300)nto
<img width="1587" alt="image" src="https://github.com/user-attachments/assets/038d4132-91eb-439f-83ed-d9e268995cb0" />


