### PR TITLE
Client RPC: Add `LadderBackendApi` interface and implementations thereof for vscode webview and jl4-web. Add lsp relay request functionality for vscode x webview. (Issue #387)

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -5,7 +5,7 @@
 <script lang="ts">
   import type { LirId } from '$lib/layout-ir/core.js'
   import { LirContext } from '$lib/layout-ir/core.js'
-  import * as LadderEnv from '$lib/ladder-env.js'
+  import { useLadderEnv } from '$lib/ladder-env.js'
   import dagre from '@dagrejs/dagre'
   import { getLayoutedElements, type DagreConfig } from './layout.js'
   import {
@@ -59,7 +59,8 @@
    * This was just the simpler route given what I already have.
    */
   const funDeclLirNode = node
-  const lir = LadderEnv.getLirRegistry()
+  const ladderEnv = useLadderEnv()
+  const lir = ladderEnv.getLirRegistry()
 
   /***********************************
       SvelteFlow config

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow.svelte
@@ -1,14 +1,11 @@
 <!--
 This is the component that consumers of the DLV lib will import,
-when trying to make ladder diagrams.
-
-This component only exists so that we can put SvelteFlowProvider
- above FlowBase (which uses SF hooks) in the component hierarchy -->
+when trying to make ladder diagrams. -->
 <script lang="ts">
   import { SvelteFlowProvider } from '@xyflow/svelte'
   import type { LadderFlowDisplayerProps } from './flow-props.js'
   import FlowBase from './flow-base.svelte'
-  import { initializeLadderEnv } from '$lib/ladder-env.js'
+  import LadderEnvProvider from '$lib/displayers/ladder-env-provider.svelte'
 
   const {
     context,
@@ -16,15 +13,16 @@ This component only exists so that we can put SvelteFlowProvider
     lir,
   }: LadderFlowDisplayerProps = $props()
 
-  initializeLadderEnv(context, lir, funDeclLirNode)
-
   let baseFlowComponent: ReturnType<typeof FlowBase>
 
   // TODO: Expose a wrapped version of SF's fitView, etc
 </script>
 
+<!-- SvelteFlowProvider supplies SF hooks used by FlowBase -->
 <SvelteFlowProvider>
-  <div style="height: 100%">
-    <FlowBase {context} node={funDeclLirNode} bind:this={baseFlowComponent} />
-  </div>
+  <LadderEnvProvider {context} {lir} node={funDeclLirNode}>
+    <div style="height: 100%">
+      <FlowBase {context} node={funDeclLirNode} bind:this={baseFlowComponent} />
+    </div>
+  </LadderEnvProvider>
 </SvelteFlowProvider>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -6,10 +6,12 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   import { defaultSFHandlesInfo } from '../svelteflow-types.js'
   import { Handle } from '@xyflow/svelte'
   import { cycle } from '$lib/eval/type.js'
-  import { getTopFunDeclLirNode } from '$lib/ladder-env.js'
+  import { useLadderEnv } from '$lib/ladder-env.js'
   let { data }: AppDisplayerProps = $props()
 
-  const ladderGraph = getTopFunDeclLirNode(data.context).getBody(data.context)
+  const ladderGraph = useLadderEnv()
+    .getTopFunDeclLirNode(data.context)
+    .getBody(data.context)
 </script>
 
 <div

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/ladder-env-provider.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/ladder-env-provider.svelte
@@ -1,0 +1,25 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte'
+  import type { LadderFlowDisplayerProps } from './flow/flow-props.js'
+
+  interface LadderEnvProviderProps extends LadderFlowDisplayerProps {
+    children: Snippet
+  }
+</script>
+
+<script lang="ts">
+  import { LadderEnv } from '$lib/ladder-env.js'
+
+  const {
+    context,
+    lir,
+    node: funDeclLirNode,
+    children,
+  }: LadderEnvProviderProps = $props()
+
+  // Initialize the LadderEnv and make it available to children components
+  const ladderEnv = LadderEnv.make(context, lir, funDeclLirNode)
+  ladderEnv.setInSvelteContext()
+</script>
+
+{@render children()}

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
@@ -8,7 +8,6 @@ but this framework is now getting quite different from what it used to be.
 */
 
 import { ComparisonResult } from '../utils.js'
-import { setContext, getContext } from 'svelte'
 
 /*********************************************
        Registry, Top-level Lir
@@ -256,19 +255,4 @@ export interface DisplayerProps {
 export interface RootDisplayerProps extends DisplayerProps {
   /** The root displayer will set the `lir` in the Svelte context so that children displayers can also access it */
   lir: LirRegistry
-}
-
-const lirRegistryKey = 'lirRegistry'
-
-export function setLirRegistryInSvelteContext(
-  lir: ReturnType<typeof getLirRegistryFromSvelteContext>
-) {
-  setContext(lirRegistryKey, lir)
-}
-
-/** This must be called during component initialization
- * since setContext / getContext must be called during component initialization.
- */
-export function getLirRegistryFromSvelteContext(): LirRegistry {
-  return getContext(lirRegistryKey)
 }

--- a/ts-apps/jl4-web/src/lib/ladder-api-for-monaco.ts
+++ b/ts-apps/jl4-web/src/lib/ladder-api-for-monaco.ts
@@ -1,0 +1,21 @@
+import type {
+  L4RpcRequestType,
+  LspResponse,
+  LadderBackendApi,
+} from 'jl4-client-rpc'
+import type { MonacoL4LanguageClient } from '$lib/monaco-l4-language-client'
+
+/** Implementation of {@link LadderBackendApi} that is used by the Monaco/jl4-web version. */
+export class LadderApiForMonaco implements LadderBackendApi {
+  constructor(
+    /** Internal language client for direct communication with the language server */
+    private readonly languageClient: MonacoL4LanguageClient
+  ) {}
+
+  async sendClientRequest<P extends object, R>(
+    type: L4RpcRequestType<P, R>,
+    params: P
+  ): Promise<LspResponse<R>> {
+    return await this.languageClient.sendRequest(type, params)
+  }
+}

--- a/ts-apps/vscode/src/extension.mts
+++ b/ts-apps/vscode/src/extension.mts
@@ -17,6 +17,7 @@ import { VSCodeL4LanguageClient } from './vscode-l4-language-client.js'
 import {
   RenderAsLadder,
   WebviewFrontendIsReadyNotification,
+  makeLspRelayRequestType,
 } from 'jl4-client-rpc'
 
 /***********************************************
@@ -64,6 +65,25 @@ function initializeWebviewMessenger(
     panelManager.markFrontendAsReady()
     outputChannel.appendLine(`Ext: got frontend is ready notification!`)
   })
+
+  // -- Listen for LSP client relay requests from webview
+  webviewMessenger.onRequest(
+    makeLspRelayRequestType<object, unknown>(),
+    async (clientReqParams) => {
+      outputChannel.appendLine(
+        `Ext: Received request from webview: ${JSON.stringify(clientReqParams)}`
+      )
+
+      const response = await client.sendRequest(
+        clientReqParams.requestType,
+        clientReqParams.params
+      )
+      outputChannel.appendLine(
+        `Response from server: ${JSON.stringify(response)}`
+      )
+      return response
+    }
+  )
 
   return webviewMessenger
 }

--- a/ts-apps/webview/src/lib/ladder-api-for-webview.ts
+++ b/ts-apps/webview/src/lib/ladder-api-for-webview.ts
@@ -1,0 +1,27 @@
+import type {
+  L4RpcRequestType,
+  LspResponse,
+  LadderBackendApi,
+} from 'jl4-client-rpc'
+import { makeLspRelayRequestType } from 'jl4-client-rpc'
+import { Messenger } from 'vscode-messenger-webview'
+import { HOST_EXTENSION } from 'vscode-messenger-common'
+
+/** Implementation of {@link LadderBackendApi} that is used by the VSCode webview. */
+export class LadderApiForWebview implements LadderBackendApi {
+  constructor(
+    /** Internal messenger for communication between VSCode extension and webview */
+    private readonly messenger: Messenger
+  ) {}
+
+  async sendClientRequest<P extends object, R>(
+    type: L4RpcRequestType<P, R>,
+    params: P
+  ): Promise<LspResponse<R>> {
+    return await this.messenger.sendRequest(
+      makeLspRelayRequestType<P, R>(),
+      HOST_EXTENSION,
+      { requestType: type, params }
+    )
+  }
+}

--- a/ts-shared/jl4-client-rpc/custom-protocol.ts
+++ b/ts-shared/jl4-client-rpc/custom-protocol.ts
@@ -14,7 +14,7 @@
  * - https://github.com/Dart-Code/Dart-Code/blob/master/src/shared/analysis/lsp/custom_protocol.ts
  */
 
-import { RequestType } from 'vscode-jsonrpc'
+import { NotificationType, RequestType } from 'vscode-jsonrpc'
 import { EvalAppRequestParams, EvalAppResult } from '@repo/viz-expr'
 export { EvalAppRequestParams, EvalAppResult }
 
@@ -22,6 +22,7 @@ export { EvalAppRequestParams, EvalAppResult }
           Protocol Types
 *****************************************/
 
+// Request type
 export type L4RpcRequestType<P extends object, R> = RequestType<P, R, void>
 
 export function makeL4RpcRequestType<P extends object, R>(
@@ -30,7 +31,17 @@ export function makeL4RpcRequestType<P extends object, R>(
   return new RequestType<P, R, void>(method)
 }
 
+// LspResponse
 export type LspResponse<T> = T | null
+
+// Notification type
+export type L4RpcNotificationType<P extends object> = NotificationType<P>
+
+export function makeL4RpcNotificationType<P extends object>(
+  method: string
+): L4RpcNotificationType<P> {
+  return new NotificationType<P>(method)
+}
 
 /****************************************
     Specific protocol extensions

--- a/ts-shared/jl4-client-rpc/index.ts
+++ b/ts-shared/jl4-client-rpc/index.ts
@@ -7,5 +7,8 @@ export * from './language-client.js'
 /* Message types for communication between VSCode extension and webview */
 export * from './vscode-and-webview-messages.js'
 
+// Ladder Backend API
+export * from './ladder-api.js'
+
 // Utils
 export * from './utils.js'

--- a/ts-shared/jl4-client-rpc/ladder-api.ts
+++ b/ts-shared/jl4-client-rpc/ladder-api.ts
@@ -1,0 +1,23 @@
+import type { L4RpcRequestType, LspResponse } from './custom-protocol.js'
+
+/** The interface that the Ladder frontend components
+ * (most proximally, the webview, and the visualizer, indirectly)
+ * use to talk to the Ladder backend */
+export type LadderBackendApi = L4BackendApi
+
+/**
+ * Can think of this as being analogous to Lean's [EditorApi](https://github.com/leanprover/vscode-lean4/blob/44bf3e6ce3a151ab457c061e16be2508066a518d/lean4-infoview-api/src/infoviewApi.ts#L34),
+ * except that we don't put editor stuff here.
+ *
+ * This is a minimal set of lower-level primitives
+ * upon which we can build higher-level interfaces like {@link L4BackendConnection}.
+ */
+interface L4BackendApi {
+  /** Make a request to the LSP server. */
+  sendClientRequest<P extends object, R>(
+    type: L4RpcRequestType<P, R>,
+    params: P
+  ): Promise<LspResponse<R>>
+
+  /* Send a notification to the LSP server. [TODO] */
+}

--- a/ts-shared/jl4-client-rpc/vscode-and-webview-messages.ts
+++ b/ts-shared/jl4-client-rpc/vscode-and-webview-messages.ts
@@ -1,11 +1,17 @@
-import type { L4RpcRequestType } from './custom-protocol.js'
-import { makeL4RpcRequestType } from './custom-protocol.js'
-import type { NotificationType, RequestType } from 'vscode-messenger-common'
+import type {
+  L4RpcRequestType,
+  L4RpcNotificationType,
+} from './custom-protocol.js'
+import {
+  makeL4RpcRequestType,
+  makeL4RpcNotificationType,
+} from './custom-protocol.js'
 import { RenderAsLadderInfo } from '@repo/viz-expr'
+import type { NotificationType, RequestType } from 'vscode-messenger-common'
 
-/*************************************************************
-     Conversion helpers
-**************************************************************/
+/*******************************************************************************
+ Convert between L4 RPC types and vscode-messenger's Request/Notification types
+********************************************************************************/
 
 export function toWebviewMessengerRequestType<P extends object, R>(
   requestType: L4RpcRequestType<P, R>
@@ -21,6 +27,19 @@ export function fromWebviewMessengerRequestType<P extends object, R>(
   return makeL4RpcRequestType(requestType.method)
 }
 
+export function toWebviewMessengerNotificationType<P extends object>(
+  notificationType: L4RpcNotificationType<P>
+): NotificationType<P> {
+  return {
+    method: notificationType.method,
+  }
+}
+
+export function fromWebviewMessengerNotificationType<P extends object>(
+  notificationType: NotificationType<P>
+): L4RpcNotificationType<P> {
+  return makeL4RpcNotificationType(notificationType.method)
+}
 /*************************************************************
    Render FunDecl in Ladder Visualizer Request and Response
                 for VSCode Webview

--- a/ts-shared/jl4-client-rpc/vscode-and-webview-messages.ts
+++ b/ts-shared/jl4-client-rpc/vscode-and-webview-messages.ts
@@ -9,6 +9,68 @@ import {
 import { RenderAsLadderInfo } from '@repo/viz-expr'
 import type { NotificationType, RequestType } from 'vscode-messenger-common'
 
+/*************************************
+  On webview frontend initialization
+**************************************/
+
+export interface WebviewFrontendIsReadyMessage {
+  $type: 'webviewReady'
+}
+
+export const WebviewFrontendIsReadyNotification: NotificationType<WebviewFrontendIsReadyMessage> =
+  {
+    method: 'webviewFrontendIsReady',
+  }
+
+/*************************************************************
+            Render FunDecl in Ladder Visualizer 
+                Request and Response
+                  for VSCode Webview
+**************************************************************/
+
+/** This is the 'please visualize this fun decl' request for the VSCode webview.
+ * Using a request so that the extension can know whether the webview received it.
+ * See also Wrapper / Protocol interfaces in viz-expr.ts
+ */
+export const RenderAsLadder: RequestType<
+  RenderAsLadderInfo,
+  RenderAsLadderResponse
+> = {
+  method: 'renderAsLadder',
+}
+
+export type RenderAsLadderResponse = { $type: 'ok' } | { $type: 'error' }
+
+export function makeRenderAsLadderSuccessResponse(): RenderAsLadderResponse {
+  return { $type: 'ok' }
+}
+
+export function makeRenderAsLadderFailureResponse(): RenderAsLadderResponse {
+  return { $type: 'error' }
+}
+
+/*************************************************************
+            For the vscode Webview to
+            get, via the Ladder Backend API,
+            the VSCode Extension to
+            forward a LSP client request
+**************************************************************/
+
+/** Returns the (vscode-webview-messenger) Request type for webview to get extension to forward a request to the language server. */
+export const makeLspRelayRequestType = <P extends object, R>(): RequestType<
+  ClientRequestParams<P, R>,
+  R
+> => ({
+  method: 'sendClientRequest',
+})
+
+/** Payload for {@link makeLspRelayRequestType}:
+ * contains all the info needed for the extension to send a request to the language server. */
+export interface ClientRequestParams<P extends object, R> {
+  requestType: L4RpcRequestType<P, R>
+  params: P
+}
+
 /*******************************************************************************
  Convert between L4 RPC types and vscode-messenger's Request/Notification types
 ********************************************************************************/
@@ -40,42 +102,3 @@ export function fromWebviewMessengerNotificationType<P extends object>(
 ): L4RpcNotificationType<P> {
   return makeL4RpcNotificationType(notificationType.method)
 }
-
-/*************************************************************
-   Render FunDecl in Ladder Visualizer Request and Response
-                for VSCode Webview
-**************************************************************/
-
-/** This is the 'please visualize this fun decl' request for the VSCode webview.
- * Using a request so that the extension can know whether the webview received it.
- * See also Wrapper / Protocol interfaces in viz-expr.ts
- */
-export const RenderAsLadder: RequestType<
-  RenderAsLadderInfo,
-  RenderAsLadderResponse
-> = {
-  method: 'renderAsLadder',
-}
-
-export type RenderAsLadderResponse = { $type: 'ok' } | { $type: 'error' }
-
-export function makeRenderAsLadderSuccessResponse(): RenderAsLadderResponse {
-  return { $type: 'ok' }
-}
-
-export function makeRenderAsLadderFailureResponse(): RenderAsLadderResponse {
-  return { $type: 'error' }
-}
-
-/*************************************
-  On webview frontend initialization
-**************************************/
-
-export interface WebviewFrontendIsReadyMessage {
-  $type: 'webviewReady'
-}
-
-export const WebviewFrontendIsReadyNotification: NotificationType<WebviewFrontendIsReadyMessage> =
-  {
-    method: 'webviewFrontendIsReady',
-  }

--- a/ts-shared/jl4-client-rpc/vscode-and-webview-messages.ts
+++ b/ts-shared/jl4-client-rpc/vscode-and-webview-messages.ts
@@ -40,13 +40,11 @@ export function fromWebviewMessengerNotificationType<P extends object>(
 ): L4RpcNotificationType<P> {
   return makeL4RpcNotificationType(notificationType.method)
 }
+
 /*************************************************************
    Render FunDecl in Ladder Visualizer Request and Response
                 for VSCode Webview
 **************************************************************/
-
-// TODO: The RenderAsLadder etc types should also use
-// our wrapper L4RpcRequestType type --- that we are using vscode-messenger for commn between webview and extension is an internal implementational detail
 
 /** This is the 'please visualize this fun decl' request for the VSCode webview.
  * Using a request so that the extension can know whether the webview received it.


### PR DESCRIPTION
Depends on #392  -- please review that first

* Add LadderBackendApi interface, and implementations for jl4-web and vscode webview
* vscode-and-webview-messages.ts: Add lsp relay request type (maker) for the vscode webview to get (via the Ladder Backend API) the extension to fire off a lsp client request. Move sections around within file to make things more readable
* VSCode's extension.mts: Add listener for LSP client relay requests from Webview

Misc: Add L4RpcNotificationType for completeness, tho not using that right now