### PR TITLE
Viz: Refactor LadderEnv, to prepare for threading `L4Connection` into the visualizer. Add a LadderEnvProvider component

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -5,7 +5,7 @@
 <script lang="ts">
   import type { LirId } from '$lib/layout-ir/core.js'
   import { LirContext } from '$lib/layout-ir/core.js'
-  import * as LadderEnv from '$lib/ladder-env.js'
+  import { useLadderEnv } from '$lib/ladder-env.js'
   import dagre from '@dagrejs/dagre'
   import { getLayoutedElements, type DagreConfig } from './layout.js'
   import {
@@ -59,7 +59,8 @@
    * This was just the simpler route given what I already have.
    */
   const funDeclLirNode = node
-  const lir = LadderEnv.getLirRegistry()
+  const ladderEnv = useLadderEnv()
+  const lir = ladderEnv.getLirRegistry()
 
   /***********************************
       SvelteFlow config

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow.svelte
@@ -1,14 +1,11 @@
 <!--
 This is the component that consumers of the DLV lib will import,
-when trying to make ladder diagrams.
-
-This component only exists so that we can put SvelteFlowProvider
- above FlowBase (which uses SF hooks) in the component hierarchy -->
+when trying to make ladder diagrams. -->
 <script lang="ts">
   import { SvelteFlowProvider } from '@xyflow/svelte'
   import type { LadderFlowDisplayerProps } from './flow-props.js'
   import FlowBase from './flow-base.svelte'
-  import { initializeLadderEnv } from '$lib/ladder-env.js'
+  import LadderEnvProvider from '$lib/displayers/ladder-env-provider.svelte'
 
   const {
     context,
@@ -16,15 +13,16 @@ This component only exists so that we can put SvelteFlowProvider
     lir,
   }: LadderFlowDisplayerProps = $props()
 
-  initializeLadderEnv(context, lir, funDeclLirNode)
-
   let baseFlowComponent: ReturnType<typeof FlowBase>
 
   // TODO: Expose a wrapped version of SF's fitView, etc
 </script>
 
+<!-- SvelteFlowProvider supplies SF hooks used by FlowBase -->
 <SvelteFlowProvider>
-  <div style="height: 100%">
-    <FlowBase {context} node={funDeclLirNode} bind:this={baseFlowComponent} />
-  </div>
+  <LadderEnvProvider {context} {lir} node={funDeclLirNode}>
+    <div style="height: 100%">
+      <FlowBase {context} node={funDeclLirNode} bind:this={baseFlowComponent} />
+    </div>
+  </LadderEnvProvider>
 </SvelteFlowProvider>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -6,10 +6,12 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   import { defaultSFHandlesInfo } from '../svelteflow-types.js'
   import { Handle } from '@xyflow/svelte'
   import { cycle } from '$lib/eval/type.js'
-  import { getTopFunDeclLirNode } from '$lib/ladder-env.js'
+  import { useLadderEnv } from '$lib/ladder-env.js'
   let { data }: AppDisplayerProps = $props()
 
-  const ladderGraph = getTopFunDeclLirNode(data.context).getBody(data.context)
+  const ladderGraph = useLadderEnv()
+    .getTopFunDeclLirNode(data.context)
+    .getBody(data.context)
 </script>
 
 <div

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/ladder-env-provider.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/ladder-env-provider.svelte
@@ -1,0 +1,25 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte'
+  import type { LadderFlowDisplayerProps } from './flow/flow-props.js'
+
+  interface LadderEnvProviderProps extends LadderFlowDisplayerProps {
+    children: Snippet
+  }
+</script>
+
+<script lang="ts">
+  import { LadderEnv } from '$lib/ladder-env.js'
+
+  const {
+    context,
+    lir,
+    node: funDeclLirNode,
+    children,
+  }: LadderEnvProviderProps = $props()
+
+  // Initialize the LadderEnv and make it available to children components
+  const ladderEnv = LadderEnv.make(context, lir, funDeclLirNode)
+  ladderEnv.setInSvelteContext()
+</script>
+
+{@render children()}

--- a/ts-apps/decision-logic-visualizer/src/lib/ladder-env.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/ladder-env.ts
@@ -19,6 +19,8 @@ export class LadderEnv {
     // Set the top fun decl lir node in Lir Registry
     lirRegistry.setRoot(context, LADDER_VIZ_ROOT_TYPE, funDeclLirNode)
 
+    // Note: Do not store a reference to the LirContext
+
     return new LadderEnv(lirRegistry)
   }
 

--- a/ts-apps/decision-logic-visualizer/src/lib/ladder-env.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/ladder-env.ts
@@ -1,50 +1,62 @@
-/******************************************************************
+/********************************************************************
                 Ladder Env
--------------------------------------------------------------------
-* Stuff for Ladder operations
-  that can be used by components that are children of the component where `initializeLadderEnv` is called.
-* Conceptually similar to an Env for a Reader monad in Haskell.
-*******************************************************************/
+---------------------------------------------------------------------
+Stuff for Ladder operations
+that can be used by components that are children of LadderEnvProvider
+*********************************************************************/
 
 import type { LirContext, LirRegistry, LirRootType } from './layout-ir/core.js'
-import {
-  getLirRegistryFromSvelteContext,
-  setLirRegistryInSvelteContext,
-} from './layout-ir/core.js'
 import type { FunDeclLirNode } from './layout-ir/ladder-graph/ladder.svelte.js'
+import { setContext, getContext } from 'svelte'
+
+export class LadderEnv {
+  /** Initialize the Ladder Env -- which includes setting the fun decl lir node in the Lir Registry */
+  static make(
+    context: LirContext,
+    lirRegistry: LirRegistry,
+    funDeclLirNode: FunDeclLirNode
+  ) {
+    // Set the top fun decl lir node in Lir Registry
+    lirRegistry.setRoot(context, LADDER_VIZ_ROOT_TYPE, funDeclLirNode)
+
+    return new LadderEnv(lirRegistry)
+  }
+
+  private constructor(private readonly lirRegistry: LirRegistry) {}
+
+  getLirRegistry(): LirRegistry {
+    return this.lirRegistry
+  }
+
+  /** Aka: 'get the topmost Decide',
+   * or 'get the root / overall source of the Ladder Lir structure'.
+   */
+  getTopFunDeclLirNode(context: LirContext): FunDeclLirNode {
+    return this.lirRegistry.getRoot(
+      context,
+      LADDER_VIZ_ROOT_TYPE
+    ) as FunDeclLirNode
+  }
+
+  setInSvelteContext() {
+    setContext(ladderEnvKeyForSvelteContext, this)
+  }
+}
+
+/*********************************
+  Ladder Env in Svelte Context
+**********************************/
+
+/** Internal */
+const ladderEnvKeyForSvelteContext = 'ladderEnv'
+
+export function useLadderEnv(): LadderEnv {
+  return getContext(ladderEnvKeyForSvelteContext) as LadderEnv
+}
+
+/*********************************
+      Ladder Viz Root Type
+**********************************/
 
 /** Internal */
 const LADDER_VIZ_ROOT_TYPE: LirRootType = 'VizFunDecl'
-
-/** This is conceptually similar to initializing an Env for a Reader monad,
- * though there isn't an explicit Env type here.
- */
-export function initializeLadderEnv(
-  context: LirContext,
-  lirRegistry: LirRegistry,
-  funDeclLirNode: FunDeclLirNode
-) {
-  /*---- An 'env' of sorts for Lir operations -------*/
-  // Make the Lir Registry available to children components
-  setLirRegistryInSvelteContext(lirRegistry)
-
-  // Similarly with the funDeclLirNode, which is the overall source / root of our Lir structure.
-  lirRegistry.setRoot(context, LADDER_VIZ_ROOT_TYPE, funDeclLirNode)
-
-  // Will add an 'env' for non-Lir stuff in the future (e.g. a logger)
-}
-
-export function getLirRegistry(): LirRegistry {
-  return getLirRegistryFromSvelteContext()
-}
-
-/** Aka: 'get the topmost Decide',
- * or 'get the root / overall source of the Ladder Lir structure'.
- *
- * This assumes that `initializeLadderLirEnv` has already been invoked
- * in a parent component.
- */
-export function getTopFunDeclLirNode(context: LirContext): FunDeclLirNode {
-  const lirRegistry = getLirRegistry()
-  return lirRegistry.getRoot(context, LADDER_VIZ_ROOT_TYPE) as FunDeclLirNode
-}

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/core.ts
@@ -8,7 +8,6 @@ but this framework is now getting quite different from what it used to be.
 */
 
 import { ComparisonResult } from '../utils.js'
-import { setContext, getContext } from 'svelte'
 
 /*********************************************
        Registry, Top-level Lir
@@ -256,19 +255,4 @@ export interface DisplayerProps {
 export interface RootDisplayerProps extends DisplayerProps {
   /** The root displayer will set the `lir` in the Svelte context so that children displayers can also access it */
   lir: LirRegistry
-}
-
-const lirRegistryKey = 'lirRegistry'
-
-export function setLirRegistryInSvelteContext(
-  lir: ReturnType<typeof getLirRegistryFromSvelteContext>
-) {
-  setContext(lirRegistryKey, lir)
-}
-
-/** This must be called during component initialization
- * since setContext / getContext must be called during component initialization.
- */
-export function getLirRegistryFromSvelteContext(): LirRegistry {
-  return getContext(lirRegistryKey)
 }


### PR DESCRIPTION
Depends on #393  -- please review that first

This should be a fairly straightforward refactor. I'll make sure to run it by Jimmy, so no need to worry too much about the Typescript stuff.