### PR TITLE
Refactor extension.mts: Clean up the webview messenger initialization code

### DIFF
--- a/ts-apps/vscode/src/extension.mts
+++ b/ts-apps/vscode/src/extension.mts
@@ -17,7 +17,6 @@ import { VSCodeL4LanguageClient } from './vscode-l4-language-client.js'
 import {
   RenderAsLadder,
   WebviewFrontendIsReadyNotification,
-  // getSendLspClientRequestFromWebview,
 } from 'jl4-client-rpc'
 
 /***********************************************


### PR DESCRIPTION
Quick refactor (the point of this will become clearer when I add more requests...)

The refactor doesn't seem to have broken stuff
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/acf518df-6c10-4cc7-947c-185d10676fc5" />
