### PR TITLE
Make monaco editor theme foreground colors the same as ladder's `--primary` (modulo rounding error)

### DIFF
--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -128,7 +128,12 @@
           { token: 'decorator', foreground: 'ffbd33' }, // for annotations
         ],
         encodedTokensColors: [],
-        colors: {},
+        colors: {
+          // The following is the hex version of the --primary css variable in the default ladder diagram theme (modulo rounding error)
+          // TODO: Would be better to reference our --primary css variable directly if possible
+          'editor.foreground': '#104e64',
+          foreground: '#104e64',
+        },
       })
 
       editor = monaco.editor.create(editorElement, {


### PR DESCRIPTION
I can't actually perceive the differences in colors very well, so I'm not 100% sure that it is consistent. But here's a first attempt at trying to make the monaco theme more in line with the ladder diagram's `--primary` color (which is what gets used for the node border color etc).

<img width="1216" alt="image" src="https://github.com/user-attachments/assets/ed6328af-7361-4857-8d63-e37d8db84801" />
