### PR TITLE
Improve same-line parsing logic.

### DIFF
--- a/jl4-core/src/L4/Parser.hs
+++ b/jl4-core/src/L4/Parser.hs
@@ -774,6 +774,18 @@ data Stack a =
 -- The exceptions are if either the whole expression is on the same line,
 -- or if all operators are on the same column.
 --
+-- NOTE: The line which is the second argument of combine is the line
+-- of the operand (not operator) currently under consideration.
+--
+-- The line stored on top of the stack is the line where the previous
+-- expression starts, the line on top of the continuations is the line
+-- where the subsequent expression continues.
+--
+-- Operators are considered to be "on the same line" if both operands
+-- are on the same line, meaning that both the top stack fram and the
+-- top continuation frame have to have the same line number to make
+-- a real same-line choice.
+--
 combine :: Stack a -> Pos -> a Name -> [Cont a] -> a Name
 
 -- If we have a single expression and nothing on the stack, then we
@@ -794,11 +806,10 @@ combine End l1 e1 (MkCont op1 prio1 assoc1 l2 p2 e2 : efs) =
 -- continuation. We have to compare the two operators. If the operator
 -- on the continuation side is stronger, we push. Otherwise, we pop.
 --
--- TODO: we currently do not track associativity.
---
-combine s1@(Frame s e1 op1 prio1 assoc1 l1 p1) _l e2 (MkCont op2 prio2 assoc2 l2 p2 e3 : efs)
+combine s1@(Frame s e1 op1 prio1 assoc1 l1 p1) l e2 (MkCont op2 prio2 assoc2 l2 p2 e3 : efs)
   | (l2, p2, prio2, assoc2) `stronger` (l1, p1, prio1, assoc1) =
-  combine (Frame s1 e2 op2 prio2 assoc2 l2 p2) l2 e3 efs -- push
+  combine (Frame s1 e2 op2 prio2 assoc2 l p2) l2 e3 efs -- push
+  -- NOTE: the topmost frame now starts with e2, thus at line l
   | otherwise =
   combine s l1 (e1 `op1` e2) (MkCont op2 prio2 assoc2 l2 p2 e3 : efs) -- pop
   where
@@ -877,11 +888,11 @@ data Cont a =
 cont :: Parser (Prio, Assoc, a Name -> a Name -> a Name) -> Parser (a Name) -> Pos -> Parser (Cont a)
 cont pop pbase p =
   withIndent GT p $ \ pos -> do
-    l <- currentLine
     (prio, assoc, op) <- pop
     -- parg <- Lexer.indentGuard spaces GT p
+    l <- currentLine
     arg <- pbase
-    pure (MkCont op prio assoc l pos arg)
+    pure (MkCont op prio assoc l pos arg) -- the line we store is the line of the argument, not the operator
 
 -- TODO: We should think whether we can obtain this more cheaply.
 currentLine :: Parser Pos

--- a/jl4-core/src/L4/Parser.hs
+++ b/jl4-core/src/L4/Parser.hs
@@ -782,7 +782,7 @@ data Stack a =
 -- where the subsequent expression continues.
 --
 -- Operators are considered to be "on the same line" if both operands
--- are on the same line, meaning that both the top stack fram and the
+-- are on the same line, meaning that both the top stack frame and the
 -- top continuation frame have to have the same line number to make
 -- a real same-line choice.
 --

--- a/jl4/examples/ok/operators-issue336-1.l4
+++ b/jl4/examples/ok/operators-issue336-1.l4
@@ -1,0 +1,72 @@
+GIVEN alpha  IS A BOOLEAN
+      beta   IS A BOOLEAN
+      gamma  IS A BOOLEAN
+      donkey IS A BOOLEAN
+      durian IS A BOOLEAN
+      dodo   IS A BOOLEAN
+      dove   IS A BOOLEAN
+
+issue336a MEANS
+      alpha
+  AND beta
+  AND gamma
+  AND       donkey
+       OR   durian
+       OR   dodo
+       OR   dove
+
+GIVEN alpha  IS A BOOLEAN
+      beta   IS A BOOLEAN
+      gamma  IS A BOOLEAN
+      donkey IS A BOOLEAN
+      durian IS A BOOLEAN
+      dodo   IS A BOOLEAN
+      dove   IS A BOOLEAN
+
+issue336b MEANS
+      alpha
+  AND beta
+  AND gamma
+  AND       donkey  OR   durian
+       OR   dodo
+       OR   dove
+
+#EVAL issue336a TRUE TRUE FALSE FALSE FALSE FALSE TRUE
+#EVAL issue336b TRUE TRUE FALSE FALSE FALSE FALSE TRUE
+
+GIVEN alpha  IS A NUMBER
+      beta   IS A NUMBER
+      gamma  IS A NUMBER
+      donkey IS A NUMBER
+      durian IS A NUMBER
+      dodo   IS A NUMBER
+      dove   IS A NUMBER
+
+issue336c MEANS
+    alpha
+  * beta
+  * gamma
+  *      donkey
+     +   durian
+     +   dodo
+     +   dove
+
+GIVEN alpha  IS A NUMBER
+      beta   IS A NUMBER
+      gamma  IS A NUMBER
+      donkey IS A NUMBER
+      durian IS A NUMBER
+      dodo   IS A NUMBER
+      dove   IS A NUMBER
+
+issue336d MEANS
+    alpha
+  * beta
+  * gamma
+  *      donkey  +   durian
+     +   dodo
+     +   dove
+
+#EVAL issue336c 1 1 0 0 0 0 1
+#EVAL issue336d 1 1 0 0 0 0 1
+

--- a/jl4/examples/ok/operators-issue336-2.l4
+++ b/jl4/examples/ok/operators-issue336-2.l4
@@ -1,0 +1,32 @@
+example1 MEANS
+      TRUE
+  AND FALSE
+  AND    FALSE
+      OR TRUE
+
+example2 MEANS
+      TRUE
+  AND FALSE
+  AND FALSE OR TRUE
+
+-- this was a previous incorrect parsing of example2
+example2a MEANS
+  TRUE AND (FALSE AND FALSE OR TRUE)
+
+#EVAL example1  -- should yield FALSE
+#EVAL example2  -- should yield FALSE TRUE (incorrectly)
+#EVAL example2a -- should yield TRUE
+
+example3 MEANS
+    1
+  * 0
+  *   0
+    + 1
+
+example4 MEANS
+    1
+  * 0
+  * 0 + 1
+
+#EVAL example3 -- yields 0
+#EVAL example4 -- yields 0

--- a/jl4/examples/ok/operators.l4
+++ b/jl4/examples/ok/operators.l4
@@ -62,11 +62,13 @@ examplecons MEANS 1 FOLLOWED BY 2 FOLLOWED BY 3 FOLLOWED BY EMPTY
 
 -- weird things happen here:
 --
--- I think this is parsed as 3 * ((4 + 2 + 3) * 3 + 2),
--- because the + is indented more and on a different line
--- from the * ...
 examplew1 MEANS   3 * (4 + 2
                 + 3) * 4 + 2
+
+-- This is currently parsed as, the reason being
+-- that + and * on line 66 are now (since issue 336)
+-- not considered "same line operators"
+examplew2 MEANS 3 * (4 + 2 + 3) * (4 + 2)
 
 #EVAL examplel1 = 14
 #EVAL examplel2 = 20
@@ -91,4 +93,6 @@ examplew1 MEANS   3 * (4 + 2
 #EVAL examplem3 = 0
 #EVAL examplem4 = -12
 
-#EVAL examplew1 = 114  -- would rather have 110, I think
+#EVAL examplew1 = 162  -- would rather have 110, I think
+#EVAL examplew2 = 162
+

--- a/jl4/examples/ok/operators.l4
+++ b/jl4/examples/ok/operators.l4
@@ -65,7 +65,7 @@ examplecons MEANS 1 FOLLOWED BY 2 FOLLOWED BY 3 FOLLOWED BY EMPTY
 examplew1 MEANS   3 * (4 + 2
                 + 3) * 4 + 2
 
--- This is currently parsed as, the reason being
+-- This is currently parsed as follows, the reason being
 -- that + and * on line 66 are now (since issue 336)
 -- not considered "same line operators"
 examplew2 MEANS 3 * (4 + 2 + 3) * (4 + 2)

--- a/jl4/examples/ok/tests/operators-issue336-1.ep.golden
+++ b/jl4/examples/ok/tests/operators-issue336-1.ep.golden
@@ -1,0 +1,72 @@
+GIVEN alpha  IS A BOOLEAN
+      beta   IS A BOOLEAN
+      gamma  IS A BOOLEAN
+      donkey IS A BOOLEAN
+      durian IS A BOOLEAN
+      dodo   IS A BOOLEAN
+      dove   IS A BOOLEAN
+
+issue336a MEANS
+      alpha
+  AND beta
+  AND gamma
+  AND       donkey
+       OR   durian
+       OR   dodo
+       OR   dove
+
+GIVEN alpha  IS A BOOLEAN
+      beta   IS A BOOLEAN
+      gamma  IS A BOOLEAN
+      donkey IS A BOOLEAN
+      durian IS A BOOLEAN
+      dodo   IS A BOOLEAN
+      dove   IS A BOOLEAN
+
+issue336b MEANS
+      alpha
+  AND beta
+  AND gamma
+  AND       donkey  OR   durian
+       OR   dodo
+       OR   dove
+
+#EVAL issue336a TRUE TRUE FALSE FALSE FALSE FALSE TRUE
+#EVAL issue336b TRUE TRUE FALSE FALSE FALSE FALSE TRUE
+
+GIVEN alpha  IS A NUMBER
+      beta   IS A NUMBER
+      gamma  IS A NUMBER
+      donkey IS A NUMBER
+      durian IS A NUMBER
+      dodo   IS A NUMBER
+      dove   IS A NUMBER
+
+issue336c MEANS
+    alpha
+  * beta
+  * gamma
+  *      donkey
+     +   durian
+     +   dodo
+     +   dove
+
+GIVEN alpha  IS A NUMBER
+      beta   IS A NUMBER
+      gamma  IS A NUMBER
+      donkey IS A NUMBER
+      durian IS A NUMBER
+      dodo   IS A NUMBER
+      dove   IS A NUMBER
+
+issue336d MEANS
+    alpha
+  * beta
+  * gamma
+  *      donkey  +   durian
+     +   dodo
+     +   dove
+
+#EVAL issue336c 1 1 0 0 0 0 1
+#EVAL issue336d 1 1 0 0 0 0 1
+

--- a/jl4/examples/ok/tests/operators-issue336-1.golden
+++ b/jl4/examples/ok/tests/operators-issue336-1.golden
@@ -1,0 +1,11 @@
+Parsing successful
+Typechecking successful
+Evaluation successful
+operators-issue336-1.l4:34:7-55:
+  FALSE
+operators-issue336-1.l4:35:7-55:
+  FALSE
+operators-issue336-1.l4:70:7-30:
+  0
+operators-issue336-1.l4:71:7-30:
+  0

--- a/jl4/examples/ok/tests/operators-issue336-1.nlg.golden
+++ b/jl4/examples/ok/tests/operators-issue336-1.nlg.golden
@@ -1,0 +1,4 @@
+`issue336a` with `TRUE`, `TRUE`, `FALSE`, `FALSE`, `FALSE`, `FALSE` and `TRUE`
+`issue336b` with `TRUE`, `TRUE`, `FALSE`, `FALSE`, `FALSE`, `FALSE` and `TRUE`
+`issue336c` with 1, 1, 0, 0, 0, 0 and 1
+`issue336d` with 1, 1, 0, 0, 0, 0 and 1

--- a/jl4/examples/ok/tests/operators-issue336-2.ep.golden
+++ b/jl4/examples/ok/tests/operators-issue336-2.ep.golden
@@ -1,0 +1,32 @@
+example1 MEANS
+      TRUE
+  AND FALSE
+  AND    FALSE
+      OR TRUE
+
+example2 MEANS
+      TRUE
+  AND FALSE
+  AND FALSE OR TRUE
+
+-- this was a previous incorrect parsing of example2
+example2a MEANS
+  TRUE AND (FALSE AND FALSE OR TRUE)
+
+#EVAL example1  -- should yield FALSE
+#EVAL example2  -- should yield FALSE TRUE (incorrectly)
+#EVAL example2a -- should yield TRUE
+
+example3 MEANS
+    1
+  * 0
+  *   0
+    + 1
+
+example4 MEANS
+    1
+  * 0
+  * 0 + 1
+
+#EVAL example3 -- yields 0
+#EVAL example4 -- yields 0

--- a/jl4/examples/ok/tests/operators-issue336-2.golden
+++ b/jl4/examples/ok/tests/operators-issue336-2.golden
@@ -1,0 +1,13 @@
+Parsing successful
+Typechecking successful
+Evaluation successful
+operators-issue336-2.l4:16:7-15:
+  FALSE
+operators-issue336-2.l4:17:7-15:
+  FALSE
+operators-issue336-2.l4:18:7-16:
+  TRUE
+operators-issue336-2.l4:31:7-15:
+  0
+operators-issue336-2.l4:32:7-15:
+  0

--- a/jl4/examples/ok/tests/operators-issue336-2.nlg.golden
+++ b/jl4/examples/ok/tests/operators-issue336-2.nlg.golden
@@ -1,0 +1,5 @@
+`example1`
+`example2`
+`example2a`
+`example3`
+`example4`

--- a/jl4/examples/ok/tests/operators.ep.golden
+++ b/jl4/examples/ok/tests/operators.ep.golden
@@ -62,11 +62,13 @@ examplecons MEANS 1 FOLLOWED BY 2 FOLLOWED BY 3 FOLLOWED BY EMPTY
 
 -- weird things happen here:
 --
--- I think this is parsed as 3 * ((4 + 2 + 3) * 3 + 2),
--- because the + is indented more and on a different line
--- from the * ...
 examplew1 MEANS   3 * (4 + 2
                 + 3) * 4 + 2
+
+-- This is currently parsed as, the reason being
+-- that + and * on line 66 are now (since issue 336)
+-- not considered "same line operators"
+examplew2 MEANS 3 * (4 + 2 + 3) * (4 + 2)
 
 #EVAL examplel1 = 14
 #EVAL examplel2 = 20
@@ -91,4 +93,6 @@ examplew1 MEANS   3 * (4 + 2
 #EVAL examplem3 = 0
 #EVAL examplem4 = -12
 
-#EVAL examplew1 = 114  -- would rather have 110, I think
+#EVAL examplew1 = 162  -- would rather have 110, I think
+#EVAL examplew2 = 162
+

--- a/jl4/examples/ok/tests/operators.golden
+++ b/jl4/examples/ok/tests/operators.golden
@@ -1,10 +1,6 @@
 Parsing successful
 Typechecking successful
 Evaluation successful
-operators.l4:71:7-21:
-  TRUE
-operators.l4:72:7-21:
-  TRUE
 operators.l4:73:7-21:
   TRUE
 operators.l4:74:7-21:
@@ -15,29 +11,35 @@ operators.l4:76:7-21:
   TRUE
 operators.l4:77:7-21:
   TRUE
-operators.l4:79:7-21:
+operators.l4:78:7-21:
   TRUE
-operators.l4:80:7-21:
+operators.l4:79:7-21:
   TRUE
 operators.l4:81:7-21:
   TRUE
 operators.l4:82:7-21:
   TRUE
-operators.l4:84:7-22:
+operators.l4:83:7-21:
   TRUE
-operators.l4:85:7-21:
+operators.l4:84:7-21:
   TRUE
 operators.l4:86:7-22:
   TRUE
 operators.l4:87:7-21:
   TRUE
-operators.l4:89:7-22:
+operators.l4:88:7-22:
   TRUE
-operators.l4:90:7-20:
+operators.l4:89:7-21:
   TRUE
-operators.l4:91:7-20:
+operators.l4:91:7-22:
   TRUE
-operators.l4:92:7-22:
+operators.l4:92:7-20:
+  TRUE
+operators.l4:93:7-20:
   TRUE
 operators.l4:94:7-22:
+  TRUE
+operators.l4:96:7-22:
+  TRUE
+operators.l4:97:7-22:
   TRUE

--- a/jl4/examples/ok/tests/operators.nlg.golden
+++ b/jl4/examples/ok/tests/operators.nlg.golden
@@ -17,4 +17,5 @@
 `examplem2` is equal to 2
 `examplem3` is equal to 0
 `examplem4` is equal to -12
-`examplew1` is equal to 114
+`examplew1` is equal to 162
+`examplew2` is equal to 162


### PR DESCRIPTION
Fixes #336.

There's a small price to pay that parsing across lines with parentheses remains weird, and is now weird in a slightly different way. But as this was a weird case before, I don't care too much.