### PR TITLE
Viz: Refactor -- Use the ladder nomenclature more consistently (e.g. rename VisualizeDecisionLogicRequest to RenderAsLadder). And related docstring tweaks. 

### DIFF
--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -13,7 +13,7 @@ import Optics.State.Operators ((<%=))
 import L4.Syntax
 import LSP.L4.Viz.VizExpr
   ( ID (..), IRExpr,
-    VisualizeDecisionLogicIRInfo (..),
+    RenderAsLadderInfo (..),
   )
 import qualified LSP.L4.Viz.VizExpr as V
 import L4.Print (prettyLayout)
@@ -65,13 +65,13 @@ prettyPrintVizError = \case
 ------------------------------------------------------
 
 -- | Entrypoint: Generate boolean circuits of the given 'Decide'.
-doVisualize :: Decide Resolved -> Bool -> Either VizError VisualizeDecisionLogicIRInfo
+doVisualize :: Decide Resolved -> Bool -> Either VizError RenderAsLadderInfo
 doVisualize decide simplify =
   case  (vizProgram simplify decide).getVizE initialVizState of
     (result, _) -> result
 
-vizProgram :: Bool -> Decide Resolved -> Viz VisualizeDecisionLogicIRInfo
-vizProgram simplify = fmap MkVisualizeDecisionLogicIRInfo . translateDecide simplify
+vizProgram :: Bool -> Decide Resolved -> Viz RenderAsLadderInfo
+vizProgram simplify = fmap MkRenderAsLadderInfo . translateDecide simplify
 
 ------------------------------------------------------
 -- translateDecide, translateExpr

--- a/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
@@ -10,7 +10,7 @@ import Data.Tuple.Optics
 import GHC.Generics (Generic)
 import Optics
 
-newtype VisualizeDecisionLogicIRInfo = MkVisualizeDecisionLogicIRInfo
+newtype RenderAsLadderInfo = MkRenderAsLadderInfo
   { funDecl :: FunDecl -- TODO: change the fieldname once this becomes more stable
   }
   deriving newtype (Eq)
@@ -117,11 +117,11 @@ instance HasCodec IRExpr where
           <*> requiredField' "name" .= view _2
           <*> requiredField' "value" .= view _3
 
-instance HasCodec VisualizeDecisionLogicIRInfo where
+instance HasCodec RenderAsLadderInfo where
   codec =
-    named "VisualizeDecisionLogicIRInfo" $
-      object "VisualizeDecisionLogicIRInfo" $
-        MkVisualizeDecisionLogicIRInfo
+    named "RenderAsLadderInfo" $
+      object "RenderAsLadderInfo" $
+        MkRenderAsLadderInfo
           <$> requiredField' "funDecl" .= view #funDecl
 
 -------------------------------------------------------------
@@ -137,8 +137,8 @@ deriving via (Autodocodec BoolValue) instance FromJSON BoolValue
 deriving via (Autodocodec IRExpr) instance ToJSON IRExpr
 deriving via (Autodocodec IRExpr) instance FromJSON IRExpr
 
-deriving via (Autodocodec VisualizeDecisionLogicIRInfo) instance ToJSON VisualizeDecisionLogicIRInfo
-deriving via (Autodocodec VisualizeDecisionLogicIRInfo) instance FromJSON VisualizeDecisionLogicIRInfo
+deriving via (Autodocodec RenderAsLadderInfo) instance ToJSON RenderAsLadderInfo
+deriving via (Autodocodec RenderAsLadderInfo) instance FromJSON RenderAsLadderInfo
 
 {-
 Am trying out autodocodec because I wanted to see if

--- a/ts-apps/decision-logic-visualizer/src/routes/+page.svelte
+++ b/ts-apps/decision-logic-visualizer/src/routes/+page.svelte
@@ -174,11 +174,12 @@
   lirRegistry.setRoot(context, 'EXAMPLE_2' as LirRootType, declLirNode2)
 </script>
 
-<h1 class="text-4xl font-bold text-center">Decision Logic Visualizer Draft</h1>
+<h1 class="text-4xl font-bold text-center">Ladder Visualizer demo page</h1>
 <section class="flex items-center justify-center my-8">
   <h2 class="text-2xl italic text-center text-gray-700 w-3/4">
-    Examples of decision logic visualizations, starting from a 'json' of the
-    IRExpr that eventually gets transformed into a SvelteFlow graph
+    Examples of visualizing Boolean formulas as ladder diagrams, starting from a
+    'json' of the IRExpr that eventually gets transformed into a SvelteFlow
+    graph
   </h2>
 </section>
 <section id="example 1" class="example w-3/4 mx-auto space-y-4">

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -8,10 +8,7 @@
     type FunDeclLirNode,
     type LirRootType,
   } from '@repo/decision-logic-visualizer'
-  import {
-    makeVizInfoDecoder,
-    type VisualizeDecisionLogicIRInfo,
-  } from '@repo/viz-expr'
+  import { makeVizInfoDecoder, type RenderAsLadderInfo } from '@repo/viz-expr'
   import {
     type MessageTransports,
     type Middleware,
@@ -46,7 +43,7 @@
   const context = new LirContext()
   const nodeInfo = { registry: lirRegistry, context }
 
-  let declLirNode: FunDeclLirNode | undefined = $state(undefined)
+  let funDeclLirNode: FunDeclLirNode | undefined = $state(undefined)
 
   /******************************
       VizInfo Payload Decoder
@@ -253,20 +250,19 @@
           switch (decoded._tag) {
             case 'Right':
               if (decoded.right) {
-                const vizProgramInfo: VisualizeDecisionLogicIRInfo =
-                  decoded.right
-                declLirNode = VizDeclLirSource.toLir(
+                const ladderInfo: RenderAsLadderInfo = decoded.right
+                funDeclLirNode = VizDeclLirSource.toLir(
                   nodeInfo,
-                  vizProgramInfo.funDecl
+                  ladderInfo.funDecl
                 )
                 lirRegistry.setRoot(
                   context,
-                  'VizDecl' as LirRootType,
-                  declLirNode
+                  'VizFunDecl' as LirRootType,
+                  funDeclLirNode
                 )
                 logger.debug(
                   'New declLirNode ',
-                  (declLirNode as FunDeclLirNode).getId().toString()
+                  (funDeclLirNode as FunDeclLirNode).getId().toString()
                 )
               }
               break
@@ -338,11 +334,11 @@ DECIDE \`is a British citizen (variant)\` IS
   <Resizable.Handle style="width: 10px;" />
   <Resizable.Pane>
     <div id="jl4-webview" class="h-full max-w-[96%] mx-auto bg-white">
-      {#if declLirNode}
+      {#if funDeclLirNode}
         <!-- TODO: Think more about whether to use #key -- which destroys and rebuilds the component --- or have flow-base work with the reactive node prop -->
-        {#key declLirNode}
+        {#key funDeclLirNode}
           <div class="slightly-shorter-than-full-viewport-height pb-1">
-            <LadderFlow {context} node={declLirNode} lir={lirRegistry} />
+            <LadderFlow {context} node={funDeclLirNode} lir={lirRegistry} />
           </div>
         {/key}
       {/if}

--- a/ts-apps/vscode/src/extension.mts
+++ b/ts-apps/vscode/src/extension.mts
@@ -9,9 +9,9 @@ import {
 import type { WebviewTypeMessageParticipant } from 'vscode-messenger-common'
 import { Messenger } from 'vscode-messenger'
 import {
-  VisualizeDecisionLogicIRInfo,
+  RenderAsLadderInfo,
   WebviewFrontendIsReadyNotification,
-  VisualizeDecisionLogicRequest,
+  RenderAsLadder,
 } from '@repo/viz-expr'
 import { Schema } from 'effect'
 // import { cmdViz } from './commands.js'
@@ -19,11 +19,11 @@ import type { PanelConfig } from './viz.js'
 import { PanelManager } from './viz.js'
 
 /***********************************************
-     decode for VisualizeDecisionLogicIRInfo
+     decode for RenderAsLadderInfo
      (aka the payload from lang server)
 ***********************************************/
 
-const decode = Schema.decodeUnknownSync(VisualizeDecisionLogicIRInfo)
+const decode = Schema.decodeUnknownSync(RenderAsLadderInfo)
 
 /***************************************
       Language Client
@@ -107,11 +107,9 @@ export async function activate(context: ExtensionContext) {
             `Received command response ${JSON.stringify(responseFromLangServer)}`
           )
 
-          const vizProgramInfo: VisualizeDecisionLogicIRInfo = decode(
-            responseFromLangServer
-          )
+          const ladderInfo: RenderAsLadderInfo = decode(responseFromLangServer)
 
-          outputChannel.appendLine(JSON.stringify(vizProgramInfo))
+          outputChannel.appendLine(JSON.stringify(ladderInfo))
 
           panelManager.render(context, editor.document.uri)
           webviewMessenger.registerWebviewPanel(panelManager.getPanel())
@@ -127,9 +125,9 @@ export async function activate(context: ExtensionContext) {
           await panelManager.getWebviewFrontendIsReadyPromise()
 
           const response = await webviewMessenger.sendRequest(
-            VisualizeDecisionLogicRequest,
+            RenderAsLadder,
             vizWebviewFrontend,
-            vizProgramInfo
+            ladderInfo
           )
           if (response.$type === 'error') {
             outputChannel.appendLine(`Error in visualisation request`)

--- a/ts-apps/webview/src/routes/+page.svelte
+++ b/ts-apps/webview/src/routes/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import {
-    VisualizeDecisionLogicIRInfo,
-    VisualizeDecisionLogicRequest,
-    makeSuccessVisualizeResponse,
+    RenderAsLadderInfo,
+    RenderAsLadder,
+    makeRenderAsLadderSuccessResponse,
     WebviewFrontendIsReadyNotification,
     type WebviewFrontendIsReadyMessage,
   } from '@repo/viz-expr'
@@ -27,7 +27,7 @@
   const context = new LirContext()
   const nodeInfo = { registry: lirRegistry, context }
 
-  let declLirNode: FunDeclLirNode | undefined = $state(undefined)
+  let funDeclLirNode: FunDeclLirNode | undefined = $state(undefined)
 
   /**************************
         VSCode
@@ -48,24 +48,21 @@
       { $type: 'webviewReady' } as WebviewFrontendIsReadyMessage
     )
 
-    messenger.onRequest(
-      VisualizeDecisionLogicRequest,
-      (payload: VisualizeDecisionLogicIRInfo) => {
-        declLirNode = VizDeclLirSource.toLir(nodeInfo, payload.funDecl)
-        lirRegistry.setRoot(context, 'VizDecl' as LirRootType, declLirNode)
-        return makeSuccessVisualizeResponse()
-      }
-    )
+    messenger.onRequest(RenderAsLadder, (payload: RenderAsLadderInfo) => {
+      funDeclLirNode = VizDeclLirSource.toLir(nodeInfo, payload.funDecl)
+      lirRegistry.setRoot(context, 'VizFunDecl' as LirRootType, funDeclLirNode)
+      return makeRenderAsLadderSuccessResponse()
+    })
 
     messenger.start()
   })
 </script>
 
-{#if declLirNode}
+{#if funDeclLirNode}
   <!-- TODO: Think more about whether to use #key -- which destroys and rebuilds the component --- or have flow-base work with the reactive node prop -->
-  {#key declLirNode}
+  {#key funDeclLirNode}
     <div class="slightly-shorter-than-full-viewport-height">
-      <LadderFlow {context} node={declLirNode} lir={lirRegistry} />
+      <LadderFlow {context} node={funDeclLirNode} lir={lirRegistry} />
     </div>
   {/key}
 {/if}

--- a/ts-shared/viz-expr/README.md
+++ b/ts-shared/viz-expr/README.md
@@ -1,3 +1,3 @@
 # README
 
-The `viz-expr` package contains types/Effect schemas/interfaces and util functions for the data for the decision logic visualizer, as well as for related communication between the extension and webview.
+The `viz-expr` package contains types/Effect schemas/interfaces and util functions for the data for the ladder visualizer, as well as for related communication between the extension and webview.

--- a/ts-shared/viz-expr/message-types.ts
+++ b/ts-shared/viz-expr/message-types.ts
@@ -1,27 +1,29 @@
 import type { NotificationType, RequestType } from 'vscode-messenger-common'
+import { RenderAsLadderInfo } from './viz-expr.js'
 
-import { VisualizeDecisionLogicIRInfo } from './viz-expr.js'
+/*************************************************************
+   Render FunDecl in Ladder Visualizer Request and Response
+                for VSCode Webview
+**************************************************************/
 
-/**
+/** This is the 'please visualize this fun decl' request for the VSCode webview.
  * Using a request so that the extension can know whether the webview received it.
  * See also Wrapper / Protocol interfaces in viz-expr.ts
  */
-export const VisualizeDecisionLogicRequest: RequestType<
-  VisualizeDecisionLogicIRInfo,
-  VisualizeDecisionLogicResponse
+export const RenderAsLadder: RequestType<
+  RenderAsLadderInfo,
+  RenderAsLadderResponse
 > = {
-  method: 'visualizeDecisionLogic',
+  method: 'renderAsLadder',
 }
 
-export type VisualizeDecisionLogicResponse =
-  | { $type: 'ok' }
-  | { $type: 'error' }
+export type RenderAsLadderResponse = { $type: 'ok' } | { $type: 'error' }
 
-export function makeSuccessVisualizeResponse(): VisualizeDecisionLogicResponse {
+export function makeRenderAsLadderSuccessResponse(): RenderAsLadderResponse {
   return { $type: 'ok' }
 }
 
-export function makeFailureVisualizeResponse(): VisualizeDecisionLogicResponse {
+export function makeRenderAsLadderFailureResponse(): RenderAsLadderResponse {
   return { $type: 'error' }
 }
 

--- a/ts-shared/viz-expr/package.json
+++ b/ts-shared/viz-expr/package.json
@@ -2,7 +2,7 @@
   "name": "@repo/viz-expr",
   "version": "1.0.0",
   "private": true,
-  "description": "Types/interfaces and util functions for the data for the decision logic visualizer, as well as for related communication between the extension and webview",
+  "description": "Types/interfaces and util functions for the data for the ladder visualizer, as well as for related communication between the extension and webview",
   "type": "module",
   "exports": {
     ".": "./dist/index.js"

--- a/ts-shared/viz-expr/viz-expr.ts
+++ b/ts-shared/viz-expr/viz-expr.ts
@@ -217,21 +217,19 @@ export const BoolVar = Schema.Struct({
   Wrapper / Protocol interfaces
 ************************************/
 
-/** The payload for VisualizeDecisionLogicNotification */
-export type VisualizeDecisionLogicIRInfo = Schema.Schema.Type<
-  typeof VisualizeDecisionLogicIRInfo
->
+/** The payload for RenderAsLadder */
+export type RenderAsLadderInfo = Schema.Schema.Type<typeof RenderAsLadderInfo>
 
-export const VisualizeDecisionLogicIRInfo = Schema.Struct({
+export const RenderAsLadderInfo = Schema.Struct({
   funDecl: FunDecl,
-}).annotations({ identifier: 'VisualizeDecisionLogicIRInfo' })
+}).annotations({ identifier: 'RenderAsLadderInfo' })
 
 /*************************
     Decode
 **************************/
 
 export function makeVizInfoDecoder() {
-  return Schema.decodeUnknownEither(VisualizeDecisionLogicIRInfo)
+  return Schema.decodeUnknownEither(RenderAsLadderInfo)
 }
 
 /***********************************
@@ -258,15 +256,15 @@ export function makeVizInfoDecoder() {
 **************************/
 
 /** See https://effect.website/docs/schema/pretty/ */
-export function getDecisionLogicIRPrettyPrinter() {
-  return Pretty.make(VisualizeDecisionLogicIRInfo)
+export function getLadderIRPrettyPrinter() {
+  return Pretty.make(RenderAsLadderInfo)
 }
 
-/** Get a JSON Schema version of the VisualizeDecisionLogicIRInfo */
-export function exportDecisionLogicIRInfoToJSONSchema() {
-  return JSON.stringify(JSONSchema.make(VisualizeDecisionLogicIRInfo))
+/** Get a JSON Schema version of the RenderAsLadderInfo */
+export function exportRenderAsLadderInfoToJSONSchema() {
+  return JSON.stringify(JSONSchema.make(RenderAsLadderInfo))
 }
-// console.log(exportDecisionLogicIRInfoToJSONSchema())
+// console.log(exportRenderAsLadderInfoToJSONSchema())
 
 /*************************
     JSON Schema version

--- a/ts-shared/viz-expr/viz-expr.ts
+++ b/ts-shared/viz-expr/viz-expr.ts
@@ -108,7 +108,7 @@ export const IRNode = Schema.Struct({
 })
 
 /*******************************
-  Decision Logic (ish) IR node
+     IR node for Ladder viz
 ********************************/
 
 export interface FunDecl extends IRNode {
@@ -118,9 +118,7 @@ export interface FunDecl extends IRNode {
   readonly body: IRExpr
 }
 
-/** Think of this as the Expr for the decision logic.
- * I.e., the Expr type here will likely be a proper subset of the source language's Expr type.
- */
+/** The Ladder graph visualizer focuses on boolean formulas. */
 export type IRExpr = And | Or | BoolVar | Not
 
 /* Thanks to Andres for pointing out that an n-ary representation would be better for the arguments for And / Or.


### PR DESCRIPTION
Depends on #360 -- please review that first.

- Another quick refactor: move away from the 'decision logic' nomenclature in favor of the 'ladder' nomenclature; also make some of the names less verbose.
- Some related docstring tweaks.
- Add section header to message-types.ts

Viz still seems to work.
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/e482ddd9-f657-4844-a9c5-d4b83f854590" />

<img width="1303" alt="image" src="https://github.com/user-attachments/assets/a5b4ff50-3c6d-4680-89bb-54977c6a008d" />

