### PR TITLE
Viz: Refactor --  Inline FunDecl / Remove IRDecl, since we probably won't be Ladder-visualizing other sorts of Decls

### DIFF
--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -92,7 +92,7 @@ vizProgram simplify = fmap MkVisualizeDecisionLogicIRInfo . translateDecide simp
 -- than being complete. So, feel free to lift these limitations at your convenience :)
 --
 -- Simple implementation: Translate Decide iff <= 1 Given
-translateDecide :: Bool -> Decide Resolved -> Viz V.IRDecl
+translateDecide :: Bool -> Decide Resolved -> Viz V.FunDecl
 translateDecide simplify (MkDecide _ (MkTypeSig _ givenSig _) (MkAppForm _ funResolved _ _) body) =
   do
     uid <- getFresh

--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -1,9 +1,8 @@
-import type { IRDecl, IRExpr, IRId } from '@repo/viz-expr'
+import type { FunDecl, IRExpr, IRId } from '@repo/viz-expr'
 /*
 Do not use $lib for the layout-ir imports
 */
 import type { LirSource, LirId, LirNodeInfo } from '../layout-ir/core.js'
-import type { DeclLirNode } from '../layout-ir/ladder-graph/ladder.svelte.js'
 import {
   FunDeclLirNode,
   BoolVarLirNode,
@@ -26,8 +25,8 @@ import { match } from 'ts-pattern'
         Lir Data Sources
 ************************************/
 
-export const VizDeclLirSource: LirSource<IRDecl, DeclLirNode> = {
-  toLir(nodeInfo: LirNodeInfo, decl: IRDecl): DeclLirNode {
+export const VizDeclLirSource: LirSource<FunDecl, FunDeclLirNode> = {
+  toLir(nodeInfo: LirNodeInfo, decl: FunDecl): FunDeclLirNode {
     return new FunDeclLirNode(
       nodeInfo,
       decl.name,

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-props.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-props.ts
@@ -1,8 +1,8 @@
 import type { RootDisplayerProps, DisplayerProps } from '$lib/layout-ir/core.js'
-import type { DeclLirNode } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
+import type { FunDeclLirNode } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
 
 export interface LadderFlowDisplayerProps extends RootDisplayerProps {
-  node: DeclLirNode
+  node: FunDeclLirNode
 }
 
 /** For flow-base.svelte */

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
@@ -57,8 +57,6 @@ is to make it easy to experiment with different displayers/renderers.
                 Decl Lir Node
  *************************************************/
 
-export type DeclLirNode = FunDeclLirNode
-
 export class FunDeclLirNode extends DefaultLirNode implements LirNode {
   readonly #name: Name
   readonly #params: readonly Name[]

--- a/ts-apps/decision-logic-visualizer/src/routes/+page.svelte
+++ b/ts-apps/decision-logic-visualizer/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Schema } from 'effect'
-  import { IRDecl } from '@repo/viz-expr'
+  import { FunDecl } from '@repo/viz-expr'
   import { VizDeclLirSource } from '$lib/data/viz-expr-to-lir.js'
   import {
     LirContext,
@@ -58,7 +58,7 @@
     },
   }
 
-  const decode = Schema.decodeSync(IRDecl)
+  const decode = Schema.decodeSync(FunDecl)
   const decl = decode(example1)
   // Set up Lir
   const lirRegistry = new LirRegistry()

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -5,7 +5,7 @@
     LirContext,
     LirRegistry,
     VizDeclLirSource,
-    type DeclLirNode,
+    type FunDeclLirNode,
     type LirRootType,
   } from '@repo/decision-logic-visualizer'
   import {
@@ -46,7 +46,7 @@
   const context = new LirContext()
   const nodeInfo = { registry: lirRegistry, context }
 
-  let declLirNode: DeclLirNode | undefined = $state(undefined)
+  let declLirNode: FunDeclLirNode | undefined = $state(undefined)
 
   /******************************
       VizInfo Payload Decoder
@@ -266,7 +266,7 @@
                 )
                 logger.debug(
                   'New declLirNode ',
-                  (declLirNode as DeclLirNode).getId().toString()
+                  (declLirNode as FunDeclLirNode).getId().toString()
                 )
               }
               break

--- a/ts-apps/webview/src/routes/+page.svelte
+++ b/ts-apps/webview/src/routes/+page.svelte
@@ -12,7 +12,7 @@
     LirRegistry,
     type LirRootType,
     LadderFlow,
-    type DeclLirNode,
+    type FunDeclLirNode,
     VizDeclLirSource,
   } from '@repo/decision-logic-visualizer'
   import type { WebviewApi } from 'vscode-webview'
@@ -27,7 +27,7 @@
   const context = new LirContext()
   const nodeInfo = { registry: lirRegistry, context }
 
-  let declLirNode: DeclLirNode | undefined = $state(undefined)
+  let declLirNode: FunDeclLirNode | undefined = $state(undefined)
 
   /**************************
         VSCode

--- a/ts-shared/viz-expr/viz-expr.ts
+++ b/ts-shared/viz-expr/viz-expr.ts
@@ -111,8 +111,6 @@ export const IRNode = Schema.Struct({
   Decision Logic (ish) IR node
 ********************************/
 
-export type IRDecl = FunDecl
-
 export interface FunDecl extends IRNode {
   readonly $type: 'FunDecl'
   readonly name: Name
@@ -186,8 +184,6 @@ export const FunDecl = Schema.Struct({
   body: IRExpr,
 }).annotations({ identifier: 'FunDecl' })
 
-export const IRDecl = FunDecl
-
 export const And = Schema.Struct({
   $type: Schema.tag('And'),
   id: IRId,
@@ -229,7 +225,7 @@ export type VisualizeDecisionLogicIRInfo = Schema.Schema.Type<
 >
 
 export const VisualizeDecisionLogicIRInfo = Schema.Struct({
-  program: IRDecl,
+  program: FunDecl,
 }).annotations({ identifier: 'VisualizeDecisionLogicIRInfo' })
 
 /*************************


### PR DESCRIPTION
This PR removes IRDecl, and thereby simplifies the code in the Ladder backend (as well as in the downstream consumers).

Viz still seems to show up.

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/fb7fc9a3-dd2f-44a8-a2fa-64267faeec08" />

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/0f612eb7-7b0a-457d-9c6f-cd34e8ee86fd" />
