### PR TITLE
Viz: Add App variant to IRExpr / VizExpr. For now, translate to IRExpr App on the Ladder backend only if dev mode flag is enabled and the App's function is a function from boolean(s) to a boolean

### DIFF
--- a/jl4-lsp/app/LSP/L4/Handlers.hs
+++ b/jl4-lsp/app/LSP/L4/Handlers.hs
@@ -295,6 +295,11 @@ handlers recorder =
               t False = "Visualize"
               t True  = "Simplify and visualize"
 
+          --  Check if can make viz with a given simplify flag
+          canVisualize decide simplify =
+            let env = Ladder.MkVizEnv (toNormalizedUri uri) typeCheck.substitution simplify
+            in isRight (Ladder.doVisualize decide env)
+
           decideToCodeLens decide =
             -- NOTE: there's a lot of DECIDE/MEANS statements that the visualizer currently doesn't work on
             -- We try to not offer any code lenses for the visualizer if that's the case.
@@ -302,7 +307,8 @@ handlers recorder =
             -- make the visualizer work on as many examples as possible.
             case rangeOfNode decide of
               Just node ->
-                map (mkCodeLens node.start) (filter (isRight . Ladder.doVisualize decide) [False, True])
+                let simplifyFlags = [False, True]
+                in map (mkCodeLens node.start) (filter (canVisualize decide) simplifyFlags)
               Nothing -> []
 
           -- adds codelenses to visualize DECIDE or MEANS clauses

--- a/jl4-lsp/src/LSP/L4/Actions.hs
+++ b/jl4-lsp/src/LSP/L4/Actions.hs
@@ -138,16 +138,17 @@ visualise mtcRes (getRecVis, setRecVis) uri msrcPos = do
 
   case mdecide of
     Nothing -> pure (InR Null)
-    Just (decide, simp, substitution) -> case Ladder.doVisualize decide simp of
-      Right vizProgramInfo -> do
-        traverse_ (lift . setRecVis) $ recentlyVisualisedDecide decide simp substitution
-        pure $ InL $ Aeson.toJSON vizProgramInfo
-      Left vizError ->
-        defaultResponseError $ Text.unlines
-          [ "Could not visualize:"
-          , getUri uri
-          , Ladder.prettyPrintVizError vizError
-          ]
+    Just (decide, simp, substitution) ->
+      case Ladder.doVisualize decide (Ladder.MkVizEnv (toNormalizedUri uri) substitution simp) of
+        Right vizProgramInfo -> do
+          traverse_ (lift . setRecVis) $ recentlyVisualisedDecide decide simp substitution
+          pure $ InL $ Aeson.toJSON vizProgramInfo
+        Left vizError ->
+          defaultResponseError $ Text.unlines
+            [ "Could not visualize:"
+            , getUri uri
+            , Ladder.prettyPrintVizError vizError
+            ]
   where
 
     -- TODO: in the future we want to be a bit more clever wrt. which

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -169,9 +169,9 @@ translateExpr False = go
           leafFromVizName (mkVizNameWith prettyLayout resolved)
 
         App appAnno fnResolved args -> do
-          fnOfAppisFnFromBooleanToBooleans <- and <$> traverse hasBooleanType (appAnno : map getAnno args)
+          fnOfAppIsFnFromBooleansToBoolean <- and <$> traverse hasBooleanType (appAnno : map getAnno args)
           -- for now, only translating App of boolean functions to V.App
-          if isDevMode && fnOfAppisFnFromBooleanToBooleans
+          if isDevMode && fnOfAppIsFnFromBooleansToBoolean
             then
               V.App
                 <$> getFresh

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -44,19 +44,26 @@ data VizState =
     }
   deriving stock (Show, Generic, Eq)
 
-getVizEnv :: Viz VizEnv
-getVizEnv = use #env
-
-getFresh :: Viz ID
-getFresh = do
-  #maxId <%= \(MkID n) -> MkID (n + 1)
-
 mkInitialVizState :: VizEnv -> VizState
 mkInitialVizState env =
   MkVizState
     { env = env
     , maxId = MkID 0
     }
+
+-- Monad ops
+
+getVizEnv :: Viz VizEnv
+getVizEnv = use #env
+
+getExpandedType :: Type' Resolved -> Viz (Type' Resolved)
+getExpandedType ty = do
+  env <- getVizEnv
+  pure $ TC.applyFinalSubstitution env.substitution env.moduleUri ty
+
+getFresh :: Viz ID
+getFresh = do
+  #maxId <%= \(MkID n) -> MkID (n + 1)
 
 ------------------------------------------------------
 -- VizError

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -19,6 +19,11 @@ import qualified LSP.L4.Viz.VizExpr as V
 import L4.Print (prettyLayout)
 import qualified L4.Transform as Transform (simplify)
 
+{- | Temporary hack to disable the translation to IRExpr App
+while the frontend doesn't have proper UI for it -}
+isDevMode :: Bool
+isDevMode = False
+
 ------------------------------------------------------
 -- Monad
 ------------------------------------------------------
@@ -166,7 +171,7 @@ translateExpr False = go
         fnApp@(App _ fnResolved@(getOriginal -> fnName) args) -> do
           fnOfAppisFnFromBooleanToBooleans <- and <$> traverse exprHasBooleanType (fnApp : args)
           -- for now, only translating App of boolean functions to V.App
-          if fnOfAppisFnFromBooleanToBooleans
+          if isDevMode && fnOfAppisFnFromBooleanToBooleans
             then
               V.App
                 <$> getFresh

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -19,8 +19,6 @@ import qualified LSP.L4.Viz.VizExpr as V
 import L4.Print (prettyLayout)
 import qualified L4.Transform as Transform (simplify)
 
--- import Debug.Trace
-
 ------------------------------------------------------
 -- Monad
 ------------------------------------------------------
@@ -120,7 +118,6 @@ vizProgram = fmap MkRenderAsLadderInfo . translateDecide
 -- Simple implementation: Translate Decide iff <= 1 Given
 translateDecide :: Decide Resolved -> Viz V.FunDecl
 translateDecide (MkDecide _ (MkTypeSig _ givenSig _) (MkAppForm _ funResolved _ _) body) =
-  -- traceShow ("decide AST" :: Text, clearAnno dec) $
   do
     vizEnv <- getVizEnv
     uid    <- getFresh
@@ -171,13 +168,11 @@ translateExpr False = go
           -- for now, only translating App of boolean functions to V.App
           if fnOfAppisFnFromBooleanToBooleans
             then
-              -- traceShow ("bf app: \n" :: Text, clearAnno e) $
               V.App
                 <$> getFresh
                 <*> pure (mkVizNameWith nameToText fnResolved)
                 <*> traverse go args
             else
-              -- traceShow ("app not bool: \n" :: Text, clearAnno appType, "\n\nexpr:\n" :: Text, clearAnno e) $
               leaf "" $ Text.unwords (nameToText fnName : (prettyLayout <$> args))
 
         _ -> do

--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -202,7 +202,9 @@ function transform(
     })
     .with({ $type: 'App' }, (app) => {
       console.log('app: \n', app)
-      throw new Error('viz-expr-to-lir: App translation not yet implemented')
+      throw new Error(
+        `viz-expr-to-lir: App translation not yet implemented. ${JSON.stringify(app, undefined, 2)}`
+      )
     })
     .exhaustive()
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -200,5 +200,9 @@ function transform(
 
       return { graph: orGraph, vizExprToLirGraph: newEnv }
     })
+    .with({ $type: 'App' }, (app) => {
+      console.log('app: \n', app)
+      throw new Error('viz-expr-to-lir: App translation not yet implemented')
+    })
     .exhaustive()
 }

--- a/ts-apps/decision-logic-visualizer/src/lib/eval/eval.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/eval/eval.ts
@@ -120,6 +120,9 @@ function eval_(
         intermediate: finalIntermediate,
       }
     })
+    .with({ $type: 'App' }, () => {
+      throw new Error('TODO: Pending integration with backend')
+    })
     .exhaustive()
 }
 

--- a/ts-shared/viz-expr/viz-expr.ts
+++ b/ts-shared/viz-expr/viz-expr.ts
@@ -119,7 +119,7 @@ export interface FunDecl extends IRNode {
 }
 
 /** The Ladder graph visualizer focuses on boolean formulas. */
-export type IRExpr = And | Or | UBoolVar | Not
+export type IRExpr = And | Or | UBoolVar | Not | App
 
 /* Thanks to Andres for pointing out that an n-ary representation would be better for the arguments for And / Or.
 It's one of those things that seems obvious in retrospect; to quote
@@ -152,6 +152,12 @@ export interface Not extends IRNode {
   readonly negand: IRExpr
 }
 
+export interface App extends IRNode {
+  readonly $type: 'App'
+  readonly fnName: Name
+  readonly args: readonly IRExpr[]
+}
+
 /** For the original Viz / IRExpr */
 export type UBoolValue = Schema.Schema.Type<typeof UBoolValue>
 export type BoolValue = Schema.Schema.Type<typeof BoolValue>
@@ -168,8 +174,31 @@ export const IRExpr = Schema.Union(
   Schema.suspend((): Schema.Schema<And> => And),
   Schema.suspend((): Schema.Schema<Or> => Or),
   Schema.suspend((): Schema.Schema<Not> => Not),
-  Schema.suspend((): Schema.Schema<UBoolVar> => UBoolVar)
+  Schema.suspend((): Schema.Schema<UBoolVar> => UBoolVar),
+  Schema.suspend((): Schema.Schema<App> => App)
 ).annotations({ identifier: 'IRExpr' })
+
+export const App = Schema.Struct({
+  $type: Schema.tag('App'),
+  id: IRId,
+  fnName: Name,
+  args: Schema.Array(IRExpr),
+}).annotations({ identifier: 'App' })
+
+// // TODO: Need to look more carefully at L4's NamedExpr
+// export const NamedExpr = Schema.Struct({
+//   $type: Schema.tag('NamedExpr'),
+//   id: IRId,
+//   name: Name,
+//   expr: IRExpr,
+// }).annotations({ identifier: 'NamedExpr' })
+
+// export const AppNamed = Schema.Struct({
+//   $type: Schema.tag('AppNamed'),
+//   id: IRId,
+//   fnName: Name,
+//   args: Schema.Array(NamedExpr),
+// }).annotations({ identifier: 'AppNamed' })
 
 export const FunDecl = Schema.Struct({
   $type: Schema.tag('FunDecl'),


### PR DESCRIPTION
- [x] Add App schema / interface to viz-expr.ts
- [x] Refactor LSP / Ladder backend to pass info like the substitution from TC result and moduleUri along to Ladder backend
- [x] Add App to Ladder backend. For now, translate to IRExpr App only if the App's function is a function from boolean(s) to a boolean.
  - I use the Anno's TypeInfo for this. I'm not sure that's the best way to do it, but it also isn't important to get this right for now, since this is just a temporary restriction.
- [x] Hide the translate-to-App functionality in the Ladder backend under a dev mode flag for the time being (that is by default False). Will add AppLirNode and concrete UI in future PR(s).

If you enable `isDevMode` in Ladder.hs and reinstall the lsp, you'll see a placeholder 'not yet implemented' error for Apps of boolean functions (which demonstrates that the backend is able to pass the right kind of object to the frontend), e.g.

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/dc3ea85f-f595-40cc-8d07-b2e7b1ead14f" />

(Ignore the dots / hats in the buffer in the screenshot --- that's from another vscode extension that I personally use.)
