### PR TITLE
Implement floating point literals

### DIFF
--- a/jl4-core/jl4-core.cabal
+++ b/jl4-core/jl4-core.cabal
@@ -51,6 +51,7 @@ library
     pretty-simple,
     prettyprinter,
     safe-exceptions,
+    scientific,
     text >= 2 && < 2.1.2,
     tree-diff,
     vector,
@@ -95,3 +96,4 @@ library
     L4.TypeCheck.Unify
     L4.TypeCheck.With
     L4.Utils.RevList
+    L4.Utils.Ratio

--- a/jl4-core/src/L4/Evaluate.hs
+++ b/jl4-core/src/L4/Evaluate.hs
@@ -18,11 +18,13 @@ import qualified Base.Map as Map
 import L4.Annotation
 import L4.Evaluate.Operators
 import L4.Evaluate.Value
+import L4.Evaluate.ValueLazy (UnaryBuiltinFun(..))
 import L4.Parser.SrcSpan (SrcRange)
 import L4.Print
 import L4.Syntax
 import qualified L4.TypeCheck as TypeCheck
 import L4.Utils.RevList
+import L4.Utils.Ratio
 
 import Data.Either
 
@@ -115,6 +117,8 @@ data EvalException =
   | EqualityOnUnsupportedType
   | NonExhaustivePatterns Value -- we could try to warn statically
   | StackOverflow
+  | DivisionByZero
+  | NotAnInteger Rational
   | Stuck
     (Expr Resolved)
     -- ^ the expression we were evaluating when getting stuck
@@ -148,6 +152,12 @@ prettyEvalException = \case
     [ "Stack overflow: "
     , "Recursion depth of " <> Text.show maximumStackSize
     , "exceeded." ]
+  DivisionByZero ->
+    [ "Division by zero"
+    ]
+  NotAnInteger num ->
+    [ "Expected an Integer but got the fractional number: " ]
+    <> [ prettyRatio num ]
   Stuck expr r ->
     [ "Expression stuck while evaluating:" ]
     <> prepare expr
@@ -254,6 +264,10 @@ initialEnvironment =
     [ (TypeCheck.falseUnique, falseVal)
     , (TypeCheck.trueUnique,  trueVal)
     , (TypeCheck.emptyUnique, ValList [])
+    , (TypeCheck.isIntegerUnique, ValUnaryBuiltinFun UnaryIsInteger)
+    , (TypeCheck.roundUnique, ValUnaryBuiltinFun UnaryRound)
+    , (TypeCheck.ceilingUnique, ValUnaryBuiltinFun UnaryCeiling)
+    , (TypeCheck.floorUnique, ValUnaryBuiltinFun UnaryFloor)
     ]
 
 evalModule :: Module Resolved -> Eval ()
@@ -484,6 +498,9 @@ backwardExpr !ss stack0@(App1 n vals [] env stack) val = do
       popFrame val
       env'' <- matchGivens givens (reverse (val : vals)) stack0
       pushExprFrame (Map.union env'' env') (ss - 1) stack e
+    Just (ValUnaryBuiltinFun builtin) -> do
+      popFrame val
+      runBuiltin stack0 (reverse (val : vals)) builtin
     Just (ValUnappliedConstructor r) -> do
       popFrame val
       backwardExpr (ss - 1) stack (ValConstructor r (reverse (val : vals)))
@@ -575,11 +592,18 @@ exception exc _stack = do
   throwError exc
 
 runBinOp :: BinOp -> Value -> Value -> Stack -> Eval Value
-runBinOp BinOpPlus   (ValNumber num1) (ValNumber num2) _stack = pure $ ValNumber (num1 + num2)
-runBinOp BinOpMinus  (ValNumber num1) (ValNumber num2) _stack = pure $ ValNumber (num1 - num2)
-runBinOp BinOpTimes  (ValNumber num1) (ValNumber num2) _stack = pure $ ValNumber (num1 * num2)
-runBinOp BinOpDividedBy (ValNumber num1) (ValNumber num2) _stack = pure $ ValNumber (num1 `div` num2)
-runBinOp BinOpModulo    (ValNumber num1) (ValNumber num2) _stack = pure $ ValNumber (num1 `mod` num2)
+runBinOp BinOpPlus      (ValNumber num1) (ValNumber num2) _stack = pure $ ValNumber (num1 + num2)
+runBinOp BinOpMinus     (ValNumber num1) (ValNumber num2) _stack = pure $ ValNumber (num1 - num2)
+runBinOp BinOpTimes     (ValNumber num1) (ValNumber num2) _stack = pure $ ValNumber (num1 * num2)
+runBinOp BinOpDividedBy (ValNumber num1) (ValNumber num2)  stack
+  | num2 /= 0 = pure $ ValNumber (num1 / num2)
+  | otherwise = exception DivisionByZero stack
+runBinOp BinOpModulo    (ValNumber num1) (ValNumber num2) stack  = do
+  n1 <- expectInteger stack num1
+  n2 <- expectInteger stack num2
+  if n2 /= 0
+    then pure $ ValNumber (toRational $ n1 `mod` n2)
+    else exception DivisionByZero stack
 runBinOp BinOpCons   val1             (ValList val2)   _stack = pure $ ValList (val1 : val2)
 runBinOp BinOpEquals val1             val2             stack  = runBinOpEquals val1 val2 stack
 runBinOp BinOpLeq    (ValNumber num1) (ValNumber num2) _stack = pure $ valBool (num1 <= num2)
@@ -634,6 +658,40 @@ valBool True  = trueVal
 runLit :: Lit -> Eval Value
 runLit (NumericLit _ann num) = pure (ValNumber num)
 runLit (StringLit _ann str)  = pure (ValString str)
+
+runBuiltin :: Stack -> [Value] -> UnaryBuiltinFun -> Eval Value
+runBuiltin s vals op = do
+  val :: Rational <- expect1Number s vals
+  pure case op of
+    UnaryIsInteger -> valBool $ isJust $ isInteger val
+    UnaryRound -> valInt $ round val
+    UnaryCeiling -> valInt $ ceiling val
+    UnaryFloor -> valInt $ floor val
+  where
+    valInt :: Integer -> Value
+    valInt = ValNumber . toRational
+
+expect1 :: Stack -> [a] -> Eval a
+expect1 s = \case
+  [x] -> pure x
+  xs ->
+    exception (RuntimeTypeError $ "Expected 1 argument but got " <> Text.show (length xs)) s
+
+expectNumber :: Stack -> Value -> Eval Rational
+expectNumber s = \case
+  ValNumber f -> pure f
+  _ -> exception (RuntimeTypeError "Expected number.") s
+
+expect1Number :: Stack -> [Value] -> Eval Rational
+expect1Number s vs = do
+  v <- expect1 s vs
+  expectNumber s v
+
+expectInteger :: Stack -> Rational -> Eval Integer
+expectInteger stack n = do
+  case isInteger n of
+    Nothing -> exception (NotAnInteger n) stack
+    Just i -> pure i
 
 lookupTerm :: Environment -> Resolved -> Maybe Value
 lookupTerm env r =

--- a/jl4-core/src/L4/Evaluate/Operators.hs
+++ b/jl4-core/src/L4/Evaluate/Operators.hs
@@ -1,4 +1,6 @@
 module L4.Evaluate.Operators where
+import Base
+import L4.Print
 
 data BinOp =
     BinOpPlus
@@ -12,4 +14,19 @@ data BinOp =
   | BinOpGeq
   | BinOpLt
   | BinOpGt
-  deriving stock Show
+  deriving stock (Show, Generic)
+  deriving anyclass (NFData)
+
+instance LayoutPrinter BinOp where
+  printWithLayout = \case
+    BinOpPlus -> "PLUS"
+    BinOpMinus -> "MINUS"
+    BinOpTimes -> "TIMES"
+    BinOpDividedBy -> "DIVIDED"
+    BinOpModulo -> "MODULO"
+    BinOpCons -> "FOLLOWED BY"
+    BinOpEquals -> "EQUALS"
+    BinOpLeq -> "AT MOST"
+    BinOpGeq -> "AT LEAST"
+    BinOpLt -> "LESS THAN"
+    BinOpGt -> "GREATER THAN"

--- a/jl4-core/src/L4/Evaluate/Value.hs
+++ b/jl4-core/src/L4/Evaluate/Value.hs
@@ -2,14 +2,16 @@ module L4.Evaluate.Value where
 
 import Base
 import L4.Syntax
+import L4.Evaluate.ValueLazy (UnaryBuiltinFun(..))
 
 type Environment = Map Unique Value
 
 data Value =
-    ValNumber Int -- for now
+    ValNumber Rational -- for now
   | ValString Text
   | ValList [Value]
   | ValClosure (GivenSig Resolved) (Expr Resolved) Environment
+  | ValUnaryBuiltinFun UnaryBuiltinFun
   | ValUnappliedConstructor Resolved
   | ValConstructor Resolved [Value]
   | ValAssumed Resolved
@@ -25,8 +27,8 @@ instance NFData Value where
   rnf (ValString t)               = rnf t
   rnf (ValList vs)                = rnf vs
   rnf (ValClosure given expr env) = env `seq` rnf given `seq` rnf expr
+  rnf (ValUnaryBuiltinFun r)      = rnf r
   rnf (ValUnappliedConstructor r) = rnf r
   rnf (ValConstructor r vs)       = rnf r `seq` rnf vs
   rnf (ValAssumed r)              = rnf r
   -- rnf (ValEnvironment env)        = env `seq` ()
-

--- a/jl4-core/src/L4/Evaluate/ValueLazy.hs
+++ b/jl4-core/src/L4/Evaluate/ValueLazy.hs
@@ -38,12 +38,13 @@ data NF = MkNF (Value NF) | ToDeep
   deriving anyclass NFData
 
 data Value a =
-    ValNumber Int -- for now
+    ValNumber Rational
   | ValString Text
   | ValNil
   | ValCons a a
   | ValClosure (GivenSig Resolved) (Expr Resolved) Environment
   | ValObligation Environment MaybeEvaluated MaybeEvaluated (Maybe (Expr Resolved)) (Expr Resolved)
+  | ValUnaryBuiltinFun UnaryBuiltinFun
   | ValUnappliedConstructor Resolved
   | ValConstructor Resolved [a]
   | ValAssumed Resolved
@@ -51,9 +52,16 @@ data Value a =
   | ValBreached (ReasonForBreach a)
   deriving stock (Show, Functor, Foldable, Traversable)
 
-data ReasonForBreach a = DeadlineMissed (Value a) (Value a) (Value a) Int
+data ReasonForBreach a = DeadlineMissed (Value a) (Value a) (Value a) Rational
   deriving stock (Generic, Show, Functor, Foldable, Traversable)
   deriving anyclass NFData
+
+data UnaryBuiltinFun
+  = UnaryIsInteger
+  | UnaryRound
+  | UnaryCeiling
+  | UnaryFloor
+  deriving stock (Show)
 
 -- | This is a non-standard instance because environments can be recursive, hence we must
 -- not actually force the environments ...
@@ -64,6 +72,7 @@ instance NFData a => NFData (Value a) where
   rnf ValNil                      = ()
   rnf (ValCons r1 r2)             = rnf r1 `seq` rnf r2
   rnf (ValClosure given expr env) = env `seq` rnf given `seq` rnf expr
+  rnf (ValUnaryBuiltinFun r)      = rnf r
   rnf (ValUnappliedConstructor r) = rnf r
   rnf (ValConstructor r vs)       = rnf r `seq` rnf vs
   rnf (ValAssumed r)              = rnf r
@@ -74,3 +83,10 @@ instance NFData a => NFData (Value a) where
 type MaybeEvaluated = Either WHNF RExpr
 
 type RExpr = Expr Resolved
+
+instance NFData UnaryBuiltinFun where
+  rnf :: UnaryBuiltinFun -> ()
+  rnf UnaryIsInteger = ()
+  rnf UnaryRound = ()
+  rnf UnaryCeiling = ()
+  rnf UnaryFloor = ()

--- a/jl4-core/src/L4/EvaluateLazy.hs
+++ b/jl4-core/src/L4/EvaluateLazy.hs
@@ -189,6 +189,7 @@ nfAux  d (ValCons r1 r2)             = do
 nfAux _d (ValClosure givens e env)   = pure (MkNF (ValClosure givens e env))
 nfAux _d (ValObligation env party act due followup) = do
   pure (MkNF (ValObligation env party act due followup))
+nfAux _d (ValUnaryBuiltinFun b)      = pure (MkNF (ValUnaryBuiltinFun b))
 nfAux _d (ValUnappliedConstructor n) = pure (MkNF (ValUnappliedConstructor n))
 nfAux  d (ValConstructor n rs)       = do
   vs <- traverse (\ r -> runConfigM (evalRef r) >>= nfAux (d - 1)) rs

--- a/jl4-core/src/L4/Lexer.hs
+++ b/jl4-core/src/L4/Lexer.hs
@@ -10,6 +10,7 @@ import qualified Base.Set as Set
 import qualified Base.Text as Text
 
 import Data.Monoid (Alt (..))
+import qualified Data.Scientific as Sci
 import Data.Char hiding (Space)
 import GHC.Show (showLitString)
 import Text.Megaparsec as Megaparsec
@@ -60,7 +61,8 @@ data DirectiveType
 data TokenType =
     TIdentifier   !Text
   | TQuoted       !Text
-  | TIntLit       !Text !Int
+  | TIntLit       !Text !Integer
+  | TRationalLit  !Text !Rational
   | TStringLit    !Text
   | TDirective    !DirectiveType
     -- copy token / ditto mark, currently '^'
@@ -266,44 +268,73 @@ directives =
   , (TContractDirective,   "CONTRACT")
   ]
 
-integerLiteral :: Lexer (Text, Int)
+integerLiteral :: Lexer (Text, Integer)
 integerLiteral =
       (\ x (xs, i) -> (x <> xs, negate i)) <$> string "-" <*> decimal
   <|> decimal
 
-decimal :: Lexer (Text, Int)
+decimal :: Lexer (Text, Integer)
 decimal = decimal_ <?> "integer"
 
-decimal_ :: Lexer (Text, Int)
+decimal_ :: Lexer (Text, Integer)
 decimal_ = (\ s -> (s, mkNum s)) <$> takeWhile1P (Just "digit") isDigit
   where
-    mkNum :: Text -> Int
+    mkNum :: Text -> Integer
     mkNum = foldl' step 0 . chunkToTokens (Proxy :: Proxy Text)
     step a c = a * 10 + fromIntegral (digitToInt c)
 
+rationalLiteral :: Lexer (Text, Rational)
+rationalLiteral =
+      (\ x (xs, i) -> (x <> xs, negate i)) <$> string "-" <*> floatP
+  <|> floatP
+{-# INLINE rationalLiteral #-}
+
+floatP :: Lexer (Text, Rational)
+floatP = float_ <?> "float"
+{-# INLINE floatP #-}
+
+float_ :: Lexer (Text, Rational)
+float_ = do
+  (t, c') <- decimal_
+  (c, e, t2) <- dotDecimal_ c'
+  pure (t <> "." <> t2, realToFrac $ Sci.scientific c e)
+{-# INLINE float_ #-}
+
+dotDecimal_ :: Integer -> Lexer (Integer, Int, Text)
+dotDecimal_ c' = do
+  void (satisfy (== '.'))
+  let mkNum = foldl' step (c', 0) . chunkToTokens (Proxy :: Proxy Text)
+      step (a, e') c =
+          ( (a * 10 + fromIntegral (digitToInt c))
+          , (e' - 1)
+          )
+  (\ s -> let (c, e) = mkNum s in (c, e, s)) <$> takeWhile1P (Just "digit") isDigit
+{-# INLINE dotDecimal_ #-}
+
 tokenPayload :: Lexer TokenType
 tokenPayload =
-      uncurry TIntLit <$> try integerLiteral
-  <|> TStringLit      <$> stringLiteral
-  <|> TGenitive       <$  string "'s"
-  <|> TQuoted         <$> quoted
-  <|> TDirective      <$> directiveLiteral
-  <|> TRefSrc         <$> refSrcAnnotation
-  <|> TRefMap         <$> refMapAnnotation
-  <|> uncurry TNlg    <$> nlgAnnotation
-  <|> uncurry TRef    <$> refAnnotation
-  <|> TSpace          <$> whitespace
-  <|> TLineComment    <$> lineComment
-  <|> TBlockComment   <$> blockComment
-  <|> TPOpen          <$  char '('
-  <|> TPClose         <$  char ')'
-  <|> TCOpen          <$  char '{'
-  <|> TCClose         <$  char '}'
-  <|> TParagraph      <$  char '§'
-  <|> TComma          <$  char ','
-  <|> TSemicolon      <$  char ';'
-  <|> TDot            <$  char '.'
-  <|> TCopy Nothing   <$  char '^'
+      uncurry TRationalLit <$> try rationalLiteral
+  <|> uncurry TIntLit      <$> try integerLiteral
+  <|> TStringLit           <$> stringLiteral
+  <|> TGenitive            <$  string "'s"
+  <|> TQuoted              <$> quoted
+  <|> TDirective           <$> directiveLiteral
+  <|> TRefSrc              <$> refSrcAnnotation
+  <|> TRefMap              <$> refMapAnnotation
+  <|> uncurry TNlg         <$> nlgAnnotation
+  <|> uncurry TRef         <$> refAnnotation
+  <|> TSpace               <$> whitespace
+  <|> TLineComment         <$> lineComment
+  <|> TBlockComment        <$> blockComment
+  <|> TPOpen               <$  char '('
+  <|> TPClose              <$  char ')'
+  <|> TCOpen               <$  char '{'
+  <|> TCClose              <$  char '}'
+  <|> TParagraph           <$  char '§'
+  <|> TComma               <$  char ','
+  <|> TSemicolon           <$  char ';'
+  <|> TDot                 <$  char '.'
+  <|> TCopy Nothing        <$  char '^'
   <|> symbolic
   <|> identifierOrKeyword
 
@@ -816,111 +847,112 @@ displayPosToken (MkPosToken _r tt) =
 displayTokenType :: TokenType -> Text
 displayTokenType tt =
   case tt of
-    TIdentifier t    -> t
-    TQuoted t        -> "`" <> t <> "`"
-    TIntLit t _i     -> t
-    TStringLit s     -> showStringLit s
-    TDirective d     -> showDirective d
-    TCopy _          -> "^"
-    TPOpen           -> "("
-    TPClose          -> ")"
-    TCOpen           -> "{"
-    TCClose          -> "}"
-    TRefOpen         -> "<<"
-    TRefClose        -> ">>"
-    TNlgOpen         -> "["
-    TNlgClose        -> "]"
-    TParagraph       -> "§"
-    TComma           -> ","
-    TSemicolon       -> ";"
-    TDot             -> "."
-    TGenitive        -> "'s"
-    TTimes           -> "*"
-    TPlus            -> "+"
-    TMinus           -> "-"
-    TGreaterEquals   -> ">="
-    TLessEquals      -> "<="
-    TGreaterThan     -> ">"
-    TLessThan        -> "<"
-    TEquals          -> "="
-    TEqualsEquals    -> "=="
-    TNotEquals       -> "/="
-    TAnd             -> "&&"
-    TOr              -> "||"
-    TImplies         -> "=>"
-    TDividedBy       -> "/"
-    TOtherSymbolic t -> t
-    TKGiven          -> "GIVEN"
-    TKGiveth         -> "GIVETH"
-    TKDecide         -> "DECIDE"
-    TKMeans          -> "MEANS"
-    TKDeclare        -> "DECLARE"
-    TKIf             -> "IF"
-    TKThen           -> "THEN"
-    TKElse           -> "ELSE"
-    TKOtherwise      -> "OTHERWISE"
-    -- TKFalse          -> "FALSE"
-    -- TKTrue           -> "TRUE"
-    TKAnd            -> "AND"
-    TKOr             -> "OR"
-    TKNot            -> "NOT"
-    TKIs             -> "IS"
-    TKHas            -> "HAS"
-    TKOne            -> "ONE"
-    TKOf             -> "OF"
-    TKWith           -> "WITH"
-    TKA              -> "A"
-    TKAn             -> "AN"
-    TKThe            -> "THE"
-    TKYield          -> "YIELD"
-    TKConsider       -> "CONSIDER"
-    TKWhere          -> "WHERE"
-    TKList           -> "LIST"
-    TKAssume         -> "ASSUME"
-    TKWhen           -> "WHEN"
-    TKType           -> "TYPE"
-    TKParty          -> "PARTY"
-    TKDo             -> "DO"
-    TKDoes           -> "DOES"
-    TKMust           -> "MUST"
-    TKWithin         -> "WITHIN"
-    TKHence          -> "HENCE"
-    TKFunction       -> "FUNCTION"
-    TKFrom           -> "FROM"
-    TKTo             -> "TO"
-    TKEquals         -> "EQUALS"
-    TKImplies        -> "IMPLIES"
-    TKPlus           -> "PLUS"
-    TKMinus          -> "MINUS"
-    TKTimes          -> "TIMES"
-    TKDivided        -> "DIVIDED"
-    TKModulo         -> "MODULO"
-    TKBy             -> "BY"
-    TKGreater        -> "GREATER"
-    TKLess           -> "LESS"
-    TKThan           -> "THAN"
-    TKAbove          -> "ABOVE"
-    TKBelow          -> "BELOW"
-    TKAt             -> "AT"
-    TKStarting       -> "STARTING"
-    TKLeast          -> "LEAST"
-    TKMost           -> "MOST"
-    TKFollowed       -> "FOLLOWED"
-    TKFor            -> "FOR"
-    TKAll            -> "ALL"
-    TKAka            -> "AKA"
-    TNlg t ty        -> toNlgAnno t ty
-    TRef t ty        -> toRefAnno t ty
-    TRefSrc t        -> "@ref-src" <> t
-    TRefMap t        -> "@ref-map" <> t
-    TNlgString t     -> t
-    TNlgPrefix       -> "@nlg"
-    TPercent         -> "%"
-    TKImport         -> "IMPORT"
-    TSpace t         -> t
-    TLineComment t   -> t
-    TBlockComment t  -> t
-    EOF              -> ""
+    TIdentifier t     -> t
+    TQuoted t         -> "`" <> t <> "`"
+    TIntLit t _i      -> t
+    TRationalLit t _i -> t
+    TStringLit s      -> showStringLit s
+    TDirective d      -> showDirective d
+    TCopy _           -> "^"
+    TPOpen            -> "("
+    TPClose           -> ")"
+    TCOpen            -> "{"
+    TCClose           -> "}"
+    TRefOpen          -> "<<"
+    TRefClose         -> ">>"
+    TNlgOpen          -> "["
+    TNlgClose         -> "]"
+    TParagraph        -> "§"
+    TComma            -> ","
+    TSemicolon        -> ";"
+    TDot              -> "."
+    TGenitive         -> "'s"
+    TTimes            -> "*"
+    TPlus             -> "+"
+    TMinus            -> "-"
+    TGreaterEquals    -> ">="
+    TLessEquals       -> "<="
+    TGreaterThan      -> ">"
+    TLessThan         -> "<"
+    TEquals           -> "="
+    TEqualsEquals     -> "=="
+    TNotEquals        -> "/="
+    TAnd              -> "&&"
+    TOr               -> "||"
+    TImplies          -> "=>"
+    TDividedBy        -> "/"
+    TOtherSymbolic t  -> t
+    TKGiven           -> "GIVEN"
+    TKGiveth          -> "GIVETH"
+    TKDecide          -> "DECIDE"
+    TKMeans           -> "MEANS"
+    TKDeclare         -> "DECLARE"
+    TKIf              -> "IF"
+    TKThen            -> "THEN"
+    TKElse            -> "ELSE"
+    TKOtherwise       -> "OTHERWISE"
+    -- TKFalse           -> "FALSE"
+    -- TKTrue            -> "TRUE"
+    TKAnd             -> "AND"
+    TKOr              -> "OR"
+    TKNot             -> "NOT"
+    TKIs              -> "IS"
+    TKHas             -> "HAS"
+    TKOne             -> "ONE"
+    TKOf              -> "OF"
+    TKWith            -> "WITH"
+    TKA               -> "A"
+    TKAn              -> "AN"
+    TKThe             -> "THE"
+    TKYield           -> "YIELD"
+    TKConsider        -> "CONSIDER"
+    TKWhere           -> "WHERE"
+    TKList            -> "LIST"
+    TKAssume          -> "ASSUME"
+    TKWhen            -> "WHEN"
+    TKType            -> "TYPE"
+    TKParty           -> "PARTY"
+    TKDo              -> "DO"
+    TKDoes            -> "DOES"
+    TKMust            -> "MUST"
+    TKWithin          -> "WITHIN"
+    TKHence           -> "HENCE"
+    TKFunction        -> "FUNCTION"
+    TKFrom            -> "FROM"
+    TKTo              -> "TO"
+    TKEquals          -> "EQUALS"
+    TKImplies         -> "IMPLIES"
+    TKPlus            -> "PLUS"
+    TKMinus           -> "MINUS"
+    TKTimes           -> "TIMES"
+    TKDivided         -> "DIVIDED"
+    TKModulo          -> "MODULO"
+    TKBy              -> "BY"
+    TKGreater         -> "GREATER"
+    TKLess            -> "LESS"
+    TKThan            -> "THAN"
+    TKAbove           -> "ABOVE"
+    TKBelow           -> "BELOW"
+    TKAt              -> "AT"
+    TKStarting        -> "STARTING"
+    TKLeast           -> "LEAST"
+    TKMost            -> "MOST"
+    TKFollowed        -> "FOLLOWED"
+    TKFor             -> "FOR"
+    TKAll             -> "ALL"
+    TKAka             -> "AKA"
+    TNlg t ty         -> toNlgAnno t ty
+    TRef t ty         -> toRefAnno t ty
+    TRefSrc t         -> "@ref-src" <> t
+    TRefMap t         -> "@ref-map" <> t
+    TNlgString t      -> t
+    TNlgPrefix        -> "@nlg"
+    TPercent          -> "%"
+    TKImport          -> "IMPORT"
+    TSpace t          -> t
+    TLineComment t    -> t
+    TBlockComment t   -> t
+    EOF               -> ""
 
 showDirective :: DirectiveType -> Text
 showDirective = \case
@@ -948,7 +980,8 @@ posTokenCategory =
   \case
     TIdentifier _ -> CIdentifier
     TQuoted _ -> CIdentifier
-    TIntLit _ _ -> CNumberLit
+    TIntLit{} -> CNumberLit
+    TRationalLit{} -> CNumberLit
     TStringLit _ -> CStringLit
     TDirective _ -> CDirective
     TCopy Nothing -> CSymbol

--- a/jl4-core/src/L4/Nlg.hs
+++ b/jl4-core/src/L4/Nlg.hs
@@ -10,6 +10,7 @@ import qualified Base.Text as Text
 import L4.Annotation
 import L4.Lexer (PosToken)
 import L4.Syntax
+import L4.Utils.Ratio (prettyRatio)
 import Optics
 
 -- TODO: I would like to be able to attach meta information and
@@ -259,7 +260,7 @@ instance Linearize (LocalDecl Resolved) where
 
 instance Linearize Lit where
   linearize = \case
-    NumericLit _ num -> text (Text.show num)
+    NumericLit _ num -> text (prettyRatio num)
     StringLit _ t -> text t
 
 instance Linearize (Branch Resolved) where

--- a/jl4-core/src/L4/Parser.hs
+++ b/jl4-core/src/L4/Parser.hs
@@ -1026,7 +1026,7 @@ nameAsApp f =
 
 lit :: Parser (Expr Name)
 lit = attachAnno $
-  Lit emptyAnno <$> annoHole (numericLit <|> stringLit)
+  Lit emptyAnno <$> annoHole (try decimalLit <|> intLit <|> stringLit)
 
 list :: Parser (Expr Name)
 list = do
@@ -1036,11 +1036,17 @@ list = do
       <$  annoLexeme (spacedToken_ TKList)
       <*> annoHole (lsepBy (indentedExpr current) (spacedToken_ TComma))
 
-numericLit :: Parser Lit
-numericLit =
+intLit :: Parser Lit
+intLit =
   attachAnno $
     NumericLit emptyAnno
-      <$> annoEpa (spacedToken (fmap snd <$> preview #_TIntLit) "Numeric Literal")
+      <$> annoEpa (spacedToken (fmap (toRational . snd) <$> preview #_TIntLit) "Numeric Literal")
+
+decimalLit :: Parser Lit
+decimalLit =
+  attachAnno $
+    NumericLit emptyAnno
+      <$> annoEpa (spacedToken (fmap snd <$> preview #_TRationalLit) "Float Literal")
 
 stringLit :: Parser Lit
 stringLit =

--- a/jl4-core/src/L4/Syntax.hs
+++ b/jl4-core/src/L4/Syntax.hs
@@ -234,7 +234,7 @@ data NamedExpr n =
   deriving anyclass (SOP.Generic, ToExpr, NFData)
 
 data Lit =
-    NumericLit Anno Int
+    NumericLit Anno Rational
   | StringLit  Anno Text
   deriving stock (GHC.Generic, Eq, Show)
   deriving anyclass (SOP.Generic, ToExpr, NFData)

--- a/jl4-core/src/L4/TypeCheck/Environment.hs
+++ b/jl4-core/src/L4/TypeCheck/Environment.hs
@@ -29,16 +29,20 @@ mkBuiltins
   , "evalContract"
   , "event"
   , "eventC" `rename` "EVENT"
+  , "isInteger" `rename` "IS INTEGER"
+  , "floor" `rename` "FLOOR"
+  , "ceiling" `rename` "CEILING"
+  , "round" `rename` "ROUND"
   , "a", "b", "c", "d", "g", "h", "i"
   ]
 
 boolean :: Type' Resolved
-boolean = TyApp emptyAnno booleanRef []
+boolean = app booleanRef []
 
 -- NUMBER
 
 number :: Type' Resolved
-number = TyApp emptyAnno numberRef []
+number = app numberRef []
 
 -- STRING
 
@@ -48,7 +52,7 @@ string = TyApp emptyAnno stringRef []
 -- LIST
 
 list :: Type' Resolved -> Type' Resolved
-list a = TyApp emptyAnno listRef [a]
+list a = app listRef [a]
 
 -- CONTRACT
 
@@ -57,6 +61,22 @@ contract party action = TyApp emptyAnno contractRef [party, action]
 
 
 -- infos
+
+-- Number conversion
+
+isInteger :: Type' Resolved
+isInteger = fun_ [number] boolean
+
+roundBuiltin :: Type' Resolved
+roundBuiltin = fun_ [number] number
+
+ceilingBuiltin :: Type' Resolved
+ceilingBuiltin = fun_ [number] number
+
+floorBuiltin :: Type' Resolved
+floorBuiltin = fun_ [number] number
+
+-- Number conversion
 
 booleanInfo :: CheckEntity
 booleanInfo =
@@ -74,6 +94,10 @@ numberInfo :: CheckEntity
 numberInfo =
   KnownType 0 [] Nothing
 
+rationalInfo :: CheckEntity
+rationalInfo =
+  KnownType 0 [] Nothing
+
 stringInfo :: CheckEntity
 stringInfo =
   KnownType 0 [] Nothing
@@ -84,7 +108,25 @@ listInfo =
 
 emptyInfo :: CheckEntity
 emptyInfo =
-  KnownTerm (Forall emptyAnno [aDef] (list (TyApp emptyAnno aRef []))) Constructor
+  KnownTerm (forall' [aDef] (list (app aRef []))) Constructor
+
+-- Number conversion
+
+isIntegerInfo :: CheckEntity
+isIntegerInfo =
+  KnownTerm isInteger Computable
+
+roundInfo :: CheckEntity
+roundInfo =
+  KnownTerm roundBuiltin Computable
+
+ceilingInfo :: CheckEntity
+ceilingInfo =
+  KnownTerm ceilingBuiltin Computable
+
+floorInfo :: CheckEntity
+floorInfo =
+  KnownTerm floorBuiltin Computable
 
 contractInfo :: CheckEntity
 contractInfo =
@@ -131,6 +173,10 @@ initialEnvironment =
     , (NormalName "EVENT",        [eventCUnique      ])
     , (NormalName "EVALCONTRACT", [evalContractUnique])
     , (NormalName "FULFILLED",    [fulfilUnique      ])
+    , (NormalName "IS INTEGER",   [isIntegerUnique ])
+    , (NormalName "ROUND",        [roundUnique     ])
+    , (NormalName "CEILING",      [ceilingUnique   ])
+    , (NormalName "FLOOR",        [floorUnique     ])
     ]
       -- NOTE: we currently do not include the Cons constructor because it has special syntax
 
@@ -149,4 +195,8 @@ initialEntityInfo =
     , (eventCUnique,       (eventCName,       eventCInfo      ))
     , (evalContractUnique, (evalContractName, evalContractInfo))
     , (fulfilUnique,       (fulfilName,       fulfilInfo      ))
+    , (isIntegerUnique,    (isIntegerName,    isIntegerInfo  ))
+    , (roundUnique,        (roundName,        roundInfo       ))
+    , (ceilingUnique,      (ceilingName,      ceilingInfo     ))
+    , (floorUnique,        (floorName,        floorInfo       ))
     ]

--- a/jl4-core/src/L4/Utils/Ratio.hs
+++ b/jl4-core/src/L4/Utils/Ratio.hs
@@ -1,0 +1,17 @@
+module L4.Utils.Ratio (Rational, denominator, numerator, isInteger, prettyRatio) where
+
+import Data.Ratio
+import Base
+import qualified Base.Text as Text
+import qualified Data.Scientific as Sci
+
+isInteger :: Rational -> Maybe Integer
+isInteger r =
+  if denominator r == 1
+    then Just $ numerator r
+    else Nothing
+
+prettyRatio :: Rational -> Text
+prettyRatio r = case isInteger r of
+  Nothing -> Text.pack $ Sci.formatScientific Sci.Fixed Nothing $ Sci.fromFloatDigits (fromRational @Double r)
+  Just i -> Text.show i

--- a/jl4/examples/ok/fib.l4
+++ b/jl4/examples/ok/fib.l4
@@ -16,13 +16,17 @@ DECIDE fibNaive n IS
 
 #EVAL fibNaive 15
 
+GIVEN m IS A NUMBER
+      n IS A NUMBER
+      o IS A NUMBER
+GIVETH A NUMBER
 DECIDE fibHelper m n o IS
   IF o EQUALS 0
     THEN m
     ELSE fibHelper OF
            n
            m PLUS n
-           o MINUS 1 
+           o MINUS 1
 
 DECIDE fib n IS
   fibHelper 0 1 n

--- a/jl4/examples/ok/float.l4
+++ b/jl4/examples/ok/float.l4
@@ -1,0 +1,49 @@
+
+-- Some top level definitions
+pi MEANS 3.14159265358979
+GIVETH A NUMBER
+DECIDE euler IS 2.71828
+DECIDE two IS 2
+
+-- Basic CHECK AND EVAL of NUMBER variables
+#CHECK pi
+#EVAL euler
+#EVAL pi
+#CHECK pi + euler
+#EVAL pi * euler MINUS pi
+#EVAL pi DIVIDED BY euler
+
+-- Division by zero
+#EVAL 5 DIVIDED BY 0.0
+#EVAL 5 DIVIDED BY 0
+
+-- module only works with integers
+#EVAL 10 MODULO 5
+#EVAL 10.0 MODULO 5.0
+#EVAL 0.5 MODULO 5.0
+#EVAL 5.0 MODULO 0.0
+
+-- Equality ad
+#EVAL 5.0 = 5.0
+#EVAL 5.0 = 5
+-- We are using RATIONAL, so we don't suffer from floating point inaccuracies
+#EVAL 0.1 + 0.2
+#EVAL 0.1 + 0.2 = 0.3
+-- We are still printing the full number, and not use scientific notation here
+#EVAL 0.0000001
+
+-- Composite expressions
+#CHECK ROUND pi + FLOOR pi
+#EVAL pi + ROUND pi * pi
+#EVAL FLOOR pi * FLOOR pi
+#EVAL CEILING pi
+
+-- Check whether a number is an integer
+#CHECK `IS INTEGER`
+#EVAL `IS INTEGER` pi
+#EVAL `IS INTEGER` 2
+#EVAL `IS INTEGER` 2.0
+#EVAL `IS INTEGER` 2.00000001
+#EVAL CONSIDER `IS INTEGER` pi
+    WHEN TRUE THEN pi
+    WHEN FALSE THEN 0.1 + 0.2

--- a/jl4/examples/ok/tests/fib.ep.golden
+++ b/jl4/examples/ok/tests/fib.ep.golden
@@ -16,13 +16,17 @@ DECIDE fibNaive n IS
 
 #EVAL fibNaive 15
 
+GIVEN m IS A NUMBER
+      n IS A NUMBER
+      o IS A NUMBER
+GIVETH A NUMBER
 DECIDE fibHelper m n o IS
   IF o EQUALS 0
     THEN m
     ELSE fibHelper OF
            n
            m PLUS n
-           o MINUS 1 
+           o MINUS 1
 
 DECIDE fib n IS
   fibHelper 0 1 n

--- a/jl4/examples/ok/tests/fib.golden
+++ b/jl4/examples/ok/tests/fib.golden
@@ -3,7 +3,7 @@ Typechecking successful
 Evaluation successful
 fib.l4:17:1-18:
   610
-fib.l4:30:1-13:
+fib.l4:34:1-13:
   6765
-fib.l4:31:1-13:
+fib.l4:35:1-13:
   12586269025

--- a/jl4/examples/ok/tests/float.ep.golden
+++ b/jl4/examples/ok/tests/float.ep.golden
@@ -1,0 +1,49 @@
+
+-- Some top level definitions
+pi MEANS 3.14159265358979
+GIVETH A NUMBER
+DECIDE euler IS 2.71828
+DECIDE two IS 2
+
+-- Basic CHECK AND EVAL of NUMBER variables
+#CHECK pi
+#EVAL euler
+#EVAL pi
+#CHECK pi + euler
+#EVAL pi * euler MINUS pi
+#EVAL pi DIVIDED BY euler
+
+-- Division by zero
+#EVAL 5 DIVIDED BY 0.0
+#EVAL 5 DIVIDED BY 0
+
+-- module only works with integers
+#EVAL 10 MODULO 5
+#EVAL 10.0 MODULO 5.0
+#EVAL 0.5 MODULO 5.0
+#EVAL 5.0 MODULO 0.0
+
+-- Equality ad
+#EVAL 5.0 = 5.0
+#EVAL 5.0 = 5
+-- We are using RATIONAL, so we don't suffer from floating point inaccuracies
+#EVAL 0.1 + 0.2
+#EVAL 0.1 + 0.2 = 0.3
+-- We are still printing the full number, and not use scientific notation here
+#EVAL 0.0000001
+
+-- Composite expressions
+#CHECK ROUND pi + FLOOR pi
+#EVAL pi + ROUND pi * pi
+#EVAL FLOOR pi * FLOOR pi
+#EVAL CEILING pi
+
+-- Check whether a number is an integer
+#CHECK `IS INTEGER`
+#EVAL `IS INTEGER` pi
+#EVAL `IS INTEGER` 2
+#EVAL `IS INTEGER` 2.0
+#EVAL `IS INTEGER` 2.00000001
+#EVAL CONSIDER `IS INTEGER` pi
+    WHEN TRUE THEN pi
+    WHEN FALSE THEN 0.1 + 0.2

--- a/jl4/examples/ok/tests/float.golden
+++ b/jl4/examples/ok/tests/float.golden
@@ -1,0 +1,63 @@
+Parsing successful
+Typechecking successful
+Evaluation successful
+float.l4:9:8-10:
+  NUMBER
+float.l4:10:1-12:
+  2.71828
+float.l4:11:1-9:
+  3.14159265358979
+float.l4:12:8-18:
+  NUMBER
+float.l4:13:1-26:
+  5.398135824810264
+float.l4:14:1-26:
+  1.1557281271943252
+float.l4:17:1-23:
+  Division by zero in the operation:
+  DIVIDED
+float.l4:18:1-21:
+  Division by zero in the operation:
+  DIVIDED
+float.l4:21:1-18:
+  0
+float.l4:22:1-22:
+  0
+float.l4:23:1-21:
+  Expected an Integer but got the fractional number: 
+  0.5
+  During the evaluation of the operation:
+  MODULO
+float.l4:24:1-21:
+  Division by zero in the operation:
+  MODULO
+float.l4:27:1-16:
+  TRUE
+float.l4:28:1-14:
+  TRUE
+float.l4:30:1-16:
+  0.3
+float.l4:31:1-22:
+  TRUE
+float.l4:33:1-16:
+  0.0000001
+float.l4:36:8-27:
+  NUMBER
+float.l4:37:1-25:
+  12.56637061435916
+float.l4:38:1-26:
+  9
+float.l4:39:1-17:
+  4
+float.l4:42:8-20:
+  FUNCTION FROM NUMBER TO BOOLEAN
+float.l4:43:1-22:
+  FALSE
+float.l4:44:1-21:
+  TRUE
+float.l4:45:1-23:
+  TRUE
+float.l4:46:1-30:
+  FALSE
+float.l4:47:1-49:30:
+  0.3

--- a/jl4/examples/ok/tests/float.nlg.golden
+++ b/jl4/examples/ok/tests/float.nlg.golden
@@ -1,0 +1,27 @@
+`pi`
+`euler`
+`pi`
+the sum of `pi` and `euler`
+the difference between `pi` and the product of `pi` and `euler`
+the result of dividing `pi` by `euler`
+the result of dividing 5 by 0
+the result of dividing 5 by 0
+the result of 10 modulo 5
+the result of 10 modulo 5
+the result of 0.5 modulo 5
+the result of 5 modulo 0
+5 is equal to 5
+5 is equal to 5
+the sum of 0.1 and 0.2
+the sum of 0.1 and 0.2 is equal to 0.3
+0.0000001
+the sum of `ROUND` with `pi` and `FLOOR` with `pi`
+the sum of `pi` and the product of `ROUND` with `pi` and `pi`
+the product of `FLOOR` with `pi` and `FLOOR` with `pi`
+`CEILING` with `pi`
+`IS INTEGER`
+`IS INTEGER` with `pi`
+`IS INTEGER` with 2
+`IS INTEGER` with 2
+`IS INTEGER` with 2.00000001
+consider the case distinctions of `IS INTEGER` with `pi` :  when `TRUE` has  then `pi`. when `FALSE` has  then the sum of 0.1 and 0.2


### PR DESCRIPTION
We change the 'NUMBER' type to work with rational numbers instead of only integers.
This allows us to use floating point literals, such as `2.0`, and `2.3`, and we still support integer literals, e.g. `1`, `2`.

Since 'NUMBER' is now backed by `Rational`, we cannot represent irrational numbers accurately, but at least to some approximation. The advantage of `Rational` over `Double` is that we do not suffer from IEEE decisions, such as `1.0 / 0.0 = NaN` (or `NaN` in general) and the usual floating point inaccuracies such as `0.1 + 0.2 = 0.3` is indeed `TRUE` in L4.

We introduce the following functions for working with 'NUMBER'

* '`IS INTEGER'`: returns 'TRUE' iff the number is an integer
* 'ROUND': rounds to the closest whole integer
* 'FLOOR': truncates to the next smallest integer
* 'CEILING': increases to the next largest integer

These functions are all built-in into the typechecker and evaluator.

Many other useful utility can be added in user-land or added to the evaluator on a by-need basis.

Implementation wise, most of the patch is rather straight forward, we introduce a new TokenType 'TFloatLit' which parses numbers such as '2.0' and '1.23456789'.
All 'NUMBER's are now 'Rational', so 'TIntLit' is also converted to 'Rational' during parsing, which is a lossless operation.

In the typechecker, we introduce the new built-in functions, which is mostly boilerplate.

Similarly in the evaluator, we provide the implementations for the built-in functions.

Bug fixes included in this patch that are not 100% related to the feature itself:

* Division by zero throws an exception instead of halting the language server
* Module by zero throws an exception instead of halting the langauge server

Closes #343 