### PR TITLE
Client-side RPC refactor for readability

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/l4-connection.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/l4-connection.ts
@@ -14,7 +14,6 @@ export class L4Connection {
     verDocId: EvalAppRequestParams['verDocId']
   ): Promise<EvalAppResult | null> {
     const params: EvalAppRequestParams = {
-      $type: 'EvalAppRequestParams',
       appExpr,
       args,
       verDocId,

--- a/ts-shared/jl4-client-rpc/custom-protocol.ts
+++ b/ts-shared/jl4-client-rpc/custom-protocol.ts
@@ -50,8 +50,7 @@ export function makeL4RpcNotificationType<P extends object>(
 /**
  * Request type for evaluating an App expr with actual arguments on the backend
  */
-export const EvalAppRequestType = new RequestType<
+export const EvalAppRequestType = makeL4RpcRequestType<
   EvalAppRequestParams,
-  LspResponse<EvalAppResult>,
-  void
->('l4/evalApp') as L4RpcRequestType<EvalAppRequestParams, EvalAppResult>
+  EvalAppResult
+>('l4/evalApp')

--- a/ts-shared/jl4-client-rpc/custom-protocol.ts
+++ b/ts-shared/jl4-client-rpc/custom-protocol.ts
@@ -19,7 +19,7 @@ import { EvalAppRequestParams, EvalAppResult } from '@repo/viz-expr'
 export { EvalAppRequestParams, EvalAppResult }
 
 /****************************************
-          Protocol Types
+        L4 RPC Protocol Types
 *****************************************/
 
 // Request type

--- a/ts-shared/viz-expr/eval-on-backend.ts
+++ b/ts-shared/viz-expr/eval-on-backend.ts
@@ -7,7 +7,6 @@ import { VersionedDocId } from './versioned-doc-id.js'
 ***********************************************/
 
 export const EvalAppRequestParams = Schema.Struct({
-  $type: Schema.tag('EvalAppRequestParams'),
   // We can think about batching requests in the future
   appExpr: IRId,
   args: Schema.Array(BoolValue).annotations({


### PR DESCRIPTION
Depends on #398 

Quick refactoring:

- Refactor: Use the `makeL4RpcRequestType` smart ctor for making EvalAppRequestType (forgot to do this before). 
  - Jimmy pointed this out too.
- Refactor: Make section heading more precise
- Refactor: Simplify EvalAppRequestParams: remove the $type tag