### PR TITLE
Quick ladder fixes

### DIFF
--- a/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
@@ -13,7 +13,7 @@ import Optics
 import qualified Language.LSP.Protocol.Types as LSP
 
 data RenderAsLadderInfo = MkRenderAsLadderInfo
-  { verTextDocId :: LSP.VersionedTextDocumentIdentifier
+  { verDocId :: LSP.VersionedTextDocumentIdentifier
   , funDecl      :: FunDecl
   }
   deriving stock (Show, Generic, Eq)
@@ -135,8 +135,8 @@ instance HasCodec RenderAsLadderInfo where
     named "RenderAsLadderInfo" $
       object "RenderAsLadderInfo" $
         MkRenderAsLadderInfo
-          <$> requiredField' "verTextDocId" .= view #verTextDocId
-          <*> requiredField' "funDecl"      .= view #funDecl
+          <$> requiredField' "verDocId" .= view #verDocId
+          <*> requiredField' "funDecl"  .= view #funDecl
 
 instance HasCodec LSP.VersionedTextDocumentIdentifier where
   codec = codecViaAeson "VersionedTextDocumentIdentifier"

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -165,14 +165,14 @@
   ***************************************/
 
   // TODO: prob better to put this in ubool-var.svelte.ts
-  const onBoolVarNodeClick: SF.NodeEventWithPointer<MouseEvent | TouchEvent> = (
-    event
-  ) => {
+  const onBoolVarNodeClick: SF.NodeEventWithPointer<
+    MouseEvent | TouchEvent
+  > = async (event) => {
     const lirId = sfNodeToLirId(event.node as LadderSFNode)
     const varNode = context.get(lirId) as UBoolVarLirNode
 
     const newValue = cycle(varNode.getValue(context))
-    ladderGraph.submitNewBinding(context, {
+    await ladderGraph.submitNewBinding(context, {
       unique: varNode.getUnique(context),
       value: newValue,
     })

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -43,11 +43,11 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
             'rounded-lg',
             ...arg.getAllClasses(data.context),
           ]}
-          onclick={() => {
+          onclick={async () => {
             console.log('clicked: ', arg.getLabel(data.context), arg.getId())
 
             const newValue = cycle(arg.getValue(data.context))
-            ladderGraph.submitNewBinding(data.context, {
+            await ladderGraph.submitNewBinding(data.context, {
               unique: arg.getUnique(data.context),
               value: newValue,
             })

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
@@ -544,7 +544,7 @@ export class LadderGraphLirNode extends DefaultLirNode implements LirNode {
     )
     this.setEvalResult(context, result)
 
-    console.log('evaluating ', this.#bindings)
+    console.log('evaluating ', this.#bindings.getEntries())
     console.log('whatif eval result: ', result)
   }
 

--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -270,7 +270,7 @@
                 const backendApi = new LadderApiForMonaco(monacoL4LangClient)
                 ladderEnv = LadderEnv.make(
                   lirRegistry,
-                  renderLadderInfo.verTextDocId,
+                  renderLadderInfo.verDocId,
                   backendApi
                 )
 

--- a/ts-apps/webview/src/routes/+page.svelte
+++ b/ts-apps/webview/src/routes/+page.svelte
@@ -85,7 +85,7 @@
         const backendApi = new LadderApiForWebview(messenger)
         const ladderEnv = LadderEnv.make(
           lirRegistry,
-          renderLadderInfo.verTextDocId,
+          renderLadderInfo.verDocId,
           backendApi
         )
         renderLadderPromise = makeFunDeclLirNodeAndSetLirRoot(

--- a/ts-shared/viz-expr/viz-expr.ts
+++ b/ts-shared/viz-expr/viz-expr.ts
@@ -248,7 +248,7 @@ export const UBoolVar = Schema.Struct({
 export type RenderAsLadderInfo = Schema.Schema.Type<typeof RenderAsLadderInfo>
 
 export const RenderAsLadderInfo = Schema.Struct({
-  verTextDocId: VersionedDocId,
+  verDocId: VersionedDocId,
   funDecl: FunDecl,
 }).annotations({ identifier: 'RenderAsLadderInfo' })
 


### PR DESCRIPTION
* Standardize on `verDocId` fieldname
* TS infra: Improve logging of user's bindings / assignment when calling frontend eval's
* Viz: Add some async/awaits that I had missed