### PR TITLE
Expose NLG information in Hover text

### DIFF
--- a/jl4-core/src/L4/Nlg.hs
+++ b/jl4-core/src/L4/Nlg.hs
@@ -318,11 +318,7 @@ instance Linearize Nlg where
     linResolvedFragment :: NlgFragment Resolved -> LinTree
     linResolvedFragment = \case
       MkNlgText _ t -> user t
-      MkNlgRef  _ n ->
-        -- Don't linearize 'Resolved', since the we are reaching this
-        -- code path by linearising the 'Nlg' annotation of an 'Resolved'.
-        -- TODO: this might be wrong when referencing 'Name's within the 'Nlg' annotation.
-        linearize $ getActual n
+      MkNlgRef  _ n -> linearize n
 
 hcat :: [LinTree] -> LinTree
 hcat = mconcat . intersperse space

--- a/jl4-core/src/L4/Nlg.hs
+++ b/jl4-core/src/L4/Nlg.hs
@@ -322,10 +322,13 @@ instance Linearize Nlg where
         -- Don't linearize 'Resolved', since the we are reaching this
         -- code path by linearising the 'Nlg' annotation of an 'Resolved'.
         -- TODO: this might be wrong when referencing 'Name's within the 'Nlg' annotation.
-        linearize (getActual n)
+        linearize $ getActual n
 
 hcat :: [LinTree] -> LinTree
-hcat = mconcat . intersperse (text " ")
+hcat = mconcat . intersperse space
+
+space :: LinTree
+space = text " "
 
 ifNonEmpty :: Monoid m => [a] -> m -> m
 ifNonEmpty [] _ = mempty

--- a/jl4-core/src/L4/Parser.hs
+++ b/jl4-core/src/L4/Parser.hs
@@ -181,7 +181,15 @@ nlgAnnotationP = do
 
 nameRefP :: Parser (NlgFragment Name)
 nameRefP = do
-  (open, n, close) <- P.between (hidden $ spacedToken_ TPercent) (spacedToken_ TPercent) name
+  (open, n, close) <- P.between
+    (hidden $ spacedToken_ TPercent)
+    -- We don't want to consume trailing whitespace, because we would need to "reproduce"
+    -- the whitespace during natural language generation. Otherwise, the text looks scuffed.
+    -- Thus, only parse the 'TPercent' here, and let the 'textFragment' parser
+    -- take care of any leading whitespace.
+    --
+    (plainToken_ TPercent)
+    name
   attachAnno $
     MkNlgRef emptyAnno
       <$  annoLexeme (pure open)
@@ -269,6 +277,10 @@ plainToken tt = do
   token
     (\ t -> if computedPayload t == tt then Just t else Nothing)
     (Set.singleton (Tokens (L.trivialToken uri tt :| [])))
+
+plainToken_ :: TokenType -> Parser (Lexeme PosToken)
+plainToken_ tt =
+  mkLexeme [] <$> plainToken tt
 
 spacedToken_ :: TokenType -> Parser (Lexeme PosToken)
 spacedToken_ tt =

--- a/jl4-core/src/L4/Parser.hs
+++ b/jl4-core/src/L4/Parser.hs
@@ -187,7 +187,6 @@ nameRefP = do
     -- the whitespace during natural language generation. Otherwise, the text looks scuffed.
     -- Thus, only parse the 'TPercent' here, and let the 'textFragment' parser
     -- take care of any leading whitespace.
-    --
     (plainToken_ TPercent)
     name
   attachAnno $

--- a/jl4-core/src/L4/Syntax.hs
+++ b/jl4-core/src/L4/Syntax.hs
@@ -76,7 +76,7 @@ data Type' n =
   | Forall Anno [n] (Type' n) -- ^ universally quantified type
   | InfVar Anno RawName Int -- ^ only used during type inference
   -- | ParenType Anno (Type' n) -- temporary
-  deriving stock (GHC.Generic, Eq, Show, Functor)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 -- | A kind of a type is its arity.
@@ -87,80 +87,80 @@ type Kind = Int
 
 data TypedName n =
   MkTypedName Anno n (Type' n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data OptionallyTypedName n =
   MkOptionallyTypedName Anno n (Maybe (Type' n))
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data OptionallyNamedType n =
   MkOptionallyNamedType Anno (Maybe n) (Type' n)
-  deriving stock (GHC.Generic, Eq, Show, Functor)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data TypeSig n =
   MkTypeSig Anno (GivenSig n) (Maybe (GivethSig n))
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data GivenSig n =
   MkGivenSig Anno [OptionallyTypedName n]
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data GivethSig n =
   MkGivethSig Anno (Type' n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Decide n =
   MkDecide Anno (TypeSig n) (AppForm n) (Expr n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data AppForm n =
   MkAppForm Anno n [n] (Maybe (Aka n))
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Aka n =
   MkAka Anno [n]
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Declare n =
   MkDeclare Anno (TypeSig n) (AppForm n) (TypeDecl n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Assume n =
   MkAssume Anno (TypeSig n) (AppForm n) (Maybe (Type' n))
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Directive n =
     Eval Anno (Expr n)
   | Check Anno (Expr n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Import n =
   MkImport Anno n
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data TypeDecl n =
     RecordDecl Anno (Maybe n) [TypedName n]
   | EnumDecl Anno [ConDecl n]
   | SynonymDecl Anno (Type' n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data ConDecl n =
   MkConDecl Anno n [TypedName n]
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Expr n =
@@ -192,12 +192,12 @@ data Expr n =
   | Lit        Anno Lit
   | List       Anno [Expr n] -- list literal
   | Where      Anno (Expr n) [LocalDecl n]
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data NamedExpr n =
   MkNamedExpr Anno n (Expr n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Lit =
@@ -209,7 +209,7 @@ data Lit =
 data Branch n =
     When Anno (Pattern n) (Expr n)
   | Otherwise Anno (Expr n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Pattern n =
@@ -217,7 +217,7 @@ data Pattern n =
     -- ^ not used during parsing, but after scope-checking
   | PatApp Anno n [Pattern n]
   | PatCons Anno (Pattern n) (Pattern n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 -- | A 'Program' is a module with some 'Module's it directly depends on
@@ -226,12 +226,12 @@ data Program n
 
 data Module n =
   MkModule Anno NormalizedUri [Section n]
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Section n =
   MkSection Anno SectionLevel (Maybe n) (Maybe (Aka n)) [TopDecl n]
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 type SectionLevel = Int
@@ -242,13 +242,13 @@ data TopDecl n =
   | Assume    Anno (Assume n)
   | Directive Anno (Directive n)
   | Import    Anno (Import n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data LocalDecl n =
     LocalDecide Anno (Decide n)
   | LocalAssume Anno (Assume n)
-  deriving stock (GHC.Generic, Eq, Show)
+  deriving stock (GHC.Generic, Eq, Show, Functor, Foldable, Traversable)
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 -- | Given a @'Module' n@, runs a 'foldMap' over all of
@@ -295,7 +295,7 @@ data Extension = Extension
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Info =
-    TypeInfo (Type' Resolved)
+    TypeInfo (Type' Resolved) (Maybe Nlg)
   | KindInfo Kind
   | KeywordInfo
   deriving stock (GHC.Generic, Eq, Show)

--- a/jl4-core/src/L4/TypeCheck/Annotation.hs
+++ b/jl4-core/src/L4/TypeCheck/Annotation.hs
@@ -32,8 +32,11 @@ resolveNlgAnnotationInResolved :: Resolved -> Check Resolved
 resolveNlgAnnotationInResolved = \case
   Def uniq name -> do
     Def uniq <$> resolveNlgAnnotation name
-  Ref refName uniq origName -> do
-    Ref refName uniq <$> resolveNlgAnnotation origName
+  Ref refName uniq origName ->
+    Ref
+      <$> resolveNlgAnnotation refName
+      <*> pure uniq
+      <*> pure origName
   OutOfScope uniq origName -> do
     OutOfScope uniq <$> resolveNlgAnnotation origName
 

--- a/jl4-core/src/L4/TypeCheck/Annotation.hs
+++ b/jl4-core/src/L4/TypeCheck/Annotation.hs
@@ -237,3 +237,35 @@ nlgOptionallyTypedName (MkOptionallyTypedName ann n mty) =
   MkOptionallyTypedName ann
     <$> resolveNlgAnnotationInResolved n
     <*> traverse nlgType mty
+
+nlgDeclare :: Declare Resolved -> Check (Declare Resolved)
+nlgDeclare (MkDeclare ann tysig appForm tydecl) =
+  MkDeclare ann
+    <$> nlgTypeSig tysig
+    <*> nlgAppForm appForm
+    <*> nlgTypeDecl tydecl
+
+nlgTypeDecl :: TypeDecl Resolved -> Check (TypeDecl Resolved)
+nlgTypeDecl = \case
+  RecordDecl ann mName typedNames ->
+    RecordDecl ann
+      <$> traverse resolveNlgAnnotationInResolved mName
+      <*> traverse nlgTypedName typedNames
+  EnumDecl ann condecls->
+    EnumDecl ann
+      <$> traverse nlgConDecl condecls
+  SynonymDecl ann ty->
+    SynonymDecl ann
+      <$> nlgType ty
+
+nlgConDecl :: ConDecl Resolved -> Check (ConDecl Resolved)
+nlgConDecl (MkConDecl ann n typedName) =
+  MkConDecl ann
+    <$> resolveNlgAnnotationInResolved n
+    <*> traverse nlgTypedName typedName
+
+nlgTypedName :: TypedName Resolved -> Check (TypedName Resolved)
+nlgTypedName (MkTypedName ann n ty) =
+  MkTypedName ann
+    <$> resolveNlgAnnotationInResolved n
+    <*> nlgType ty

--- a/jl4-core/src/L4/TypeCheck/Types.hs
+++ b/jl4-core/src/L4/TypeCheck/Types.hs
@@ -272,6 +272,22 @@ ambiguousType n xs = do
 -- JL4 specific primitives for resolving names
 -- ----------------------------------------------------------------------------
 
+resolvedType :: Resolved -> Check Resolved
+resolvedType n = do
+  ei <- use #entityInfo
+  case Map.lookup (getUnique n) ei of
+    Nothing -> do
+      -- TODO: there are cases where this situation is a clear bug.
+      -- Sometimes, it is fine, e.g. when the 'Resolved' is 'OutOfScope'.
+      -- Tricky what to do here.
+      -- addError $ MissingEntityInfo n
+      pure n
+    Just (_, checkEntity) ->
+      pure case checkEntity of
+        KnownType kind _resolved _tyDecl -> setAnnResolvedKindOfResolved kind n
+        KnownTerm ty _term -> setAnnResolvedTypeOfResolved ty n
+        KnownTypeVariable -> setAnnResolvedKindOfResolved 0 n
+
 lookupRawNameInEnvironment :: RawName -> Check [(Unique, Name, CheckEntity)]
 lookupRawNameInEnvironment n = do
   env <- use #environment
@@ -316,10 +332,22 @@ setAnnResolvedType ::
      (HasAnno a, AnnoToken a ~ PosToken, AnnoExtra a ~ Extension)
   => Type' Resolved -> a -> a
 setAnnResolvedType t x =
-  setAnno (set annInfo (Just (TypeInfo t)) (getAnno x)) x
+  setAnno (set annInfo (Just (TypeInfo t Nothing)) (getAnno x)) x
 
 setAnnResolvedKind ::
      (HasAnno a, AnnoToken a ~ PosToken, AnnoExtra a ~ Extension)
   => Kind -> a -> a
 setAnnResolvedKind k x =
   setAnno (set annInfo (Just (KindInfo k)) (getAnno x)) x
+
+setAnnResolvedTypeOfResolved :: Type' Resolved -> Resolved -> Resolved
+setAnnResolvedTypeOfResolved t = \case
+  Def u n -> Def u (setAnnResolvedType t n)
+  Ref r u o -> Ref (setAnnResolvedType t r) u o
+  OutOfScope u n -> OutOfScope u (setAnnResolvedType t n)
+
+setAnnResolvedKindOfResolved :: Kind -> Resolved -> Resolved
+setAnnResolvedKindOfResolved k = \case
+  Def u n -> Def u (setAnnResolvedKind k n)
+  Ref r u o -> Ref (setAnnResolvedKind k r) u o
+  OutOfScope u n -> OutOfScope u (setAnnResolvedKind k n)

--- a/jl4/examples/ok/tests/nlg_lin2.nlg.golden
+++ b/jl4/examples/ok/tests/nlg_lin2.nlg.golden
@@ -1,1 +1,1 @@
-consider the case distinctions of `choice` :  when `Left` has This is attached to `a` then `Left` with This is also attached to `a`. when `Right` has `b` then `Right` with Might be attached to %right b% in the future
+consider the case distinctions of `choice` :  when `Left` has This is attached to This is attached to `a` then `Left` with This is also attached to This is attached to `a`. when `Right` has `b` then `Right` with Might be attached to %right b% in the future


### PR DESCRIPTION
We expose the NLG linearisation to the `InfoTree`. This makes it easy to discover and can be used as a form of documentation.

Additionally, add a bunch of type and name resolution to the AST after type checking.

Similarly to the NLG annotations, we need to be careful to add the additional type information when the respective type information is actually available.
For example, when new variables are brought into scope, for example in:

```
  ...
  CONSIDER x
  WHEN y FOLLOWED BY ys THEN y
  OTHERWISE 0
```

then the `Resolved` `y` is only in scope within the `inferBranch` code, i.e. `THEN y` part. Thus, we need to make sure to add type information to `y` after we have typechecked the body of branch.

The same logic is applied to anything that brings a new binder into scope.
As a rule of thumb, whenever we have a `scope` within the typechecker, some extra logic will need to be added.