### PR TITLE
Fix edge case bug in edge label. Fix CSS variable name. Improve paths-related usability-related CSS and pretty printing. Improve JL4-webview CSS.

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/algebraic-graphs/dag.ts
@@ -148,7 +148,14 @@ export abstract class Dag<A extends Ord<A>>
       .otherwise((source) =>
         this.getAllPathsFromVertex((source as Vertex<A>).getValue())
       )
-    return barePaths.map(pathFromValues)
+    const pathGraphs = barePaths.map(pathFromValues)
+    pathGraphs.forEach((pathGraph) => {
+      const edges = pathGraph.getEdges()
+      edges.forEach((edge) => {
+        pathGraph.setEdgeAttributes(edge, this.getAttributesForEdge(edge))
+      })
+    })
+    return pathGraphs
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -334,7 +334,7 @@ Misc SF UI TODOs:
       <Collapsible.Trigger class="flex items-center justify-end w-full gap-2">
         <!-- TODO: Improve the button styles -->
         <button
-          class="rounded-md border-1 border-sky-700 px-2 py-1 text-sm hover:bg-accent flex items-center gap-1"
+          class="rounded-md border-1 border-sky-700 px-2 py-1 text-xs hover:bg-accent flex items-center gap-1"
         >
           <List /><span>List paths</span>
         </button>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -41,7 +41,7 @@
           <!-- Why h-full: so that height of rows can increase to fit content when, e.g., browser window is made narrower -->
           <ToggleGroupItem
             value={`${pathIndex}`}
-            class="rounded-lg max-w-fit border-1 hover:border-2 data-[state=on]:border-2 p-2 h-full data-[state=on]:border-sky-600 hover:border-sky-600 hover:bg-transparent text-xs text-left break-words"
+            class="rounded-lg max-w-fit border-1 data-[state=on]:border-2 p-2 h-full data-[state=on]:border-sky-600 hover:border-sky-800 text-xs text-left break-words"
           >
             {path.toPretty(context)}
           </ToggleGroupItem>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -38,6 +38,7 @@
           <div class="px-2 max-w-[25px] text-right">
             {pathIndex + 1}
           </div>
+          <!-- Why h-full: so that height of rows can increase to fit content when, e.g., browser window is made narrower -->
           <ToggleGroupItem
             value={`${pathIndex}`}
             class="rounded-lg max-w-fit border-1 hover:border-2 data-[state=on]:border-2 p-2 h-full data-[state=on]:border-sky-600 hover:border-sky-600 hover:bg-transparent text-xs text-left break-words"

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/paths-list.svelte
@@ -40,7 +40,7 @@
           </div>
           <ToggleGroupItem
             value={`${pathIndex}`}
-            class="rounded-lg border-1 hover:border-2 data-[state=on]:border-2 p-2 max-w-fit data-[state=on]:border-sky-600 hover:border-sky-600 hover:bg-transparent text-xs text-left"
+            class="rounded-lg max-w-fit border-1 hover:border-2 data-[state=on]:border-2 p-2 h-full data-[state=on]:border-sky-600 hover:border-sky-600 hover:bg-transparent text-xs text-left break-words"
           >
             {path.toPretty(context)}
           </ToggleGroupItem>

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -806,6 +806,7 @@ export function augmentEdgesWithExplanatoryLabel(
     return (
       !edgeSourceIsAnyOfAnnoSource &&
       edgeSourceIsNotOverallSource &&
+      !isNotStartLirNode(edgeU) &&
       (isBoolVarLirNode(edgeV) ||
         isNotStartLirNode(edgeV) ||
         isSourceWithOrAnnoLirNode(edgeV))

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -13,9 +13,16 @@ import { LirContext, DefaultLirNode } from './core.js'
 import type { Ord } from '$lib/utils.js'
 import { ComparisonResult } from '$lib/utils.js'
 import {
+  isEmpty,
   isVertex,
+  isOverlay,
+  isConnect,
   overlay,
   empty,
+  foldg,
+  type Overlay,
+  type Connect,
+  type Vertex,
   type DirectedAcyclicGraph,
 } from '../algebraic-graphs/dag.js'
 import {
@@ -30,7 +37,7 @@ import type {
   Dimensions,
   BundlingNodeDisplayerData,
 } from '$lib/displayers/flow/svelteflow-types.js'
-import { match } from 'ts-pattern'
+import { match, P } from 'ts-pattern'
 import _ from 'lodash'
 
 /*
@@ -195,9 +202,7 @@ export class LinPathLirNode extends DefaultLirNode implements LirNode {
   }
 
   toPretty(context: LirContext) {
-    return this.getVertices(context)
-      .map((n) => n.toPretty(context))
-      .join(' ')
+    return pprintPathGraph(context, this.rawPath)
   }
 
   toString() {
@@ -815,4 +820,52 @@ export function augmentEdgesWithExplanatoryLabel(
       context.getExplanatoryAndEdgeLabel()
     )
   })
+}
+
+/** Bit hacky? */
+function pprintPathGraph(
+  context: LirContext,
+  initialGraph: DirectedAcyclicGraph<LirId>
+): string {
+  const processed = new Set<LirId>()
+
+  function pprintHelper(
+    context: LirContext,
+    g: DirectedAcyclicGraph<LirId>
+  ): string {
+    return match(g)
+      .with(P.when(isEmpty<LirId>), () => '')
+      .with(P.when(isVertex<LirId>), (v: Vertex<LirId>) => {
+        if (processed.has(v.getValue())) return ''
+        processed.add(v.getValue())
+        return (context.get(v.getValue()) as LadderLirNode).toPretty(context)
+      })
+      .with(P.when(isOverlay<LirId>), (o: Overlay<LirId>) => {
+        return (
+          pprintHelper(context, o.getLeft()) +
+          ' ' +
+          pprintHelper(context, o.getRight())
+        )
+      })
+      .with(P.when(isConnect<LirId>), (c: Connect<LirId>) => {
+        const from = pprintHelper(context, c.getFrom())
+        const to = pprintHelper(context, c.getTo())
+
+        if (isVertex(c.getFrom()) && isVertex(c.getTo())) {
+          const edgeAttrs = initialGraph.getAttributesForEdge(
+            new DirectedEdge(
+              (c.getFrom() as Vertex<LirId>).getValue(),
+              (c.getTo() as Vertex<LirId>).getValue()
+            )
+          )
+          const label = edgeAttrs.getLabel()
+          return `${from} ${label} ${to}`
+        } else {
+          return `${from} ${to}`
+        }
+      })
+      .exhaustive()
+  }
+
+  return pprintHelper(context, initialGraph)
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -603,7 +603,7 @@ export class NotStartLirNode extends BaseFlowLirNode implements FlowLirNode {
   }
 
   toPretty() {
-    return 'NOT'
+    return 'NOT ('
   }
 
   toString(): string {
@@ -620,7 +620,7 @@ export class NotEndLirNode extends BaseFlowLirNode implements FlowLirNode {
   }
 
   toPretty() {
-    return ''
+    return ')'
   }
 
   toString(): string {

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -245,7 +245,7 @@ body {
 :root,
 .svelte-flow {
   --ladder-node-border-radius: var(--radius);
-  --ladder-node-color: var(--ladder-color-node-text);
+  --ladder-node-color: var(--color-node-text, var(--color-primary));
   --ladder-node-border: 2px solid var(--color-primary);
 
   /* TODO: Refactor the stuff below to move away from fragile overriding of

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -40,7 +40,9 @@
   --background: 1 0 0;
   --foreground: 0.137 0.036 258.53;
 
-  --muted: 0.96 0.005 249.1;
+  /* fuschia 50
+  Formerly: 0.96 0.005 249.1 */
+  --muted: 0.977 0.017 320.058;
   --muted-foreground: 0.53 0.035 251.2;
 
   /* The default shadcn svelte border color: 214.3 31.8% 91.4%; 

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -336,7 +336,7 @@ DECIDE \`is a British citizen (variant)\` IS
       {#if declLirNode}
         <!-- TODO: Think more about whether to use #key -- which destroys and rebuilds the component --- or have flow-base work with the reactive node prop -->
         {#key declLirNode}
-          <div class="slightly-shorter-than-full-viewport-height pb-2">
+          <div class="slightly-shorter-than-full-viewport-height pb-1">
             <LadderFlow {context} node={declLirNode} lir={lirRegistry} />
           </div>
         {/key}

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -332,7 +332,7 @@ DECIDE \`is a British citizen (variant)\` IS
   </Resizable.Pane>
   <Resizable.Handle style="width: 10px;" />
   <Resizable.Pane>
-    <div id="jl4-webview" class="h-full bg-white">
+    <div id="jl4-webview" class="h-full max-w-[96%] mx-auto bg-white">
       {#if declLirNode}
         <!-- TODO: Think more about whether to use #key -- which destroys and rebuilds the component --- or have flow-base work with the reactive node prop -->
         {#key declLirNode}

--- a/ts-apps/webview/src/app.css
+++ b/ts-apps/webview/src/app.css
@@ -3,6 +3,7 @@
   This stylesheet is required for the Ladder diagram to render correctly 
 ****************************************************************************/
 @import '@repo/decision-logic-visualizer/dist/style.css';
+@import 'tailwindcss';
 
 /* ===== Basic 'CSS reset' ======================= 
 


### PR DESCRIPTION
- [x] Make webview app.css a bit more like jl4-web's, to facilitate debugging differences in look
- [x] Make jl4-webview less cramped: Set a max width of 96% for jl4-webview pane and center it
- [x] Set height of rows in PathsList to 100%, so that their height can increase when browser window is made narrower. This fixes the issue with text appearing to overflow the path button
- [x] Make 'List Paths' text a bit smaller
- [x] Use edge labels when pretty printing paths
- [x] Tweak path hover styles
- [x] Bugfix: Fix a CSS variable name that had gone un-noticed in the previous rename
- [x] Fix an edge case in edge annotations involving NOT (where the AND edge label should not appear)
- [x] Improve NOT pretty printing: make scope explicit. There are things that can be done to avoid printing unnecessary parentheses; this is just meant to be a quick improvement.

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/d65d43e6-7a9e-4a73-826d-72e5e0be98b9" />

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/f086914d-a887-42e9-af39-4006d3629452" />
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/9f18b4aa-5e9b-4775-989a-6031a8066da3" />

Not scope:
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/da0fabf1-15d7-443c-905b-3af8baf4a122" />

