### PR TITLE
Init `ts-shared/jl4-lsp-client` TS project with `custom-protocol.ts` for our custom LSP extensions (tho currently only contains the `EvalAppRequest` type)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14505,8 +14505,9 @@
       }
     },
     "ts-shared/jl4-lsp-client": {
-      "version": "1.0.0",
+      "version": "0.0.1",
       "dependencies": {
+        "@repo/viz-expr": "*",
         "@types/vscode": "^1.99.1",
         "@typescript-eslint/eslint-plugin": "^8.23.0",
         "ts-pattern": "^5.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5152,10 +5152,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.97.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.97.0.tgz",
-      "integrity": "sha512-ueE73loeOTe7olaVyqP9mrRI54kVPJifUPjblZo9fYcv1CuVLPOEKEkqW0GkqPC454+nCEoigLWnC2Pp7prZ9w==",
-      "dev": true,
+      "version": "1.99.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.99.1.tgz",
+      "integrity": "sha512-cQlqxHZ040ta6ovZXnXRxs3fJiTmlurkIWOfZVcLSZPcm9J4ikFpXuB7gihofGn5ng+kDVma5EmJIclfk0trPQ==",
       "license": "MIT"
     },
     "node_modules/@types/vscode-webview": {
@@ -9186,6 +9185,10 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/jl4-lsp-client": {
+      "resolved": "ts-shared/jl4-lsp-client",
+      "link": true
     },
     "node_modules/jl4-vscode": {
       "resolved": "ts-apps/vscode",
@@ -14499,6 +14502,28 @@
         "globals": "^15.13.0",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.20.0"
+      }
+    },
+    "ts-shared/jl4-lsp-client": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@types/vscode": "^1.99.1",
+        "@typescript-eslint/eslint-plugin": "^8.23.0",
+        "ts-pattern": "^5.6.1",
+        "vscode-languageclient": "^9.0.1"
+      },
+      "devDependencies": {
+        "@repo/eslint-config": "*",
+        "@repo/prettier-config": "*",
+        "eslint": "^9.17.0",
+        "eslint-config-prettier": "^9.1.0",
+        "prettier": "3.4.2",
+        "turbo": "^2.3.3",
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.16.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "ts-shared/prettier-config": {

--- a/ts-shared/jl4-lsp-client/README.md
+++ b/ts-shared/jl4-lsp-client/README.md
@@ -1,0 +1,7 @@
+# JL4 LSP Client
+
+Shared LSP client functionality for JL4 language clients and IDE extensions.
+
+## License
+
+Apache License 2.0

--- a/ts-shared/jl4-lsp-client/custom-protocol.ts
+++ b/ts-shared/jl4-lsp-client/custom-protocol.ts
@@ -2,8 +2,9 @@
  * Custom extensions to the LSP for JL4
  *
  * TODO:
- * - Add the other viz requests (will be done in another PR),
- *   since the intent is to have all the protocol extensions collected here.
+ * - Look into whether shld add the other viz requests here;
+ *   not sure if that'd make sense since the viz stuff is done through commands
+ *   (as opposed to custom methods).
  *
  * Examples of other languages that extend the LSP:
  * - https://github.com/rust-lang/rust-analyzer/blob/master/editors/code/src/lsp_ext.ts

--- a/ts-shared/jl4-lsp-client/custom-protocol.ts
+++ b/ts-shared/jl4-lsp-client/custom-protocol.ts
@@ -4,6 +4,10 @@
  * TODO:
  * - Add the other viz requests (will be done in another PR),
  *   since the intent is to have all the protocol extensions collected here.
+ *
+ * Examples of other languages that extend the LSP:
+ * - https://github.com/rust-lang/rust-analyzer/blob/master/editors/code/src/lsp_ext.ts
+ * - https://github.com/Dart-Code/Dart-Code/blob/master/src/shared/analysis/lsp/custom_protocol.ts
  */
 
 import {

--- a/ts-shared/jl4-lsp-client/custom-protocol.ts
+++ b/ts-shared/jl4-lsp-client/custom-protocol.ts
@@ -10,10 +10,7 @@
  * - https://github.com/Dart-Code/Dart-Code/blob/master/src/shared/analysis/lsp/custom_protocol.ts
  */
 
-import {
-  // NotificationType,
-  RequestType,
-} from 'vscode-languageclient'
+import { RequestType } from 'vscode-languageclient'
 import { EvalAppRequestParams, EvalAppResult } from '@repo/viz-expr'
 
 export type LspResult<T> = T | null
@@ -25,4 +22,4 @@ export const EvalAppRequestType = new RequestType<
   EvalAppRequestParams,
   LspResult<EvalAppResult>,
   void
->('jl4/evalApp')
+>('l4/evalApp')

--- a/ts-shared/jl4-lsp-client/custom-protocol.ts
+++ b/ts-shared/jl4-lsp-client/custom-protocol.ts
@@ -1,0 +1,13 @@
+/**
+ * Custom extensions to the LSP for JL4
+ */
+
+// import {
+//   Location,
+//   NotificationType,
+//   Range,
+//   RequestType,
+//   RequestType0,
+//   TextDocumentPositionParams,
+//   URI,
+// } from 'vscode-languageclient'

--- a/ts-shared/jl4-lsp-client/custom-protocol.ts
+++ b/ts-shared/jl4-lsp-client/custom-protocol.ts
@@ -1,13 +1,24 @@
 /**
  * Custom extensions to the LSP for JL4
+ *
+ * TODO:
+ * - Add the other viz requests (will be done in another PR),
+ *   since the intent is to have all the protocol extensions collected here.
  */
 
-// import {
-//   Location,
-//   NotificationType,
-//   Range,
-//   RequestType,
-//   RequestType0,
-//   TextDocumentPositionParams,
-//   URI,
-// } from 'vscode-languageclient'
+import {
+  // NotificationType,
+  RequestType,
+} from 'vscode-languageclient'
+import { EvalAppParams, EvalAppResult } from '@repo/viz-expr'
+
+export type LspResult<T> = T | null
+
+/**
+ * Request type for evaluating an App expr with actual arguments on the backend
+ */
+export const EvalAppRequestType = new RequestType<
+  EvalAppParams,
+  LspResult<EvalAppResult>,
+  void
+>('jl4/evalApp')

--- a/ts-shared/jl4-lsp-client/custom-protocol.ts
+++ b/ts-shared/jl4-lsp-client/custom-protocol.ts
@@ -10,7 +10,7 @@ import {
   // NotificationType,
   RequestType,
 } from 'vscode-languageclient'
-import { EvalAppParams, EvalAppResult } from '@repo/viz-expr'
+import { EvalAppRequestParams, EvalAppResult } from '@repo/viz-expr'
 
 export type LspResult<T> = T | null
 
@@ -18,7 +18,7 @@ export type LspResult<T> = T | null
  * Request type for evaluating an App expr with actual arguments on the backend
  */
 export const EvalAppRequestType = new RequestType<
-  EvalAppParams,
+  EvalAppRequestParams,
   LspResult<EvalAppResult>,
   void
 >('jl4/evalApp')

--- a/ts-shared/jl4-lsp-client/eslint.config.js
+++ b/ts-shared/jl4-lsp-client/eslint.config.js
@@ -1,0 +1,3 @@
+import { config } from '@repo/eslint-config/base'
+
+export default config

--- a/ts-shared/jl4-lsp-client/index.ts
+++ b/ts-shared/jl4-lsp-client/index.ts
@@ -1,0 +1,2 @@
+// Custom extensions to the LSP for JL4
+export * from './custom-protocol.js'

--- a/ts-shared/jl4-lsp-client/package.json
+++ b/ts-shared/jl4-lsp-client/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "jl4-lsp-client",
+  "version": "1.0.0",
+  "private": true,
+  "description": "LSP client functionality for JL4 that can be used by the various language clients / IDE extensions (e.g. VSCode, Monaco).",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "lint": "eslint --max-warnings=0 .",
+    "lint-fix": "eslint . --fix"
+  },
+  "packageManager": "npm@11.0.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "prettier": "@repo/prettier-config",
+  "devDependencies": {
+    "@repo/eslint-config": "*",
+    "@repo/prettier-config": "*",
+    "eslint": "^9.17.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "3.4.2",
+    "turbo": "^2.3.3",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.16.0"
+  },
+  "dependencies": {
+    "@types/vscode": "^1.99.1",
+    "@typescript-eslint/eslint-plugin": "^8.23.0",
+    "ts-pattern": "^5.6.1",
+    "vscode-languageclient": "^9.0.1"
+  }
+}

--- a/ts-shared/jl4-lsp-client/package.json
+++ b/ts-shared/jl4-lsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jl4-lsp-client",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "LSP client functionality for JL4 that can be used by the various language clients / IDE extensions (e.g. VSCode, Monaco).",
   "type": "module",
@@ -32,6 +32,7 @@
     "typescript-eslint": "^8.16.0"
   },
   "dependencies": {
+    "@repo/viz-expr": "*",
     "@types/vscode": "^1.99.1",
     "@typescript-eslint/eslint-plugin": "^8.23.0",
     "ts-pattern": "^5.6.1",

--- a/ts-shared/jl4-lsp-client/tsconfig.json
+++ b/ts-shared/jl4-lsp-client/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Language and Environment */
+    "target": "ES2020",
+
+    /* Modules */
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+
+    /* Emit */
+    "declaration": true,
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+
+    /* Type Checking */
+    "strict": true,
+
+    /* Completeness */
+    "skipLibCheck": true
+  },
+  "exclude": ["../node_modules/**", "dist"]
+}

--- a/ts-shared/viz-expr/eslint.config.js
+++ b/ts-shared/viz-expr/eslint.config.js
@@ -1,3 +1,3 @@
-import { config } from '@repo/eslint-config/svelte'
+import { config } from '@repo/eslint-config/base'
 
 export default config

--- a/ts-shared/viz-expr/eval-on-backend.ts
+++ b/ts-shared/viz-expr/eval-on-backend.ts
@@ -3,11 +3,11 @@ import { BoolValue, IRId } from './viz-expr.js'
 import { VersionId } from './version-id.js'
 
 /**********************************************
-        Request payload: EvalAppParams
+      Request payload: EvalAppRequestParams
 ***********************************************/
 
-export const EvalAppParams = Schema.Struct({
-  $type: Schema.tag('EvalAppParams'),
+export const EvalAppRequestParams = Schema.Struct({
+  $type: Schema.tag('EvalAppRequestParams'),
   // We can think about batching requests in the future
   appExpr: IRId,
   arguments: Schema.Array(BoolValue).annotations({
@@ -19,12 +19,14 @@ export const EvalAppParams = Schema.Struct({
       'To serve as an independent check that the backend and frontend are talking about the same version of the document / to avoid race conditions.',
   }),
 }).annotations({
-  identifier: 'EvalAppParams',
+  identifier: 'EvalAppRequestParams',
   description:
-    'EvalAppParams is the payload for the request to evaluate an App expr with actual arguments on the backend.',
+    'EvalAppRequestParams is the payload for the request to evaluate an App expr with actual arguments on the backend.',
 })
 
-export type EvalAppParams = Schema.Schema.Type<typeof EvalAppParams>
+export type EvalAppRequestParams = Schema.Schema.Type<
+  typeof EvalAppRequestParams
+>
 
 /**********************************************
         Response payload: EvalAppResult        

--- a/ts-shared/viz-expr/eval-on-backend.ts
+++ b/ts-shared/viz-expr/eval-on-backend.ts
@@ -3,11 +3,11 @@ import { BoolValue, IRId } from './viz-expr.js'
 import { VersionId } from './version-id.js'
 
 /**********************************************
-        Request payload: EvalAppInfo
+        Request payload: EvalAppParams
 ***********************************************/
 
-export const EvalAppInfo = Schema.Struct({
-  $type: Schema.tag('EvalAppInfo'),
+export const EvalAppParams = Schema.Struct({
+  $type: Schema.tag('EvalAppParams'),
   // We can think about batching requests in the future
   appExpr: IRId,
   arguments: Schema.Array(BoolValue).annotations({
@@ -19,12 +19,12 @@ export const EvalAppInfo = Schema.Struct({
       'To serve as an independent check that the backend and frontend are talking about the same version of the document / to avoid race conditions.',
   }),
 }).annotations({
-  identifier: 'EvalAppInfo',
+  identifier: 'EvalAppParams',
   description:
-    'EvalAppInfo is the payload for the request to evaluate an App expr with actual arguments on the backend.',
+    'EvalAppParams is the payload for the request to evaluate an App expr with actual arguments on the backend.',
 })
 
-export type EvalAppInfo = Schema.Schema.Type<typeof EvalAppInfo>
+export type EvalAppParams = Schema.Schema.Type<typeof EvalAppParams>
 
 /**********************************************
         Response payload: EvalAppResult        


### PR DESCRIPTION
Closes #380 

Refactoring:
* Misc refactor: Improve viz-expr project's eslint config (don't need the additional svelte eslint stuff)
* Refactor: Rename `EvalAppInfo` to the more LSP-y `EvalAppRequestParams`

Init a shared LSP client package:
* Init the `ts-shared/jl4-lsp-client` TS project / package, to be used by the various LSP clients / IDE extensions
* Add a `custom-protocol.ts` that's meant to collect all the custom LSP extensions, though for now there's just the `EvalAppRequest` type