### PR TITLE
Viz: Only display 'List Paths' button if the ladder graph is a NNF

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -104,7 +104,7 @@ function transform(
     })
     .with({ $type: 'Not' }, (neg) => {
       const negand = transform(nodeInfo, neg.negand)
-      const notStart = vertex(new NotStartLirNode(nodeInfo).getId())
+      const notStart = vertex(new NotStartLirNode(nodeInfo, negand).getId())
       const notEnd = vertex(new NotEndLirNode(nodeInfo).getId())
       return notStart
         .connect(negand.getSource())

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -40,6 +40,7 @@
     BoolVarLirNode,
     LadderLirNode,
   } from '$lib/layout-ir/ladder-lir.svelte.js'
+  import { isValidPathsListLirNode } from '$lib/layout-ir/ladder-lir.svelte.js'
   import { Collapsible } from 'bits-ui'
   import List from 'lucide-svelte/icons/list'
   import PathsList from './paths-list.svelte'
@@ -94,6 +95,10 @@
   const sfNodeToLirId = (sfNode: LadderSFNode) => {
     return sfIdToLirId(getSFNodeId(sfNode))
   }
+
+  // PathsList
+  // TODO: Would be better to compute this on demand
+  const pathsList = ladderGraph.getPathsList(context)
 
   /***********************************
       SvelteFlow hooks
@@ -327,23 +332,25 @@ Misc SF UI TODOs:
   </div>
   <!-- Paths Section -->
   <!-- TODO: Move the following into a lin paths container component -->
-  <div class="paths-container">
-    <!-- TODO: Make a standalone wrapper over the collapsible component, as suggested by https://bits-ui.com/docs/components/collapsible  -->
-    <!-- Using setTimeout instead of window requestAnimationFrame because it can take time to generate the paths list the first time round -->
-    <Collapsible.Root onOpenChange={() => setTimeout(doFitView, 10)}>
-      <Collapsible.Trigger class="flex items-center justify-end w-full gap-2">
-        <!-- TODO: Improve the button styles -->
-        <button
-          class="rounded-md border-1 border-sky-700 px-2 py-1 text-xs hover:bg-accent flex items-center gap-1"
-        >
-          <List /><span>List paths</span>
-        </button>
-      </Collapsible.Trigger>
-      <Collapsible.Content class="pt-2">
-        <PathsList {context} node={ladderGraph.getPathsList(context)} />
-      </Collapsible.Content>
-    </Collapsible.Root>
-  </div>
+  {#if isValidPathsListLirNode(pathsList)}
+    <div class="paths-container">
+      <!-- TODO: Make a standalone wrapper over the collapsible component, as suggested by https://bits-ui.com/docs/components/collapsible  -->
+      <!-- Using setTimeout instead of window requestAnimationFrame because it can take time to generate the paths list the first time round -->
+      <Collapsible.Root onOpenChange={() => setTimeout(doFitView, 10)}>
+        <Collapsible.Trigger class="flex items-center justify-end w-full gap-2">
+          <!-- TODO: Improve the button styles -->
+          <button
+            class="rounded-md border-1 border-sky-700 px-2 py-1 text-xs hover:bg-accent flex items-center gap-1"
+          >
+            <List /><span>List paths</span>
+          </button>
+        </Collapsible.Trigger>
+        <Collapsible.Content class="pt-2">
+          <PathsList {context} node={pathsList} />
+        </Collapsible.Content>
+      </Collapsible.Root>
+    </div>
+  {/if}
 </div>
 
 <!-- For debugging -->

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/svelteflow-types.ts
@@ -10,7 +10,7 @@ import type {
 } from '$lib/layout-ir/core.js'
 import type {
   DeclLirNode,
-  PathsListLirNode,
+  ValidPathsListLirNode,
 } from '$lib/layout-ir/ladder-lir.svelte.js'
 import { emptyEdgeLabel, EmptyEdgeStyles } from '../../algebraic-graphs/edge.js'
 import * as SF from '@xyflow/svelte'
@@ -49,7 +49,7 @@ export interface BaseLadderFlowDisplayerProps extends DisplayerProps {
 }
 
 export interface PathListDisplayerProps extends DisplayerProps {
-  node: PathsListLirNode
+  node: ValidPathsListLirNode
 }
 
 /************************************************

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -105,10 +105,42 @@ export class FunDeclLirNode extends DefaultLirNode implements LirNode {
 }
 
 /*************************************************
-              Path Lir Node
+          Paths List, Lin Path
  *************************************************/
 
-export class PathsListLirNode extends DefaultLirNode implements LirNode {
+export type PathsListLirNode = InvalidPathsListLirNode | ValidPathsListLirNode
+
+export function isInvalidPathsListLirNode(
+  node: PathsListLirNode
+): node is InvalidPathsListLirNode {
+  return node instanceof InvalidPathsListLirNode
+}
+
+export class InvalidPathsListLirNode extends DefaultLirNode implements LirNode {
+  constructor(nodeInfo: LirNodeInfo) {
+    super(nodeInfo)
+  }
+
+  toString(): string {
+    return 'INVALID_PATHS_LIST_LIR_NODE'
+  }
+
+  getChildren(_context: LirContext) {
+    return []
+  }
+
+  dispose(context: LirContext) {
+    context.clear(this.getId())
+  }
+}
+
+export function isValidPathsListLirNode(
+  node: PathsListLirNode
+): node is ValidPathsListLirNode {
+  return node instanceof ValidPathsListLirNode
+}
+
+export class ValidPathsListLirNode extends DefaultLirNode implements LirNode {
   private paths: Array<LirId>
 
   constructor(
@@ -169,7 +201,7 @@ export class PathsListLirNode extends DefaultLirNode implements LirNode {
   }
 
   toString(): string {
-    return 'PATHS_LIST_LIR_NODE'
+    return 'VALID_PATHS_LIST_LIR_NODE'
   }
 }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-lir.svelte.ts
@@ -823,6 +823,10 @@ export function augmentEdgesWithExplanatoryLabel(
   })
 }
 
+/************************************************
+          Pretty print path graph
+*************************************************/
+
 /** Bit hacky? */
 function pprintPathGraph(
   context: LirContext,


### PR DESCRIPTION
Closes #311 

<img width="1386" alt="image" src="https://github.com/user-attachments/assets/f1f03409-4efa-4c2d-b6a5-4933a652bfc7" />

but when it *is* an NNF:

<img width="1364" alt="image" src="https://github.com/user-attachments/assets/2e72db6b-ca68-4ed5-a366-a4c597adbc6d" />

Haven't tested this super extensively tho