### PR TITLE
refactor the evaluator to use an explicit monad and configurations for mutual recursion

### DIFF
--- a/jl4-core/jl4-core.cabal
+++ b/jl4-core/jl4-core.cabal
@@ -73,6 +73,7 @@ library
     L4.Evaluate.Value
     L4.Evaluate.ValueLazy
     L4.EvaluateLazy
+    L4.EvaluateLazy.Machine
     L4.EvaluateLazy.ContractFrame
     L4.ExactPrint
     L4.FindDefinition

--- a/jl4-core/src/L4/EvaluateLazy.hs
+++ b/jl4-core/src/L4/EvaluateLazy.hs
@@ -1,32 +1,23 @@
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE GADTs #-}
 module L4.EvaluateLazy
-  ( EvalDirectiveResult(..)
-  , execEvalModuleWithEnv
-  , prettyEvalException
-  , contractToEvalDirective
-  )
-  where
+( EvalDirectiveResult (..)
+, execEvalModuleWithEnv
+, prettyEvalException
+)
+where
 
 import Base
-import qualified Base.Text as Text
 import qualified Base.Map as Map
 import qualified Base.Set as Set
+import L4.EvaluateLazy.Machine
 import Control.Concurrent
-import L4.Annotation
-import L4.Evaluate.Operators
 import L4.Evaluate.ValueLazy
 import L4.Parser.SrcSpan (SrcRange)
-import L4.Print
 import L4.Syntax
-import qualified L4.TypeCheck as TypeCheck
-import L4.EvaluateLazy.ContractFrame
 
-newtype Eval a = MkEval (EvalState -> IO (Either EvalException a))
-  deriving (Functor, Applicative, Monad, MonadError EvalException, MonadReader EvalState, MonadIO)
-    via ExceptT EvalException (ReaderT EvalState IO)
-
+-----------------------------------------------------------------------------
+-- The Eval monad and the required types for the monad
+-----------------------------------------------------------------------------
 data EvalState =
   MkEvalState
     { moduleUri :: !NormalizedUri
@@ -34,110 +25,13 @@ data EvalState =
     , supply    :: !(IORef Int)   -- used for uniques and addresses
     }
 
-data EvalException =
-    InternalEvalException InternalEvalException
-  | UserEvalException UserEvalException
-  deriving stock (Generic, Show)
-  deriving anyclass NFData
+newtype Eval a = MkEval (EvalState -> IO (Either EvalException a))
+  deriving (Functor, Applicative, Monad, MonadError EvalException, MonadReader EvalState, MonadIO)
+    via ExceptT EvalException (ReaderT EvalState IO)
 
-data InternalEvalException =
-    RuntimeScopeError Resolved -- internal
-  | RuntimeTypeError Text -- internal
-  | PrematureGC -- internal
-  | DanglingPointer -- internal
-  | UnhandledPatternMatch -- internal
-  deriving stock (Generic, Show)
-  deriving anyclass NFData
-
-data UserEvalException =
-    BlackholeForced (Expr Resolved)
-  | EqualityOnUnsupportedType
-  | NonExhaustivePatterns Reference -- we could try to warn statically
-  | StackOverflow
-  | Stuck Resolved -- ^ stores the term we got stuck on
-  deriving stock (Generic, Show)
-  deriving anyclass NFData
-
-prettyEvalException :: EvalException -> [Text]
-prettyEvalException (InternalEvalException exc) = wrapInternal (prettyInternalEvalException exc)
-  where
-    wrapInternal :: [Text] -> [Text]
-    wrapInternal msgs = [ "Internal error:" ] <> msgs <> [ "Please report this as a bug." ]
-prettyEvalException (UserEvalException exc)     = prettyUserEvalException exc
-
-prettyInternalEvalException :: InternalEvalException -> [Text]
-prettyInternalEvalException = \case
-  RuntimeScopeError r ->
-    indentMany r
-    <> [ "is not in scope." ]
-  RuntimeTypeError err ->
-    [ "I encountered a type error during evaluation:" ]
-    <> [ indentSingle err ]
-  PrematureGC ->
-    [ "Trying to access an address that has already been garbage-collected." ]
-  DanglingPointer ->
-    [ "Trying to access an address that is not on the abstract machine heap." ]
-  UnhandledPatternMatch ->
-    [ "Unhandled pattern match failure." ]
-
-indentSingle :: Text -> Text
-indentSingle = ("  " <>)
-
-indentMany :: LayoutPrinter a => a -> [Text]
-indentMany = map ind . Text.lines .  prettyLayout
-  where
-    ind = ("  " <>)
-
-prettyUserEvalException :: UserEvalException -> [Text]
-prettyUserEvalException = \case
-  BlackholeForced expr ->
-    [ "Infinite loop detected while trying to evaluate:"
-    , prettyLayout expr ]
-  EqualityOnUnsupportedType -> ["Trying to check equality on types that do not support it."]
-  NonExhaustivePatterns val ->
-    [ "Value" ]
-    <> indentMany val
-    <> [ "has no corresponding pattern." ]
-  StackOverflow ->
-    [ "Stack overflow: "
-    , "Recursion depth of " <> Text.show maximumStackSize
-    , "exceeded." ]
-  Stuck r ->
-    [ "I could not continue evaluating, because I needed to know the value of" ]
-    <> indentMany r
-    <> [ "but it is an assumed term." ]
-
-emptyEnvironment :: Environment
-emptyEnvironment = Map.empty
-
-data Stack =
-  MkStack
-    { size   :: !Int
-    , frames :: [Frame]
-    }
-  deriving stock (Generic, Show)
-
-emptyStack :: Stack
-emptyStack = MkStack 0 []
-
-data Frame =
-    BinOp1 BinOp {- -} (Expr Resolved) Environment
-  | BinOp2 BinOp WHNF {- -}
-  | App1 {- -} [Reference]
-  | IfThenElse1 {- -} (Expr Resolved) (Expr Resolved) Environment
-  | ConsiderWhen1 Reference {- -} (Expr Resolved) [Branch Resolved] Environment
-  | PatNil0
-  | PatCons0 (Pattern Resolved) (Pattern Resolved)
-  | PatCons1 {- -} Reference (Pattern Resolved)
-  | PatCons2 Environment {- -}
-  | PatApp0 Resolved [Pattern Resolved]
-  | PatApp1 [Environment] {- -} [(Reference, Pattern Resolved)]
-  | EqConstructor1 {- -} Reference [(Reference, Reference)]
-  | EqConstructor2 WHNF {- -} [(Reference, Reference)]
-  | EqConstructor3 {- -} [(Reference, Reference)]
-  | UpdateThunk Reference
-  | ContractFrame ContractFrame
-  deriving stock Show
+-----------------------------------------------------------------------------
+-- Helper functions for the Eval Monad
+-----------------------------------------------------------------------------
 
 step :: Eval Int
 step = do
@@ -151,18 +45,6 @@ newUnique = do
   u <- asks (.moduleUri)
   pure (MkUnique 'e' i u)
 
-def :: Name -> Eval Resolved
-def n = do
-  u <- newUnique
-  pure (Def u n)
-
-ref :: Name -> Resolved -> Eval Resolved
-ref n a =
-  let
-    (u, o) = getUniqueName a
-  in
-    pure (Ref n u o)
-
 readRef :: (EvalState -> IORef a) -> Eval a
 readRef r = asks r >>= liftIO . readIORef
 
@@ -173,7 +55,7 @@ pushFrame :: Frame -> Eval ()
 pushFrame frame = do
   s <- readRef (.stack)
   if s.size == maximumStackSize
-    then userException StackOverflow
+    then exception $ UserEvalException StackOverflow
     else writeRef (.stack) (over #frames (frame :) s)
 
 -- | Pops a stack frame (if any are left) and calls the continuation on it.
@@ -186,14 +68,6 @@ withPoppedFrame k = do
       writeRef (.stack) (MkStack { size = stack.size - 1, frames = fs })
       k (Just f)
 
-internalException :: InternalEvalException -> Eval a
-internalException =
-  exception . InternalEvalException
-
-userException :: UserEvalException -> Eval a
-userException =
-  exception . UserEvalException
-
 -- | For the time being, exceptions are always fatal. But we could
 -- in principle have exception we can recover from ...
 exception :: EvalException -> Eval a
@@ -203,68 +77,15 @@ exception exc =
     Just _f -> exception exc
 
 tryEval :: Eval a -> Eval (Either EvalException a)
-tryEval m =
-  tryError m
+tryEval = tryError
 
-stuckOnAssumed :: Resolved -> Eval b
-stuckOnAssumed assumedResolved =
-  userException (Stuck assumedResolved)
-
-maximumStackSize :: Int
-maximumStackSize = 200
-
-lookupTerm :: Environment -> Resolved -> Maybe Reference
-lookupTerm env r =
-  Map.lookup (getUnique r) env
-
-expectTerm :: Environment -> Resolved -> Eval Reference
-expectTerm env r =
-  case lookupTerm env r of
-    Nothing -> internalException (RuntimeScopeError r)
-    Just rf -> pure rf
-
--- NOTE: Modifications of thunks should probably be atomic,
--- because they could be updated concurrently from different
--- modules.
 lookupAndUpdateRef :: Reference -> (Thunk -> (Thunk, a)) -> Eval a
 lookupAndUpdateRef rf f =
   liftIO $
     atomicModifyIORef' rf.pointer f
 
-updateThunk :: Reference -> Thunk -> Eval ()
-updateThunk rf thunk = do
-  liftIO (atomicWriteIORef rf.pointer $! thunk)
-
-updateThunkToWHNF :: Reference -> WHNF -> Eval ()
-updateThunkToWHNF rf v =
-  updateThunk rf (WHNF v)
-
--- NOTE: Once we start evaluating a thunk, we store the (Haskell) thread
--- that does so. If we encounter a thunk with such an entry created by
--- ourselves, we treat it as a blackhole: we tried to evaluate the thunk
--- again recursively, which means we're in a loop. If the evaluation was
--- triggered by a different thread though (in our case, this basically
--- means from a different module, then it's not necessarily a loop. We could
--- just wait (which is what GHC does), but we just try to evaluate it as
--- well, which should be benign.
-evalRef :: Reference -> Eval WHNF
-evalRef rf = do
-  tid <- liftIO myThreadId
-  join $ lookupAndUpdateRef rf $ \ case
-    thunk@(WHNF val) -> (thunk, backward val)
-    thunk@(Unevaluated tids e env)
-      | tid `Set.member` tids -> (thunk, userException $ BlackholeForced e)
-      | otherwise             -> (Unevaluated (Set.insert tid tids) e env, pushFrame (UpdateThunk rf) >> forwardExpr env e)
-
-newAddress :: Eval Address
-newAddress = do
-  i <- step
-  u <- asks (.moduleUri)
-  pure (MkAddress u i)
-
-blackhole :: ThreadId -> Thunk
-blackhole tid =
-  Unevaluated (Set.singleton tid) (error "blackhole") Map.empty
+updateRef :: Reference -> Thunk -> Eval ()
+updateRef rf a = lookupAndUpdateRef rf $ const (a, ())
 
 newReference :: Eval Reference
 newReference = do
@@ -272,694 +93,85 @@ newReference = do
   reference <- liftIO (myThreadId >>= newIORef . blackhole)
   pure (MkReference address reference)
 
--- | Recursive pre-allocation, used for mutually recursive let-bindings / declarations.
-preAllocate :: [Resolved] -> Eval Environment
-preAllocate ns = do
-  pairs <- traverse (\ r -> do
-      let u = getUnique r
+blackhole :: ThreadId -> Thunk
+blackhole tid =
+  Unevaluated (Set.singleton tid) (error "blackhole") Map.empty
+
+
+
+-----------------------------------------------------------------------------
+-- The Stack of the machine
+-----------------------------------------------------------------------------
+
+data Stack =
+  MkStack
+    { size   :: !Int
+    , frames :: [Frame]
+    }
+  deriving stock (Generic, Show)
+
+emptyStack :: Stack
+emptyStack = MkStack 0 []
+
+newAddress :: Eval Address
+newAddress = do
+  i <- step
+  u <- asks (.moduleUri)
+  pure (MkAddress u i)
+
+interpMachine :: Machine a -> Eval a
+interpMachine = \case
+  Config a -> pure a
+  Exception e -> exception e
+  Allocate' alloc -> case alloc of
+    Recursive expr env -> do
       rf <- newReference
-      pure (u, rf)
-    ) ns
-  pure (Map.fromList pairs)
+      let env' = env rf
+      updateRef rf $ Unevaluated Set.empty expr env'
+      pure (rf, env')
+    Value whnf -> do
+      rf <- newReference
+      updateRef rf $ WHNF whnf
+      pure rf
+    PreAllocation r -> do
+      rf <- newReference
+      pure (getUnique r, rf)
+  WithPoppedFrame k -> withPoppedFrame (interpMachine . k)
+  PokeThunk rf k -> do
+    tid <- liftIO myThreadId
+    conf <- lookupAndUpdateRef rf (k tid)
+    interpMachine $ pure conf
+  Bind act k -> interpMachine act >>= interpMachine . k
+  PushFrame f -> pushFrame f
+  NewUnique -> newUnique
 
-allocateValue :: WHNF -> Eval Reference
-allocateValue v = do
-  rf <- newReference
-  updateThunk rf (WHNF v)
-  pure rf
+runConfig :: Config -> Eval WHNF
+runConfig = \case
+  ForwardMachine env expr ->  runConfig =<< interpMachine (forwardExpr env expr)
+  BackwardMachine whnf -> runConfig =<< interpMachine (backward whnf)
+  EvalRefMachine r -> runConfig =<< interpMachine (evalRef r)
+  DoneMachine whnf -> pure whnf
 
--- | Recursive allocation.
-allocate :: Expr Resolved -> (Reference -> Environment) -> Eval (Reference, Environment)
-allocate expr env = do
-  rf <- newReference
-  let
-    env' = env rf
-  updateThunk rf (Unevaluated Set.empty expr env')
-  pure (rf, env')
-
-allocate_ :: Expr Resolved -> Environment -> Eval Reference
-allocate_ (Var _ann n) env = do
-  -- special case where we do not actually need to allocate
-  expectTerm env n
-allocate_ expr env =
-  fst <$> allocate expr (const env)
-
-forwardExpr :: Environment -> Expr Resolved -> Eval WHNF
-forwardExpr env (And _ann e1 e2) =
-  forwardExpr env (IfThenElse emptyAnno e1 e2 falseExpr)
-forwardExpr env (Or _ann e1 e2) =
-  forwardExpr env (IfThenElse emptyAnno e1 trueExpr e2)
-forwardExpr env (Implies _ann e1 e2) =
-  forwardExpr env (IfThenElse emptyAnno e1 e2 trueExpr)
-forwardExpr env (Not _ann e) =
-  forwardExpr env (IfThenElse emptyAnno e falseExpr trueExpr)
-forwardExpr env (Equals _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpEquals e2 env)
-  forwardExpr env e1
-forwardExpr env (Plus _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpPlus e2 env)
-  forwardExpr env e1
-forwardExpr env (Minus _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpMinus e2 env)
-  forwardExpr env e1
-forwardExpr env (Times _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpTimes e2 env)
-  forwardExpr env e1
-forwardExpr env (DividedBy _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpDividedBy e2 env)
-  forwardExpr env e1
-forwardExpr env (Modulo _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpModulo e2 env)
-  forwardExpr env e1
-forwardExpr env (Leq _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpLeq e2 env)
-  forwardExpr env e1
-forwardExpr env (Geq _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpGeq e2 env)
-  forwardExpr env e1
-forwardExpr env (Lt _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpLt e2 env)
-  forwardExpr env e1
-forwardExpr env (Gt _ann e1 e2) = do
-  pushFrame (BinOp1 BinOpGt e2 env)
-  forwardExpr env e1
-forwardExpr env (Proj _ann e l) =
-  forwardExpr env (App emptyAnno l [e]) -- we desugar projection to plain function application
-forwardExpr env (Var _ann n) = -- still problematic: similarity / overlap between this and App with no args
-  expectTerm env n >>= evalRef
-forwardExpr env (Cons _ann e1 e2) = do
-  rf1 <- allocate_ e1 env
-  rf2 <- allocate_ e2 env
-  backward (ValCons rf1 rf2)
-forwardExpr env (Lam _ann givens e) =
-  backward (ValClosure givens e env)
-forwardExpr env (App _ann n []) =
-  expectTerm env n >>= evalRef
-forwardExpr env (App _ann n es@(_ : _)) = do
-  rs <- traverse (`allocate_` env) es
-  pushFrame (App1 rs)
-  forwardExpr env (Var emptyAnno n)
-forwardExpr env (AppNamed ann n [] _) =
-  forwardExpr env (App ann n [])
-forwardExpr _env (AppNamed _ann _n _nes Nothing) =
-  internalException (RuntimeTypeError "named application where the order of arguments is not resolved")
-forwardExpr env (AppNamed ann n nes (Just order)) =
-  let
-    -- move expressions into order, drop names
-    es = (\ (MkNamedExpr _ _ e) -> e) . snd <$> sortOn fst (zip order nes)
-  in
-    forwardExpr env (App ann n es)
-forwardExpr env (IfThenElse _ann e1 e2 e3) = do
-  pushFrame (IfThenElse1 e2 e3 env)
-  forwardExpr env e1
-forwardExpr env (Consider _ann e branches) = do
-  rf <- allocate_ e env
-  matchBranches rf env branches
-forwardExpr _env (Lit _ann lit) = do
-  rval <- runLit lit
-  backward rval
-forwardExpr _env (List _ann []) =
-  backward ValNil
-forwardExpr env (List _ann (e : es)) =
-  forwardExpr env (Cons emptyAnno e (List emptyAnno es))
-forwardExpr env (Where _ann e ds) = do
-  env' <- evalRecLocalDecls env ds
-  let combinedEnv = Map.union env' env
-  forwardExpr combinedEnv e
-forwardExpr env (Regulative _ann (MkObligation _ party action due followup)) = do
-  backward (ValObligation env (Right party) (Right action) due (fromMaybe fulfilExpr followup))
-forwardExpr env (Event _ann ev) = forwardExpr env (desugarEvent ev)
-
-backward :: WHNF -> Eval WHNF
-backward val = withPoppedFrame $ \ case
-  Nothing -> pure val
-  Just (BinOp1 binOp e2 env) -> do
-    pushFrame (BinOp2 binOp val)
-    forwardExpr env e2
-  Just (BinOp2 binOp val1) -> do
-    runBinOp binOp val1 val
-  Just f@(App1 rs) -> do
-    case val of
-      ValClosure givens e env' -> do
-        env'' <- matchGivens givens f rs
-        forwardExpr (Map.union env'' env') e
-      ValUnappliedConstructor r -> do
-        backward (ValConstructor r rs)
-      ValObligation env party act due followup -> do
-        (events, time) <- case rs of
-          [r, t] -> pure (r, t)
-          rs' -> internalException $ RuntimeTypeError $ "expected a list of events, and a time stamp but found: " <> foldMap prettyLayout rs'
-        pushFrame (ContractFrame (Contract1 ScrutEvents {..}))
-        evalRef events
-      v@(ValConstructor r []) | r `sameResolved` TypeCheck.fulfilRef -> backward v
-      ValAssumed r ->
-        stuckOnAssumed r -- TODO: we can do better here
-      res -> internalException (RuntimeTypeError $ "expected a function but found: " <> prettyLayout res)
-  Just (IfThenElse1 e2 e3 env) ->
-    case boolView val of
-      Just True ->
-        forwardExpr env e2
-      Just False ->
-        forwardExpr env e3
-      Nothing | ValAssumed r <- val ->
-        stuckOnAssumed r
-      Nothing ->
-        internalException (RuntimeTypeError $ "expected a BOOLEAN but found: " <> prettyLayout val <> " when evaluating IF-THEN-ELSE")
-  Just (ConsiderWhen1 _scrutinee e _branches env) -> do
-    case val of
-      ValEnvironment env' ->
-        forwardExpr (Map.union env' env) e
-      _ ->
-        internalException (RuntimeTypeError $ "expected an environment but found: " <> prettyLayout val <> " when evaluating WHEN")
-  Just PatNil0 -> do
-    case val of
-      ValNil ->
-        backward (ValEnvironment Map.empty)
-      _ ->
-        patternMatchFailure
-  Just (PatCons0 p1 p2) -> do
-    case val of
-      ValCons rf1 rf2 -> do
-        pushFrame (PatCons1 rf2 p2)
-        matchPattern rf1 p1
-      _ ->
-        patternMatchFailure
-  Just (PatCons1 rf2 p2) -> do
-    case val of
-      ValEnvironment env1 -> do
-        pushFrame (PatCons2 env1)
-        matchPattern rf2 p2
-      _ ->
-        internalException (RuntimeTypeError $ "expected an environment but found: " <> prettyLayout val <> " when matching FOLLOWED BY")
-  Just (PatCons2 env1) ->
-    case val of
-      ValEnvironment env2 ->
-        backward (ValEnvironment (Map.union env2 env1))
-      _ ->
-        internalException (RuntimeTypeError $ "expected an environment but found: " <> prettyLayout val <> " when matching FOLLOWED BY")
-  Just (PatApp0 n ps) ->
-    case val of
-      ValConstructor n' rfs
-        | sameResolved n n' ->
-          if length rfs == length ps
-            then
-              let
-                pairs = zip rfs ps
-              in
-                case pairs of
-                  []             -> backward (ValEnvironment Map.empty)
-                  ((r, p) : rps) -> do
-                    pushFrame (PatApp1 [] rps)
-                    matchPattern r p
-            else internalException (RuntimeTypeError $ "pattern for constructor has the wrong number of arguments")
-      _ ->
-        patternMatchFailure
-  Just (PatApp1 envs rps) ->
-    case val of
-      ValEnvironment env ->
-        case rps of
-          []              -> backward (ValEnvironment (Map.unions (env : envs)))
-          ((r, p) : rps') -> do
-            pushFrame (PatApp1 (env : envs) rps')
-            matchPattern r p
-      _ -> internalException (RuntimeTypeError $ "expected an environment but found: " <> prettyLayout val <> " when matching constructor")
-  Just (EqConstructor1 rf rfs) -> do
-    pushFrame (EqConstructor2 val rfs)
-    evalRef rf
-  Just (EqConstructor2 val1 rfs) -> do
-    pushFrame (EqConstructor3 rfs)
-    runBinOpEquals val1 val
-  Just (EqConstructor3 rfs) ->
-    case boolView val of
-      Just False -> backward $ valBool False
-      Just True ->
-        case rfs of
-          [] -> backward $ valBool True
-          ((r1, r2) : rfs') -> do
-            pushFrame (EqConstructor1 r2 rfs')
-            evalRef r1
-      Nothing -> internalException (RuntimeTypeError $ "expected a BOOLEAN but found: " <> prettyLayout val <> " when testing equality")
-  Just (UpdateThunk rf) -> do
-    updateThunkToWHNF rf val
-    backward val
-  Just (ContractFrame cFrame) -> backwardContractFrame val cFrame
-
-backwardContractFrame :: Value Reference -> ContractFrame -> Eval WHNF
-backwardContractFrame val = \case
-  Contract1 ScrutEvents {..} -> do
-    case val of
-      ValCons e es -> do
-        pushCFrame (Contract2 ScrutEvent {events = es, ..})
-        evalRef e
-      ValNil -> backward (ValObligation env party act due followup)
-      _ -> internalException (RuntimeTypeError $ "expected LIST EVENT but found: " <> prettyLayout val <> " when scrutinizing regulative events")
-  Contract2 ScrutEvent {..} -> do
-    (ev'party, ev'act, ev'time) <- case val of
-      ValConstructor n [p, a, t]  | n `sameResolved` TypeCheck.eventCRef -> pure (p, a, t)
-      _ -> internalException (RuntimeTypeError $ "expected an EVENT but found: " <> prettyLayout val <> " when scrutinizing a regulative event")
-    pushCFrame (Contract3 PartyWHNF {..})
-    maybeEvaluate env party
-  Contract3 PartyWHNF {..} -> do
-    pushCFrame (Contract3' PartyEqual {party = val, ..})
-    evalRef ev'party
-  Contract3' PartyEqual {..} -> do
-    pushCFrame (Contract4 ScrutParty {ev'party = val, ..})
-    runBinOpEquals party val
-  Contract4 ScrutParty {..} -> do
-    case boolView val of
-      Nothing -> internalException (RuntimeTypeError $ "expected BOOLEAN but found: " <> prettyLayout val)
-      Just True -> do
-        pushCFrame (Contract5 ActWHNF {..})
-        maybeEvaluate env act
-      Just False -> continueWithNextEvent ScrutEvents {party = Left party, ..} events
-  Contract5 ActWHNF {..} -> do
-    pushCFrame (Contract5' ActEqual {act = val, ..})
-    evalRef ev'act
-  Contract5' ActEqual {..} -> do
-    pushCFrame (Contract6 ScrutAct {ev'act = val, ..})
-    runBinOpEquals act val
-  Contract6 ScrutAct {..} -> do
-    case boolView val of
-      Nothing -> internalException (RuntimeTypeError $ "expected BOOLEAN but found: " <> prettyLayout val)
-      Just True -> case due of
-        Just due' -> do
-          pushCFrame (Contract7 StampWHNF {..})
-          forwardExpr env due'
-        Nothing -> continueWithFollowup env followup events ev'time
-      Just False -> continueWithNextEvent ScrutEvents {party = Left party, act = Left act, ..} events
-  Contract7 StampWHNF {..} -> do
-    pushCFrame (Contract8 CurTimeWHNF {due = val, ..})
-    evalRef ev'time
-  Contract8 CurTimeWHNF {..} -> do
-    pushCFrame (Contract9 ScrutTime {ev'time = val, ..})
-    evalRef time
-  Contract9 ScrutTime {..} -> do
-    let assertTime = \case
-          ValNumber i -> pure i
-          v -> internalException (RuntimeTypeError $ "expected a NUMBER but got: " <> prettyLayout v)
-    stamp <- assertTime ev'time
-    due' <- assertTime due
-    time <- assertTime val
-    let deadline = time + due'
-    if stamp > deadline
-      then backward (ValBreached (DeadlineMissed ev'party ev'act ev'time deadline))
-      else do
-        -- NOTE: this is not too nice, but not wanting this would require to change `App1` to take MaybeEvaluated's
-        timeR <- allocateValue ev'time
-        continueWithFollowup env followup events timeR
-  where
-    continueWithNextEvent :: ScrutEvents -> Reference -> Eval WHNF
-    continueWithNextEvent frame events = do
-      pushCFrame (Contract1 frame)
-      evalRef events
-
-    pushCFrame = pushFrame . ContractFrame
-
-    continueWithFollowup :: Environment -> RExpr -> Reference -> Reference -> Eval WHNF
-    continueWithFollowup env followup events time = do
-      pushFrame (App1 [events, time])
-      forwardExpr env followup
-
-maybeEvaluate :: Environment -> MaybeEvaluated -> Eval WHNF
-maybeEvaluate env = either backward (forwardExpr env)
-
-matchGivens :: GivenSig Resolved -> Frame -> [Reference] -> Eval Environment
-matchGivens (MkGivenSig _ann otns) f es = do
-  let others = foldMap (either (const []) (\x -> [fst x]) . TypeCheck.isQuantifier) otns
-  matchGivens' others f es
-
-matchGivens' :: [Resolved] -> Frame -> [Reference] -> Eval (Map Unique Reference)
-matchGivens' ns f rs = do
-  if length ns == length rs
-    then do
-      pure $ Map.fromList (zipWith (\ r v -> (getUnique r, v)) ns rs)
-    else do
-      pushFrame f -- provides better error context
-      internalException (RuntimeTypeError "given signatures' values' lengths do not match")
-
-matchBranches :: Reference -> Environment -> [Branch Resolved] -> Eval WHNF
-matchBranches scrutinee _env [] =
-  userException (NonExhaustivePatterns scrutinee)
-matchBranches _scrutinee env (Otherwise _ann e : _) =
-  forwardExpr env e
-matchBranches scrutinee env (When _ann pat e : branches) = do
-  pushFrame (ConsiderWhen1 scrutinee e branches env)
-  matchPattern scrutinee pat
-
-matchPattern :: Reference -> Pattern Resolved -> Eval WHNF
-matchPattern scrutinee (PatVar _ann n) = do
-  backward (ValEnvironment (Map.singleton (getUnique n) scrutinee))
-matchPattern scrutinee (PatApp _ann n [])
-  | getUnique n == TypeCheck.emptyUnique = do -- pattern for the empty list
-  pushFrame PatNil0
-  evalRef scrutinee
-matchPattern scrutinee (PatCons _ann p1 p2) = do
-  pushFrame (PatCons0 p1 p2 )
-  evalRef scrutinee
-matchPattern scrutinee (PatApp _ann n ps) = do
-  pushFrame (PatApp0 n ps )
-  evalRef scrutinee
-
--- | This unwinds the stack until it finds the enclosing pattern match and then resumes.
-patternMatchFailure :: Eval WHNF
-patternMatchFailure = withPoppedFrame $ \ case
-  Nothing ->
-    internalException UnhandledPatternMatch
-  Just (ConsiderWhen1 scrutinee _ branches env) ->
-    matchBranches scrutinee env branches
-  Just _ ->
-    patternMatchFailure
-
-runLit :: Lit -> Eval WHNF
-runLit (NumericLit _ann num) = pure (ValNumber num)
-runLit (StringLit _ann str)  = pure (ValString str)
-
-runBinOp :: BinOp -> WHNF -> WHNF -> Eval WHNF
-runBinOp BinOpPlus   (ValNumber num1) (ValNumber num2)           = backward $ ValNumber (num1 + num2)
-runBinOp BinOpMinus  (ValNumber num1) (ValNumber num2)           = backward $ ValNumber (num1 - num2)
-runBinOp BinOpTimes  (ValNumber num1) (ValNumber num2)           = backward $ ValNumber (num1 * num2)
-runBinOp BinOpDividedBy (ValNumber num1) (ValNumber num2)        = backward $ ValNumber (num1 `div` num2)
-runBinOp BinOpModulo    (ValNumber num1) (ValNumber num2)        = backward $ ValNumber (num1 `mod` num2)
-runBinOp BinOpEquals val1             val2                       = runBinOpEquals val1 val2
-runBinOp BinOpLeq    (ValNumber num1) (ValNumber num2)           = backward $ ValBool (num1 <= num2)
-runBinOp BinOpLeq    (ValString str1) (ValString str2)           = backward $ ValBool (str1 <= str2)
-runBinOp BinOpLeq    (ValBool b1)     (ValBool b2)               = backward $ ValBool (b1 <= b2)
-runBinOp BinOpGeq    (ValNumber num1) (ValNumber num2)           = backward $ ValBool (num1 >= num2)
-runBinOp BinOpGeq    (ValString str1) (ValString str2)           = backward $ ValBool (str1 >= str2)
-runBinOp BinOpGeq    (ValBool b1)     (ValBool b2)               = backward $ ValBool (b1 >= b2)
-runBinOp BinOpLt     (ValNumber num1) (ValNumber num2)           = backward $ ValBool (num1 < num2)
-runBinOp BinOpLt     (ValString str1) (ValString str2)           = backward $ ValBool (str1 < str2)
-runBinOp BinOpLt     (ValBool b1)     (ValBool b2)               = backward $ ValBool (b1 < b2)
-runBinOp BinOpGt     (ValNumber num1) (ValNumber num2)           = backward $ ValBool (num1 > num2)
-runBinOp BinOpGt     (ValString str1) (ValString str2)           = backward $ ValBool (str1 > str2)
-runBinOp BinOpGt     (ValBool b1)     (ValBool b2)               = backward $ ValBool (b1 > b2)
-runBinOp _op         (ValAssumed r) _e2                          = stuckOnAssumed r
-runBinOp _op         _e1 (ValAssumed r)                          = stuckOnAssumed r
-runBinOp _           _                _                          = internalException (RuntimeTypeError "running bin op with invalid operation / value combination")
-
-runBinOpEquals :: WHNF -> WHNF -> Eval WHNF
-runBinOpEquals (ValNumber num1)        (ValNumber num2) = backward $ valBool $ num1 == num2
-runBinOpEquals (ValString str1)        (ValString str2) = backward $ valBool $ str1 == str2
-runBinOpEquals ValNil                  ValNil           = backward $ valBool True
-runBinOpEquals (ValCons r1 rs1)        (ValCons r2 rs2) = do
-  pushFrame (EqConstructor1 r2 [(rs1, rs2)])
-  evalRef r1
-runBinOpEquals (ValConstructor n1 rs1) (ValConstructor n2 rs2)
-  | sameResolved n1 n2 && length rs1 == length rs2 =
-    let
-      pairs = zip rs1 rs2
-    in
-      case pairs of
-        [] -> backward $ ValBool True
-        ((r1, r2) : rss) -> do
-          pushFrame (EqConstructor1 r2 rss)
-          evalRef r1
-  | otherwise                                           = backward $ ValBool False
-runBinOpEquals _                       _                = userException EqualityOnUnsupportedType
-
-pattern ValBool :: Bool -> WHNF
-pattern ValBool b <- (boolView -> Just b)
-  where
-    ValBool b = valBool b
-
-valBool :: Bool -> WHNF
-valBool False = falseVal
-valBool True  = trueVal
-
--- | Checks if a value is a Boolean constructor.
-boolView :: WHNF -> Maybe Bool
-boolView val =
-  case val of
-    ValConstructor n []
-      | sameResolved n TypeCheck.trueRef  -> Just True
-      | sameResolved n TypeCheck.falseRef -> Just False
-    _ -> Nothing
-
-sameResolved :: Resolved -> Resolved -> Bool
-sameResolved r1 r2 =
-  getUnique r1 == getUnique r2
-
-evalModule :: Environment -> Module Resolved -> Eval (Environment, [EvalDirective])
-evalModule env (MkModule _ann _uri section) = do
-  names <- scanSection section
-  env' <- preAllocate names
-  let combinedEnv = Map.union env' env
-  directives <- evalSection combinedEnv section
-  pure (env', directives)
-
--- | Doesn't do any actual evaluation, just performs allocations
--- and returns the environment containing all the new bindings.
-evalRecLocalDecls :: Environment -> [LocalDecl Resolved] -> Eval Environment
-evalRecLocalDecls env decls = do
-  names <- concat <$> traverse scanLocalDecl decls
-  env' <- preAllocate names
-  let combinedEnv = Map.union env' env
-  traverse_ (evalLocalDecl combinedEnv) decls
-  pure env'
-
--- | Just collect all defined names; could plausibly be done generically.
-scanSection :: Section Resolved -> Eval [Resolved]
-scanSection (MkSection _ann _mn _maka topdecls) =
-  concat <$> traverse scanTopDecl topdecls
-
--- | Just collect all defined names; could plausibly be done generically.
-scanTopDecl :: TopDecl Resolved -> Eval [Resolved]
-scanTopDecl (Declare _ann declare) =
-  scanDeclare declare
-scanTopDecl (Decide _ann decide) =
-  scanDecide decide
-scanTopDecl (Assume _ann assume) =
-  scanAssume assume
-scanTopDecl (Section _ann section) =
-  scanSection section
-scanTopDecl (Directive _ann _directive) =
-  pure []
-scanTopDecl (Import _ann _import_) =
-  pure []
-
--- | Just collect all defined names; could plausibly be done generically.
-scanLocalDecl :: LocalDecl Resolved -> Eval [Resolved]
-scanLocalDecl (LocalDecide _ann decide) =
-  scanDecide decide
-scanLocalDecl (LocalAssume _ann assume) =
-  scanAssume assume
-
-scanDecide :: Decide Resolved -> Eval [Resolved]
-scanDecide (MkDecide _ann _tysig (MkAppForm _ n _ _) _expr) = pure [n]
-
-scanAssume :: Assume Resolved -> Eval [Resolved]
-scanAssume (MkAssume _ann _tysig (MkAppForm _ n _ _) _t) = pure [n]
-
--- | The only run-time names a type declaration brings into scope are constructors and selectors.
-scanDeclare :: Declare Resolved -> Eval [Resolved]
-scanDeclare (MkDeclare _ann _tysig _appFormAka t) = scanTypeDecl t
-
-scanTypeDecl :: TypeDecl Resolved -> Eval [Resolved]
-scanTypeDecl (EnumDecl _ann conDecls) =
-  concat <$> traverse scanConDecl conDecls
-scanTypeDecl (RecordDecl _ann mcon tns) =
-  concat <$> traverse (\ c -> scanConDecl (MkConDecl emptyAnno c tns)) (toList mcon)
-scanTypeDecl (SynonymDecl _ann _t) =
-  pure []
-
-scanConDecl :: ConDecl Resolved -> Eval [Resolved]
-scanConDecl (MkConDecl _ann n [])  = pure [n]
-scanConDecl (MkConDecl _ann n tns) = pure (n : ((\ (MkTypedName _ n' _) -> n') <$> tns))
-
-evalSection :: Environment -> Section Resolved -> Eval [EvalDirective]
-evalSection env (MkSection _ann _mn _maka topdecls) =
-  concat <$> traverse (evalTopDecl env) topdecls
-
-evalTopDecl :: Environment -> TopDecl Resolved -> Eval [EvalDirective]
-evalTopDecl env (Declare _ann declare) =
-  [] <$ evalDeclare env declare
-evalTopDecl env (Decide _ann decide) =
-  [] <$ evalDecide env decide
-evalTopDecl env (Assume _ann assume) =
-  [] <$ evalAssume env assume
-evalTopDecl env (Directive _ann directive) =
-  evalDirective env directive
-evalTopDecl env (Section _ann section) =
-  evalSection env section
-evalTopDecl _env (Import _ann _import_) =
-  pure []
-
-evalDirective :: Environment -> Directive Resolved -> Eval [EvalDirective]
-evalDirective env (LazyEval ann expr) =
-  pure ((\ r -> MkEvalDirective r expr env) <$> toList (rangeOf ann))
-evalDirective _env (StrictEval _ann _expr) =
-  pure []
-evalDirective _env (Check _ann _expr) =
-  pure []
-evalDirective env (Contract ann expr t evs) =
-  evalDirective env . LazyEval ann =<< contractToEvalDirective expr t evs
-
-contractToEvalDirective :: Expr Resolved -> Expr Resolved -> [Expr Resolved] -> Eval (Expr Resolved)
-contractToEvalDirective contract t evs = do
-  evs' <- evListExpr
-  pure $ App emptyAnno TypeCheck.evalContractRef [contract, evs', t]
-  where
-  evListExpr = List emptyAnno <$> traverse eventExpr evs
-
-eventExpr :: Expr Resolved -> Eval (Expr Resolved)
-eventExpr (Event _ann ev) = pure $ desugarEvent ev
-eventExpr o = internalException $ RuntimeTypeError $ "expected an EVENT, but got " <> prettyLayout o
-
-desugarEvent :: Event Resolved -> Expr Resolved
-desugarEvent (MkEvent ann party act timestamp) = App ann TypeCheck.eventCRef [party, act, timestamp]
-
-evalLocalDecl :: Environment -> LocalDecl Resolved -> Eval ()
-evalLocalDecl env (LocalDecide _ann decide) =
-  evalDecide env decide
-evalLocalDecl env (LocalAssume _ann assume) =
-  evalAssume env assume
-
--- We are assuming that the environment already contains an entry with an address for us.
-evalAssume :: Environment -> Assume Resolved -> Eval ()
-evalAssume env (MkAssume _ann _tysig (MkAppForm _ n []   _maka) _) =
-  updateTerm env n (WHNF (ValAssumed n))
-evalAssume env (MkAssume _ann _tysig (MkAppForm _ n _args _maka) _) = do
-  -- TODO: we should create a given here yielding an assumed, but we currently cannot do that easily,
-  -- because we do not have Assumed as an expression, and we also cannot embed values into expressions.
-  updateTerm env n (WHNF (ValAssumed n))
-
-updateTerm :: Environment -> Resolved -> Thunk -> Eval ()
-updateTerm env n thunk = do
-  rf <- expectTerm env n
-  updateThunk rf thunk
-
--- We are assuming that the environment already contains an entry with an address for us.
-evalDecide :: Environment -> Decide Resolved -> Eval ()
-evalDecide env (MkDecide _ann _tysig (MkAppForm _ n []   _maka) expr) =
-  updateTerm env n (Unevaluated Set.empty expr env)
-evalDecide env (MkDecide _ann _tysig (MkAppForm _ n args _maka) expr) = do
-  let
-    v = ValClosure (MkGivenSig emptyAnno ((\ r -> MkOptionallyTypedName emptyAnno r Nothing) <$> args)) expr env
-  updateTerm env n (WHNF v)
-
--- We are assuming that the environment already contains an entry with an address for us.
-evalDeclare :: Environment -> Declare Resolved -> Eval ()
-evalDeclare env (MkDeclare _ann _tysig _appFormAka t) =
-  evalTypeDecl env t
-
-evalTypeDecl :: Environment -> TypeDecl Resolved -> Eval ()
-evalTypeDecl env (EnumDecl _ann conDecls) =
-  traverse_ (evalConDecl env) conDecls
-evalTypeDecl env (RecordDecl _ann mcon tns) =
-  traverse_ (\ c -> evalConDecl env (MkConDecl emptyAnno c tns)) mcon
-evalTypeDecl _env (SynonymDecl _ann _t) =
-  pure ()
-
-evalConDecl :: Environment -> ConDecl Resolved -> Eval ()
-evalConDecl env (MkConDecl _ann n []) =
-  updateTerm env n (WHNF (ValConstructor n []))
-evalConDecl env (MkConDecl _ann n tns) = do
-  -- constructor
-  updateTerm env n (WHNF (ValUnappliedConstructor n))
-  conRef <- ref (TypeCheck.getName n) n
-  -- selectors (we need to create fresh names for the lambda abstractions so that every binder is unique)
-  traverse_ (\ (i, MkTypedName _ sn _t) -> do
-    arg    <- def (TypeCheck.getName n)
-    argRef <- ref (TypeCheck.getName n) arg
-    args <- traverse def (TypeCheck.getName <$> tns)
-    body <- ref (TypeCheck.getName sn) (args !! i)
-    let
-      sel =
-        ValClosure
-          (MkGivenSig emptyAnno [MkOptionallyTypedName emptyAnno arg Nothing])      -- \ x ->
-          (Consider emptyAnno (App emptyAnno argRef [])                             -- case x of
-            [ When emptyAnno (PatApp emptyAnno conRef (PatVar emptyAnno <$> args))  --   Con y_1 ... y_n ->
-                (App emptyAnno body [])                                             --     y_i
-            ]
-          )
-          emptyEnvironment
-    updateTerm env sn (WHNF sel)
-    ) (zip [0 ..] tns)
-
-falseExpr :: Expr Resolved
-falseExpr = App emptyAnno TypeCheck.falseRef []
-
-falseVal :: WHNF
-falseVal = ValConstructor TypeCheck.falseRef []
-
-trueExpr :: Expr Resolved
-trueExpr = App emptyAnno TypeCheck.trueRef []
-
-trueVal :: WHNF
-trueVal = ValConstructor TypeCheck.trueRef []
-
-fulfilExpr :: Expr Resolved
-fulfilExpr = App emptyAnno TypeCheck.fulfilRef []
-
-fulfilVal :: Value a
-fulfilVal = ValConstructor TypeCheck.fulfilRef []
-
--- \a b c. a b c
-evalContractVal :: Eval (Value a)
-evalContractVal = do
-  let mn = MkName emptyAnno . NormalName
-      (na, nb, nc) = (mn "a", mn "b", mn "c")
-  ad <- def na
-  bd <- def nb
-  cd <- def nc
-  ar <- ref na ad
-  br <- ref nb bd
-  cr <- ref nc cd
-
-  pure $ ValClosure
-    (MkGivenSig emptyAnno
-      [ MkOptionallyTypedName emptyAnno ad Nothing
-      , MkOptionallyTypedName emptyAnno bd Nothing
-      , MkOptionallyTypedName emptyAnno cd Nothing
-      ]
-    )
-    (App emptyAnno ar [App emptyAnno br [], App emptyAnno cr []])
-    emptyEnvironment
-
--- EVENT :: party -> act -> Number -> EVENT party act
-eventCVal :: Value a
-eventCVal = ValUnappliedConstructor TypeCheck.eventCRef
-
--- The initial environment has to be built by pre-allocation.
-initialEnvironment :: Eval Environment
-initialEnvironment = do
-  falseRef <- allocateValue falseVal
-  trueRef  <- allocateValue trueVal
-  nilRef   <- allocateValue ValNil
-  evalContractRef <- allocateValue =<< evalContractVal
-  eventCRef <- allocateValue eventCVal
-  fulfilRef <- allocateValue fulfilVal
-  pure $
-    Map.fromList
-      [ (TypeCheck.falseUnique, falseRef)
-      , (TypeCheck.trueUnique,  trueRef)
-      , (TypeCheck.emptyUnique, nilRef)
-      , (TypeCheck.evalContractUnique, evalContractRef)
-      , (TypeCheck.eventCUnique, eventCRef)
-      , (TypeCheck.fulfilUnique, fulfilRef)
-      ]
-
--- TODO: This currently allocates the initial environment once per module.
--- This isn't a big deal, but can we somehow do this only once per program,
--- for example by passing this in from the outside?
-evalModuleAndDirectives :: Environment -> Module Resolved -> Eval (Environment, [EvalDirectiveResult])
-evalModuleAndDirectives env m = do
-  ienv <- initialEnvironment
-  (env', directives) <- evalModule (env <> ienv) m
-  results <- traverse nfDirective directives
-  -- NOTE: We are only returning the new definitions of this module, not any imports.
-  -- Depending on future export semantics, this may have to change.
-  pure (env', results)
+runConfigM :: Machine Config -> Eval WHNF
+runConfigM mc = interpMachine mc >>= runConfig
 
 -- | Evaluate an EVAL directive. For this, we evaluate to normal form,
 -- not just WHNF.
---
 nfDirective :: EvalDirective -> Eval EvalDirectiveResult
 nfDirective (MkEvalDirective r expr env) = do
   v <- tryEval $ do
-    whnf <- forwardExpr env expr
+    whnf <- runConfig $ ForwardMachine env expr
     nf whnf
   pure (MkEvalDirectiveResult r v)
+
+data EvalDirectiveResult =
+  MkEvalDirectiveResult
+    { range  :: !SrcRange -- ^ of the (L)EVAL / CONTRACT directive
+    , result :: Either EvalException NF
+    }
+  deriving stock (Generic, Show)
+  deriving anyclass NFData
+
 
 -- | Evaluate WHNF to NF, with a cutoff (which possibly could be made configurable).
 nf :: WHNF -> Eval NF
@@ -971,20 +183,20 @@ nfAux _d (ValNumber i)               = pure (MkNF (ValNumber i))
 nfAux _d (ValString s)               = pure (MkNF (ValString s))
 nfAux _d ValNil                      = pure (MkNF ValNil)
 nfAux  d (ValCons r1 r2)             = do
-  v1 <- evalRef r1 >>= nfAux (d - 1)
-  v2 <- evalRef r2 >>= nfAux (d - 1)
+  v1 <- runConfigM (evalRef r1) >>= nfAux (d - 1)
+  v2 <- runConfigM (evalRef r2) >>= nfAux (d - 1)
   pure (MkNF (ValCons v1 v2))
 nfAux _d (ValClosure givens e env)   = pure (MkNF (ValClosure givens e env))
 nfAux _d (ValObligation env party act due followup) = do
   pure (MkNF (ValObligation env party act due followup))
 nfAux _d (ValUnappliedConstructor n) = pure (MkNF (ValUnappliedConstructor n))
 nfAux  d (ValConstructor n rs)       = do
-  vs <- traverse (\ r -> evalRef r >>= nfAux (d - 1)) rs
+  vs <- traverse (\ r -> runConfigM (evalRef r) >>= nfAux (d - 1)) rs
   pure (MkNF (ValConstructor n vs))
 nfAux _d (ValAssumed n)              = pure (MkNF (ValAssumed n))
 nfAux _d (ValEnvironment env)        = pure (MkNF (ValEnvironment env))
 nfAux d (ValBreached r')            = do
-  let evalAndNF = traverse $ nfAux (d - 1) <=< evalRef
+  let evalAndNF = traverse $ nfAux (d - 1) <=< runConfigM . evalRef
   r <- case r' of
     DeadlineMissed party act timestamp deadline -> do
       party' <- evalAndNF party
@@ -1016,18 +228,16 @@ execEvalModuleWithEnv env m@(MkModule _ moduleUri _) = do
         Right result -> do
           pure result
 
-data EvalDirective =
-  MkEvalDirective
-    { range :: !SrcRange -- ^ of the (L)EVAL directive
-    , expr  :: !(Expr Resolved) -- ^ expression to evaluate
-    , env   :: !Environment -- ^ environment to evaluate the expression in
-    }
-  deriving stock (Generic, Show)
+-- TODO: This currently allocates the initial environment once per module.
+-- This isn't a big deal, but can we somehow do this only once per program,
+-- for example by passing this in from the outside?
+evalModuleAndDirectives :: Environment -> Module Resolved -> Eval (Environment, [EvalDirectiveResult])
+evalModuleAndDirectives env m = do
+  (env', directives) <- interpMachine do
+    ienv <- initialEnvironment
+    evalModule (env <> ienv) m
+  results <- traverse nfDirective directives
+  -- NOTE: We are only returning the new definitions of this module, not any imports.
+  -- Depending on future export semantics, this may have to change.
+  pure (env', results)
 
-data EvalDirectiveResult =
-  MkEvalDirectiveResult
-    { range  :: !SrcRange -- ^ of the (L)EVAL / CONTRACT directive
-    , result :: Either EvalException NF
-    }
-  deriving stock (Generic, Show)
-  deriving anyclass NFData

--- a/jl4-core/src/L4/EvaluateLazy/Machine.hs
+++ b/jl4-core/src/L4/EvaluateLazy/Machine.hs
@@ -1,0 +1,933 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE GADTs #-}
+module L4.EvaluateLazy.Machine
+( Frame
+, EvalException (..)
+, UserEvalException (..)
+, Machine (Allocate, AllocateValue, PreAllocate, ..)
+, Allocation (..)
+, Config (..)
+, forwardExpr
+, backward
+, EvalDirective (..)
+, evalModule
+, maximumStackSize
+, initialEnvironment
+, evalRef
+, emptyEnvironment
+, prettyEvalException
+)
+where
+
+import Base
+import qualified Base.Text as Text
+import qualified Base.Map as Map
+import qualified Base.Set as Set
+import Control.Concurrent
+import L4.Annotation
+import L4.Evaluate.Operators
+import L4.Evaluate.ValueLazy
+import L4.Parser.SrcSpan (SrcRange)
+import L4.Print
+import L4.Syntax
+import qualified L4.TypeCheck as TypeCheck
+import L4.EvaluateLazy.ContractFrame
+
+data Frame =
+    BinOp1 BinOp {- -} (Expr Resolved) Environment
+  | BinOp2 BinOp WHNF {- -}
+  | App1 {- -} [Reference]
+  | IfThenElse1 {- -} (Expr Resolved) (Expr Resolved) Environment
+  | ConsiderWhen1 Reference {- -} (Expr Resolved) [Branch Resolved] Environment
+  | PatNil0
+  | PatCons0 (Pattern Resolved) (Pattern Resolved)
+  | PatCons1 {- -} Reference (Pattern Resolved)
+  | PatCons2 Environment {- -}
+  | PatApp0 Resolved [Pattern Resolved]
+  | PatApp1 [Environment] {- -} [(Reference, Pattern Resolved)]
+  | EqConstructor1 {- -} Reference [(Reference, Reference)]
+  | EqConstructor2 WHNF {- -} [(Reference, Reference)]
+  | EqConstructor3 {- -} [(Reference, Reference)]
+  | UpdateThunk Reference
+  | ContractFrame ContractFrame
+  deriving stock Show
+
+data EvalException =
+    InternalEvalException InternalEvalException
+  | UserEvalException UserEvalException
+  deriving stock (Generic, Show)
+  deriving anyclass NFData
+
+data InternalEvalException =
+    RuntimeScopeError Resolved -- internal
+  | RuntimeTypeError Text -- internal
+  | PrematureGC -- internal
+  | DanglingPointer -- internal
+  | UnhandledPatternMatch -- internal
+  deriving stock (Generic, Show)
+  deriving anyclass NFData
+
+data UserEvalException =
+    BlackholeForced (Expr Resolved)
+  | EqualityOnUnsupportedType
+  | NonExhaustivePatterns Reference -- we could try to warn statically
+  | StackOverflow
+  | Stuck Resolved -- ^ stores the term we got stuck on
+  deriving stock (Generic, Show)
+  deriving anyclass NFData
+
+data Machine a where
+  Config :: a -> Machine a
+  Exception :: EvalException -> Machine a
+  WithPoppedFrame :: (Maybe Frame -> Machine a) -> Machine a
+  PushFrame :: Frame -> Machine ()
+  Allocate' :: Allocation t -> Machine t
+  NewUnique :: Machine Unique
+  PokeThunk :: Reference
+    -> (ThreadId -> Thunk -> (Thunk, a))
+    -> Machine a
+  Bind :: Machine a -> (a -> Machine b) -> Machine b
+
+data Allocation t where
+  Recursive :: Expr Resolved -> (Reference -> Environment) -> Allocation (Reference, Environment)
+  Value :: WHNF -> Allocation Reference
+  PreAllocation :: Resolved -> Allocation (Unique, Reference)
+
+instance Functor Machine where
+  fmap = liftM
+
+instance Applicative Machine where
+  (<*>) = ap
+  pure = Config
+
+instance Monad Machine where
+  Config a >>= k = k a
+  Exception e >>= _k = Exception e
+  WithPoppedFrame k' >>= k = WithPoppedFrame (k' >=> k)
+  PushFrame a >>= k = Bind (PushFrame a) (\_ -> k ())
+  Allocate' a >>= k = Bind (Allocate' a) k
+  PokeThunk rf k' >>= k = Bind (PokeThunk rf k') k
+  NewUnique >>= k = Bind NewUnique k
+  Bind m k' >>= k = Bind m (k' >=> k)
+
+pattern Allocate :: Expr Resolved -> (Reference -> Environment) -> Machine (Reference, Environment)
+pattern Allocate expr k = Allocate' (Recursive expr k)
+
+pattern AllocateValue :: WHNF -> Machine Reference
+pattern AllocateValue whnf = Allocate' (Value whnf)
+
+pattern PreAllocate ::Resolved -> Machine (Unique, Reference)
+pattern PreAllocate r = Allocate' (PreAllocation r)
+
+data Config
+  = ForwardMachine Environment (Expr Resolved)
+  | BackwardMachine WHNF
+  | EvalRefMachine Reference
+  | DoneMachine WHNF
+
+pattern ForwardExpr :: Environment -> Expr Resolved -> Machine Config
+pattern ForwardExpr env e = Config (ForwardMachine env e)
+
+pattern Backward :: WHNF -> Machine Config
+pattern Backward whnf = Config (BackwardMachine whnf)
+
+pattern EvalRef :: Reference -> Machine Config
+pattern EvalRef ref = Config (EvalRefMachine ref)
+
+pattern InternalException :: InternalEvalException -> Machine a
+pattern InternalException e = Exception (InternalEvalException e)
+
+pattern UserException :: UserEvalException -> Machine a
+pattern UserException e = Exception (UserEvalException e)
+
+pattern Done :: WHNF -> Machine Config
+pattern Done whnf = Config (DoneMachine whnf)
+
+forwardExpr :: Environment -> Expr Resolved -> Machine Config
+forwardExpr env (And _ann e1 e2) =
+  ForwardExpr env (IfThenElse emptyAnno e1 e2 falseExpr)
+forwardExpr env (Or _ann e1 e2) =
+  ForwardExpr env (IfThenElse emptyAnno e1 trueExpr e2)
+forwardExpr env (Implies _ann e1 e2) =
+  ForwardExpr env (IfThenElse emptyAnno e1 e2 trueExpr)
+forwardExpr env (Not _ann e) =
+  ForwardExpr env (IfThenElse emptyAnno e falseExpr trueExpr)
+forwardExpr env (Equals _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpEquals e2 env)
+  ForwardExpr env e1
+forwardExpr env (Plus _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpPlus e2 env)
+  ForwardExpr env e1
+forwardExpr env (Minus _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpMinus e2 env)
+  ForwardExpr env e1
+forwardExpr env (Times _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpTimes e2 env)
+  ForwardExpr env e1
+forwardExpr env (DividedBy _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpDividedBy e2 env)
+  ForwardExpr env e1
+forwardExpr env (Modulo _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpModulo e2 env)
+  ForwardExpr env e1
+forwardExpr env (Leq _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpLeq e2 env)
+  ForwardExpr env e1
+forwardExpr env (Geq _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpGeq e2 env)
+  ForwardExpr env e1
+forwardExpr env (Lt _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpLt e2 env)
+  ForwardExpr env e1
+forwardExpr env (Gt _ann e1 e2) = do
+  PushFrame (BinOp1 BinOpGt e2 env)
+  ForwardExpr env e1
+forwardExpr env (Proj _ann e l) =
+  ForwardExpr env (App emptyAnno l [e]) -- we desugar projection to plain function application
+forwardExpr env (Var _ann n) = -- still problematic: similarity / overlap between this and App with no args
+  expectTerm env n >>= EvalRef
+forwardExpr env (Cons _ann e1 e2) = do
+  rf1 <- allocate_ e1 env
+  rf2 <- allocate_ e2 env
+  Backward (ValCons rf1 rf2)
+forwardExpr env (Lam _ann givens e) =
+  Backward (ValClosure givens e env)
+forwardExpr env (App _ann n []) =
+  expectTerm env n >>= EvalRef
+forwardExpr env (App _ann n es@(_ : _)) = do
+  rs <- traverse (`allocate_` env) es
+  PushFrame (App1 rs)
+  ForwardExpr env (Var emptyAnno n)
+forwardExpr env (AppNamed ann n [] _) =
+  ForwardExpr env (App ann n [])
+forwardExpr _env (AppNamed _ann _n _nes Nothing) =
+  InternalException $ RuntimeTypeError
+    "named application where the order of arguments is not resolved"
+forwardExpr env (AppNamed ann n nes (Just order)) =
+  let
+    -- move expressions into order, drop names
+    es = (\ (MkNamedExpr _ _ e) -> e) . snd <$> sortOn fst (zip order nes)
+  in
+    ForwardExpr env (App ann n es)
+forwardExpr env (IfThenElse _ann e1 e2 e3) = do
+  PushFrame (IfThenElse1 e2 e3 env)
+  ForwardExpr env e1
+forwardExpr env (Consider _ann e branches) = do
+  rf <- allocate_ e env
+  matchBranches rf env branches
+forwardExpr _env (Lit _ann lit) = do
+  rval <- runLit lit
+  Backward rval
+forwardExpr _env (List _ann []) =
+  Backward ValNil
+forwardExpr env (List _ann (e : es)) =
+  ForwardExpr env (Cons emptyAnno e (List emptyAnno es))
+forwardExpr env (Where _ann e ds) = do
+  env' <- evalRecLocalDecls env ds
+  let combinedEnv = Map.union env' env
+  ForwardExpr combinedEnv e
+forwardExpr env (Regulative _ann (MkObligation _ party action due followup)) = do
+  Backward (ValObligation env (Right party) (Right action) due (fromMaybe fulfilExpr followup))
+forwardExpr env (Event _ann ev) =
+  ForwardExpr env (desugarEvent ev)
+
+backward :: WHNF -> Machine Config
+backward val = WithPoppedFrame $ \ case
+  Nothing -> Done val
+  Just (BinOp1 binOp e2 env) -> do
+    PushFrame (BinOp2 binOp val)
+    ForwardExpr env e2
+  Just (BinOp2 binOp val1) -> do
+    runBinOp binOp val1 val
+  Just f@(App1 rs) -> do
+    case val of
+      ValClosure givens e env' -> do
+        env'' <- matchGivens givens f rs
+        ForwardExpr (Map.union env'' env') e
+      ValUnappliedConstructor r -> do
+        Backward (ValConstructor r rs)
+      ValObligation env party act due followup -> do
+        (events, time) <- case rs of
+          [r, t] -> pure (r, t)
+          rs' -> InternalException $ RuntimeTypeError $
+            "expected a list of events, and a time stamp but found: " <> foldMap prettyLayout rs'
+        PushFrame (ContractFrame (Contract1 ScrutEvents {..}))
+        EvalRef events
+      v@(ValConstructor r []) | r `sameResolved` TypeCheck.fulfilRef -> backward v
+      ValAssumed r ->
+        stuckOnAssumed r -- TODO: we can do better here
+      res -> InternalException (RuntimeTypeError $ "expected a function but found: " <> prettyLayout res)
+  Just (IfThenElse1 e2 e3 env) ->
+    case boolView val of
+      Just True ->
+        ForwardExpr env e2
+      Just False ->
+        ForwardExpr env e3
+      Nothing | ValAssumed r <- val ->
+        stuckOnAssumed r
+      Nothing ->
+        InternalException $ RuntimeTypeError $
+          "expected a BOOLEAN but found: " <> prettyLayout val <> " when evaluating IF-THEN-ELSE"
+  Just (ConsiderWhen1 _scrutinee e _branches env) -> do
+    case val of
+      ValEnvironment env' ->
+        ForwardExpr (Map.union env' env) e
+      _ ->
+        InternalException $ RuntimeTypeError $
+          "expected an environment but found: " <> prettyLayout val <> " when evaluating WHEN"
+  Just PatNil0 -> do
+    case val of
+      ValNil ->
+        Backward (ValEnvironment Map.empty)
+      _ ->
+        patternMatchFailure
+  Just (PatCons0 p1 p2) -> do
+    case val of
+      ValCons rf1 rf2 -> do
+        PushFrame (PatCons1 rf2 p2)
+        matchPattern rf1 p1
+      _ ->
+        patternMatchFailure
+  Just (PatCons1 rf2 p2) -> do
+    case val of
+      ValEnvironment env1 -> do
+        PushFrame (PatCons2 env1)
+        matchPattern rf2 p2
+      _ ->
+        InternalException $ RuntimeTypeError $
+          "expected an environment but found: " <> prettyLayout val <> " when matching FOLLOWED BY"
+  Just (PatCons2 env1) ->
+    case val of
+      ValEnvironment env2 ->
+        Backward (ValEnvironment (Map.union env2 env1))
+      _ -> InternalException $ RuntimeTypeError $
+        "expected an environment but found: " <> prettyLayout val <> " when matching FOLLOWED BY"
+  Just (PatApp0 n ps) ->
+    case val of
+      ValConstructor n' rfs
+        | sameResolved n n' ->
+          if length rfs == length ps
+            then
+              let
+                pairs = zip rfs ps
+              in
+                case pairs of
+                  []             -> backward (ValEnvironment Map.empty)
+                  ((r, p) : rps) -> do
+                    PushFrame (PatApp1 [] rps)
+                    matchPattern r p
+            else InternalException $ RuntimeTypeError
+              "pattern for constructor has the wrong number of arguments"
+      _ ->
+        patternMatchFailure
+  Just (PatApp1 envs rps) ->
+    case val of
+      ValEnvironment env ->
+        case rps of
+          []              -> Backward (ValEnvironment (Map.unions (env : envs)))
+          ((r, p) : rps') -> do
+            PushFrame (PatApp1 (env : envs) rps')
+            matchPattern r p
+      _ -> InternalException $ RuntimeTypeError $
+        "expected an environment but found: " <> prettyLayout val <> " when matching constructor"
+  Just (EqConstructor1 rf rfs) -> do
+    PushFrame (EqConstructor2 val rfs)
+    EvalRef rf
+  Just (EqConstructor2 val1 rfs) -> do
+    PushFrame (EqConstructor3 rfs)
+    runBinOpEquals val1 val
+  Just (EqConstructor3 rfs) ->
+    case boolView val of
+      Just False -> Backward $ valBool False
+      Just True ->
+        case rfs of
+          [] -> Backward $ valBool True
+          ((r1, r2) : rfs') -> do
+            PushFrame (EqConstructor1 r2 rfs')
+            EvalRef r1
+      Nothing -> InternalException $ RuntimeTypeError $
+        "expected a BOOLEAN but found: " <> prettyLayout val <> " when testing equality"
+  Just (UpdateThunk rf) -> do
+    updateThunkToWHNF rf val
+    Backward val
+  Just (ContractFrame cFrame) -> backwardContractFrame val cFrame
+
+backwardContractFrame :: Value Reference -> ContractFrame -> Machine Config
+backwardContractFrame val = \case
+  Contract1 ScrutEvents {..} -> do
+    case val of
+      ValCons e es -> do
+        pushCFrame (Contract2 ScrutEvent {events = es, ..})
+        EvalRef e
+      ValNil -> Backward (ValObligation env party act due followup)
+      _ -> InternalException $ RuntimeTypeError $
+        "expected LIST EVENT but found: " <> prettyLayout val <> " when scrutinizing regulative events"
+  Contract2 ScrutEvent {..} -> do
+    (ev'party, ev'act, ev'time) <- case val of
+      ValConstructor n [p, a, t]  | n `sameResolved` TypeCheck.eventCRef -> pure (p, a, t)
+      _ -> InternalException $ RuntimeTypeError $
+        "expected an EVENT but found: " <> prettyLayout val <> " when scrutinizing a regulative event"
+    pushCFrame (Contract3 PartyWHNF {..})
+    maybeEvaluate env party
+  Contract3 PartyWHNF {..} -> do
+    pushCFrame (Contract3' PartyEqual {party = val, ..})
+    EvalRef ev'party
+  Contract3' PartyEqual {..} -> do
+    pushCFrame (Contract4 ScrutParty {ev'party = val, ..})
+    runBinOpEquals party val
+  Contract4 ScrutParty {..} -> do
+    case boolView val of
+      Nothing -> InternalException $ RuntimeTypeError $
+        "expected BOOLEAN but found: " <> prettyLayout val
+      Just True -> do
+        pushCFrame (Contract5 ActWHNF {..})
+        maybeEvaluate env act
+      Just False -> continueWithNextEvent ScrutEvents {party = Left party, ..} events
+  Contract5 ActWHNF {..} -> do
+    pushCFrame (Contract5' ActEqual {act = val, ..})
+    EvalRef ev'act
+  Contract5' ActEqual {..} -> do
+    pushCFrame (Contract6 ScrutAct {ev'act = val, ..})
+    runBinOpEquals act val
+  Contract6 ScrutAct {..} -> do
+    case boolView val of
+      Nothing -> InternalException $ RuntimeTypeError $
+        "expected BOOLEAN but found: " <> prettyLayout val
+      Just True -> case due of
+        Just due' -> do
+          pushCFrame (Contract7 StampWHNF {..})
+          forwardExpr env due'
+        Nothing -> continueWithFollowup env followup events ev'time
+      Just False -> continueWithNextEvent ScrutEvents {party = Left party, act = Left act, ..} events
+  Contract7 StampWHNF {..} -> do
+    pushCFrame (Contract8 CurTimeWHNF {due = val, ..})
+    EvalRef ev'time
+  Contract8 CurTimeWHNF {..} -> do
+    pushCFrame (Contract9 ScrutTime {ev'time = val, ..})
+    EvalRef time
+  Contract9 ScrutTime {..} -> do
+    let assertTime = \case
+          ValNumber i -> pure i
+          v -> InternalException $ RuntimeTypeError $
+            "expected a NUMBER but got: " <> prettyLayout v
+    stamp <- assertTime ev'time
+    due' <- assertTime due
+    time <- assertTime val
+    let deadline = time + due'
+    if stamp > deadline
+      then backward (ValBreached (DeadlineMissed ev'party ev'act ev'time deadline))
+      else do
+        -- NOTE: this is not too nice, but not wanting this would require to change `App1` to take MaybeEvaluated's
+        timeR <- AllocateValue ev'time
+        continueWithFollowup env followup events timeR
+  where
+    continueWithNextEvent :: ScrutEvents -> Reference -> Machine Config
+    continueWithNextEvent frame events = do
+      pushCFrame (Contract1 frame)
+      EvalRef events
+
+    pushCFrame = PushFrame . ContractFrame
+
+    continueWithFollowup :: Environment -> RExpr -> Reference -> Reference -> Machine Config
+    continueWithFollowup env followup events time = do
+      PushFrame (App1 [events, time])
+      ForwardExpr env followup
+
+maybeEvaluate :: Environment -> MaybeEvaluated -> Machine Config
+maybeEvaluate env = either Backward (ForwardExpr env)
+
+matchGivens :: GivenSig Resolved -> Frame -> [Reference] -> Machine Environment
+matchGivens (MkGivenSig _ann otns) f es = do
+  let others = foldMap (either (const []) (\x -> [fst x]) . TypeCheck.isQuantifier) otns
+  matchGivens' others f es
+
+matchGivens' :: [Resolved] -> Frame -> [Reference] -> Machine (Map Unique Reference)
+matchGivens' ns f rs = do
+  if length ns == length rs
+    then do
+      pure $ Map.fromList (zipWith (\ r v -> (getUnique r, v)) ns rs)
+    else do
+      PushFrame f -- provides better error context
+      InternalException $
+        RuntimeTypeError "given signatures' values' lengths do not match"
+
+matchBranches :: Reference -> Environment -> [Branch Resolved] -> Machine Config
+matchBranches scrutinee _env [] =
+  UserException (NonExhaustivePatterns scrutinee)
+matchBranches _scrutinee env (Otherwise _ann e : _) =
+  ForwardExpr env e
+matchBranches scrutinee env (When _ann pat e : branches) = do
+  PushFrame (ConsiderWhen1 scrutinee e branches env)
+  matchPattern scrutinee pat
+
+matchPattern :: Reference -> Pattern Resolved -> Machine Config
+matchPattern scrutinee (PatVar _ann n) = do
+  Backward (ValEnvironment (Map.singleton (getUnique n) scrutinee))
+matchPattern scrutinee (PatApp _ann n [])
+  | getUnique n == TypeCheck.emptyUnique = do -- pattern for the empty list
+  PushFrame PatNil0
+  EvalRef scrutinee
+matchPattern scrutinee (PatCons _ann p1 p2) = do
+  PushFrame (PatCons0 p1 p2 )
+  EvalRef scrutinee
+matchPattern scrutinee (PatApp _ann n ps) = do
+  PushFrame (PatApp0 n ps )
+  EvalRef scrutinee
+
+-- | This unwinds the stack until it finds the enclosing pattern match and then resumes.
+patternMatchFailure :: Machine Config
+patternMatchFailure = WithPoppedFrame $ \ case
+  Nothing ->
+    InternalException UnhandledPatternMatch
+  Just (ConsiderWhen1 scrutinee _ branches env) ->
+    matchBranches scrutinee env branches
+  Just _ ->
+    patternMatchFailure
+
+runLit :: Lit -> Machine WHNF
+runLit (NumericLit _ann num) = pure (ValNumber num)
+runLit (StringLit _ann str)  = pure (ValString str)
+
+runBinOp :: BinOp -> WHNF -> WHNF -> Machine Config
+runBinOp BinOpPlus   (ValNumber num1) (ValNumber num2)           = Backward $ ValNumber (num1 + num2)
+runBinOp BinOpMinus  (ValNumber num1) (ValNumber num2)           = Backward $ ValNumber (num1 - num2)
+runBinOp BinOpTimes  (ValNumber num1) (ValNumber num2)           = Backward $ ValNumber (num1 * num2)
+runBinOp BinOpDividedBy (ValNumber num1) (ValNumber num2)        = Backward $ ValNumber (num1 `div` num2)
+runBinOp BinOpModulo    (ValNumber num1) (ValNumber num2)        = Backward $ ValNumber (num1 `mod` num2)
+runBinOp BinOpEquals val1             val2                       = runBinOpEquals val1 val2
+runBinOp BinOpLeq    (ValNumber num1) (ValNumber num2)           = Backward $ ValBool (num1 <= num2)
+runBinOp BinOpLeq    (ValString str1) (ValString str2)           = Backward $ ValBool (str1 <= str2)
+runBinOp BinOpLeq    (ValBool b1)     (ValBool b2)               = Backward $ ValBool (b1 <= b2)
+runBinOp BinOpGeq    (ValNumber num1) (ValNumber num2)           = Backward $ ValBool (num1 >= num2)
+runBinOp BinOpGeq    (ValString str1) (ValString str2)           = Backward $ ValBool (str1 >= str2)
+runBinOp BinOpGeq    (ValBool b1)     (ValBool b2)               = Backward $ ValBool (b1 >= b2)
+runBinOp BinOpLt     (ValNumber num1) (ValNumber num2)           = Backward $ ValBool (num1 < num2)
+runBinOp BinOpLt     (ValString str1) (ValString str2)           = Backward $ ValBool (str1 < str2)
+runBinOp BinOpLt     (ValBool b1)     (ValBool b2)               = Backward $ ValBool (b1 < b2)
+runBinOp BinOpGt     (ValNumber num1) (ValNumber num2)           = Backward $ ValBool (num1 > num2)
+runBinOp BinOpGt     (ValString str1) (ValString str2)           = Backward $ ValBool (str1 > str2)
+runBinOp BinOpGt     (ValBool b1)     (ValBool b2)               = Backward $ ValBool (b1 > b2)
+runBinOp _op         (ValAssumed r) _e2                          = stuckOnAssumed r
+runBinOp _op         _e1 (ValAssumed r)                          = stuckOnAssumed r
+runBinOp _           _                _                          = InternalException (RuntimeTypeError "running bin op with invalid operation / value combination")
+
+runBinOpEquals :: WHNF -> WHNF -> Machine Config
+runBinOpEquals (ValNumber num1)        (ValNumber num2) = Backward $ valBool $ num1 == num2
+runBinOpEquals (ValString str1)        (ValString str2) = Backward $ valBool $ str1 == str2
+runBinOpEquals ValNil                  ValNil           = Backward $ valBool True
+runBinOpEquals (ValCons r1 rs1)        (ValCons r2 rs2) = do
+  PushFrame (EqConstructor1 r2 [(rs1, rs2)])
+  EvalRef r1
+runBinOpEquals (ValConstructor n1 rs1) (ValConstructor n2 rs2)
+  | sameResolved n1 n2 && length rs1 == length rs2 =
+    let
+      pairs = zip rs1 rs2
+    in
+      case pairs of
+        [] -> backward $ ValBool True
+        ((r1, r2) : rss) -> do
+          PushFrame (EqConstructor1 r2 rss)
+          EvalRef r1
+  | otherwise                                           = Backward $ ValBool False
+runBinOpEquals _                       _                = UserException EqualityOnUnsupportedType
+
+pattern ValBool :: Bool -> WHNF
+pattern ValBool b <- (boolView -> Just b)
+  where
+    ValBool b = valBool b
+
+valBool :: Bool -> WHNF
+valBool False = falseVal
+valBool True  = trueVal
+
+-- | Checks if a value is a Boolean constructor.
+boolView :: WHNF -> Maybe Bool
+boolView val =
+  case val of
+    ValConstructor n []
+      | sameResolved n TypeCheck.trueRef  -> Just True
+      | sameResolved n TypeCheck.falseRef -> Just False
+    _ -> Nothing
+
+sameResolved :: Resolved -> Resolved -> Bool
+sameResolved r1 r2 =
+  getUnique r1 == getUnique r2
+
+def :: Name -> Machine Resolved
+def n = do
+  u <- NewUnique
+  pure (Def u n)
+
+ref :: Name -> Resolved -> Machine Resolved
+ref n a =
+  let
+    (u, o) = getUniqueName a
+  in
+    pure (Ref n u o)
+
+
+stuckOnAssumed :: Resolved -> Machine b
+stuckOnAssumed assumedResolved = UserException (Stuck assumedResolved)
+
+lookupTerm :: Environment -> Resolved -> Maybe Reference
+lookupTerm env r =
+  Map.lookup (getUnique r) env
+
+expectTerm :: Environment -> Resolved -> Machine Reference
+expectTerm env r =
+  case lookupTerm env r of
+    Nothing -> InternalException (RuntimeScopeError r)
+    Just rf -> pure rf
+
+updateThunk :: Reference -> Thunk -> Machine ()
+updateThunk rf !thunk = PokeThunk rf \_ _ -> (thunk, ())
+
+updateThunkToWHNF :: Reference -> WHNF -> Machine ()
+updateThunkToWHNF rf v =
+  updateThunk rf (WHNF v)
+
+-- NOTE: Once we start evaluating a thunk, we store the (Haskell) thread
+-- that does so. If we encounter a thunk with such an entry created by
+-- ourselves, we treat it as a blackhole: we tried to evaluate the thunk
+-- again recursively, which means we're in a loop. If the evaluation was
+-- triggered by a different thread though (in our case, this basically
+-- means from a different module, then it's not necessarily a loop. We could
+-- just wait (which is what GHC does), but we just try to evaluate it as
+-- well, which should be benign.
+evalRef :: Reference -> Machine Config
+evalRef rf =
+  join $ PokeThunk rf \tid -> \case
+    thunk@(WHNF val) -> (thunk, backward val)
+    thunk@(Unevaluated tids e env)
+      | tid `Set.member` tids ->  (thunk, UserException (BlackholeForced e))
+      | otherwise -> (Unevaluated (Set.insert tid tids) e env, PushFrame (UpdateThunk rf) *> ForwardExpr env e)
+
+-- | Recursive pre-allocation, used for mutually recursive let-bindings / declarations.
+preAllocate :: [Resolved] -> Machine Environment
+preAllocate ns = do
+  pairs <- traverse PreAllocate ns
+  pure (Map.fromList pairs)
+
+allocate_ :: Expr Resolved -> Environment -> Machine Reference
+allocate_ (Var _ann n) env = do
+  -- special case where we do not actually need to allocate
+  expectTerm env n
+allocate_ expr env =
+  fst <$> Allocate expr (const env)
+
+-----------------------------------------------------------------------------
+-- Prescanning and evaluation of modules
+-----------------------------------------------------------------------------
+
+evalModule :: Environment -> Module Resolved -> Machine (Environment, [EvalDirective])
+evalModule env (MkModule _ann _uri section) = do
+  names <- scanSection section
+  env' <- preAllocate names
+  let combinedEnv = Map.union env' env
+  directives <- evalSection combinedEnv section
+  pure (env', directives)
+
+-- | Doesn't do any actual evaluation, just performs allocations
+-- and returns the environment containing all the new bindings.
+evalRecLocalDecls :: Environment -> [LocalDecl Resolved] -> Machine Environment
+evalRecLocalDecls env decls = do
+  names <- concat <$> traverse scanLocalDecl decls
+  env' <- preAllocate names
+  let combinedEnv = Map.union env' env
+  traverse_ (evalLocalDecl combinedEnv) decls
+  pure env'
+
+-- | Just collect all defined names; could plausibly be done generically.
+scanSection :: Section Resolved -> Machine [Resolved]
+scanSection (MkSection _ann _mn _maka topdecls) =
+  concat <$> traverse scanTopDecl topdecls
+
+-- | Just collect all defined names; could plausibly be done generically.
+scanTopDecl :: TopDecl Resolved -> Machine [Resolved]
+scanTopDecl (Declare _ann declare) =
+  scanDeclare declare
+scanTopDecl (Decide _ann decide) =
+  scanDecide decide
+scanTopDecl (Assume _ann assume) =
+  scanAssume assume
+scanTopDecl (Section _ann section) =
+  scanSection section
+scanTopDecl (Directive _ann _directive) =
+  pure []
+scanTopDecl (Import _ann _import_) =
+  pure []
+
+-- | Just collect all defined names; could plausibly be done generically.
+scanLocalDecl :: LocalDecl Resolved -> Machine [Resolved]
+scanLocalDecl (LocalDecide _ann decide) =
+  scanDecide decide
+scanLocalDecl (LocalAssume _ann assume) =
+  scanAssume assume
+
+scanDecide :: Decide Resolved -> Machine [Resolved]
+scanDecide (MkDecide _ann _tysig (MkAppForm _ n _ _) _expr) = pure [n]
+
+scanAssume :: Assume Resolved -> Machine [Resolved]
+scanAssume (MkAssume _ann _tysig (MkAppForm _ n _ _) _t) = pure [n]
+
+-- | The only run-time names a type declaration brings into scope are constructors and selectors.
+scanDeclare :: Declare Resolved -> Machine [Resolved]
+scanDeclare (MkDeclare _ann _tysig _appFormAka t) = scanTypeDecl t
+
+scanTypeDecl :: TypeDecl Resolved -> Machine [Resolved]
+scanTypeDecl (EnumDecl _ann conDecls) =
+  concat <$> traverse scanConDecl conDecls
+scanTypeDecl (RecordDecl _ann mcon tns) =
+  concat <$> traverse (\ c -> scanConDecl (MkConDecl emptyAnno c tns)) (toList mcon)
+scanTypeDecl (SynonymDecl _ann _t) =
+  pure []
+
+scanConDecl :: ConDecl Resolved -> Machine [Resolved]
+scanConDecl (MkConDecl _ann n [])  = pure [n]
+scanConDecl (MkConDecl _ann n tns) = pure (n : ((\ (MkTypedName _ n' _) -> n') <$> tns))
+
+evalSection :: Environment -> Section Resolved -> Machine [EvalDirective]
+evalSection env (MkSection _ann _mn _maka topdecls) =
+  concat <$> traverse (evalTopDecl env) topdecls
+
+evalTopDecl :: Environment -> TopDecl Resolved -> Machine [EvalDirective]
+evalTopDecl env (Declare _ann declare) =
+  [] <$ evalDeclare env declare
+evalTopDecl env (Decide _ann decide) =
+  [] <$ evalDecide env decide
+evalTopDecl env (Assume _ann assume) =
+  [] <$ evalAssume env assume
+evalTopDecl env (Directive _ann directive) =
+  evalDirective env directive
+evalTopDecl env (Section _ann section) =
+  evalSection env section
+evalTopDecl _env (Import _ann _import_) =
+  pure []
+
+evalDirective :: Environment -> Directive Resolved -> Machine [EvalDirective]
+evalDirective env (LazyEval ann expr) =
+  pure ((\ r -> MkEvalDirective r expr env) <$> toList (rangeOf ann))
+evalDirective _env (StrictEval _ann _expr) =
+  pure []
+evalDirective _env (Check _ann _expr) =
+  pure []
+evalDirective env (Contract ann expr t evs) =
+  evalDirective env . LazyEval ann =<< contractToEvalDirective expr t evs
+
+contractToEvalDirective :: Expr Resolved -> Expr Resolved -> [Expr Resolved] -> Machine (Expr Resolved)
+contractToEvalDirective contract t evs = do
+  evs' <- evListExpr
+  pure $ App emptyAnno TypeCheck.evalContractRef [contract, evs', t]
+  where
+  evListExpr = List emptyAnno <$> traverse eventExpr evs
+
+eventExpr :: Expr Resolved -> Machine (Expr Resolved)
+eventExpr (Event _ann ev) = pure $ desugarEvent ev
+eventExpr o = InternalException $ RuntimeTypeError $ "expected an EVENT, but got " <> prettyLayout o
+
+desugarEvent :: Event Resolved -> Expr Resolved
+desugarEvent (MkEvent ann party act timestamp) = App ann TypeCheck.eventCRef [party, act, timestamp]
+
+evalLocalDecl :: Environment -> LocalDecl Resolved -> Machine ()
+evalLocalDecl env (LocalDecide _ann decide) =
+  evalDecide env decide
+evalLocalDecl env (LocalAssume _ann assume) =
+  evalAssume env assume
+
+-- We are assuming that the environment already contains an entry with an address for us.
+evalAssume :: Environment -> Assume Resolved -> Machine ()
+evalAssume env (MkAssume _ann _tysig (MkAppForm _ n []   _maka) _) =
+  updateTerm env n (WHNF (ValAssumed n))
+evalAssume env (MkAssume _ann _tysig (MkAppForm _ n _args _maka) _) = do
+  -- TODO: we should create a given here yielding an assumed, but we currently cannot do that easily,
+  -- because we do not have Assumed as an expression, and we also cannot embed values into expressions.
+  updateTerm env n (WHNF (ValAssumed n))
+
+updateTerm :: Environment -> Resolved -> Thunk -> Machine ()
+updateTerm env n thunk = do
+  rf <- expectTerm env n
+  updateThunk rf thunk
+
+-- We are assuming that the environment already contains an entry with an address for us.
+evalDecide :: Environment -> Decide Resolved -> Machine ()
+evalDecide env (MkDecide _ann _tysig (MkAppForm _ n []   _maka) expr) =
+  updateTerm env n (Unevaluated Set.empty expr env)
+evalDecide env (MkDecide _ann _tysig (MkAppForm _ n args _maka) expr) = do
+  let
+    v = ValClosure (MkGivenSig emptyAnno ((\ r -> MkOptionallyTypedName emptyAnno r Nothing) <$> args)) expr env
+  updateTerm env n (WHNF v)
+
+-- We are assuming that the environment already contains an entry with an address for us.
+evalDeclare :: Environment -> Declare Resolved -> Machine ()
+evalDeclare env (MkDeclare _ann _tysig _appFormAka t) =
+  evalTypeDecl env t
+
+evalTypeDecl :: Environment -> TypeDecl Resolved -> Machine ()
+evalTypeDecl env (EnumDecl _ann conDecls) =
+  traverse_ (evalConDecl env) conDecls
+evalTypeDecl env (RecordDecl _ann mcon tns) =
+  traverse_ (\ c -> evalConDecl env (MkConDecl emptyAnno c tns)) mcon
+evalTypeDecl _env (SynonymDecl _ann _t) =
+  pure ()
+
+evalConDecl :: Environment -> ConDecl Resolved -> Machine ()
+evalConDecl env (MkConDecl _ann n []) =
+  updateTerm env n (WHNF (ValConstructor n []))
+evalConDecl env (MkConDecl _ann n tns) = do
+  -- constructor
+  updateTerm env n (WHNF (ValUnappliedConstructor n))
+  conRef <- ref (TypeCheck.getName n) n
+  -- selectors (we need to create fresh names for the lambda abstractions so that every binder is unique)
+  traverse_ (\ (i, MkTypedName _ sn _t) -> do
+    arg    <- def (TypeCheck.getName n)
+    argRef <- ref (TypeCheck.getName n) arg
+    args <- traverse (def . TypeCheck.getName) tns
+    body <- ref (TypeCheck.getName sn) (args !! i)
+    let
+      sel =
+        ValClosure
+          (MkGivenSig emptyAnno [MkOptionallyTypedName emptyAnno arg Nothing])      -- \ x ->
+          (Consider emptyAnno (App emptyAnno argRef [])                             -- case x of
+            [ When emptyAnno (PatApp emptyAnno conRef (PatVar emptyAnno <$> args))  --   Con y_1 ... y_n ->
+                (App emptyAnno body [])                                             --     y_i
+            ]
+          )
+          emptyEnvironment
+    updateTerm env sn (WHNF sel)
+    ) (zip [0 ..] tns)
+
+-----------------------------------------------------------------------------
+-- Premade expressions and values
+-----------------------------------------------------------------------------
+
+falseExpr :: Expr Resolved
+falseExpr = App emptyAnno TypeCheck.falseRef []
+
+falseVal :: WHNF
+falseVal = ValConstructor TypeCheck.falseRef []
+
+trueExpr :: Expr Resolved
+trueExpr = App emptyAnno TypeCheck.trueRef []
+
+trueVal :: WHNF
+trueVal = ValConstructor TypeCheck.trueRef []
+
+fulfilExpr :: Expr Resolved
+fulfilExpr = App emptyAnno TypeCheck.fulfilRef []
+
+fulfilVal :: Value a
+fulfilVal = ValConstructor TypeCheck.fulfilRef []
+
+-- \a b c. a b c
+evalContractVal :: Machine (Value a)
+evalContractVal = do
+  let mn = MkName emptyAnno . NormalName
+      (na, nb, nc) = (mn "a", mn "b", mn "c")
+  ad <- def na
+  bd <- def nb
+  cd <- def nc
+  ar <- ref na ad
+  br <- ref nb bd
+  cr <- ref nc cd
+
+  pure $ ValClosure
+    (MkGivenSig emptyAnno
+      [ MkOptionallyTypedName emptyAnno ad Nothing
+      , MkOptionallyTypedName emptyAnno bd Nothing
+      , MkOptionallyTypedName emptyAnno cd Nothing
+      ]
+    )
+    (App emptyAnno ar [App emptyAnno br [], App emptyAnno cr []])
+    emptyEnvironment
+
+-- EVENT :: party -> act -> Number -> EVENT party act
+eventCVal :: Value a
+eventCVal = ValUnappliedConstructor TypeCheck.eventCRef
+
+emptyEnvironment :: Environment
+emptyEnvironment = Map.empty
+
+data EvalDirective =
+  MkEvalDirective
+    { range :: !SrcRange -- ^ of the (L)EVAL directive
+    , expr  :: !(Expr Resolved) -- ^ expression to evaluate
+    , env   :: !Environment -- ^ environment to evaluate the expression in
+    }
+  deriving stock (Generic, Show)
+
+-----------------------------------------------------------------------------
+-- Prettyprinting of the EvalExceptions
+-----------------------------------------------------------------------------
+
+prettyEvalException :: EvalException -> [Text]
+prettyEvalException (InternalEvalException exc) = wrapInternal (prettyInternalEvalException exc)
+  where
+    wrapInternal :: [Text] -> [Text]
+    wrapInternal msgs = [ "Internal error:" ] <> msgs <> [ "Please report this as a bug." ]
+prettyEvalException (UserEvalException exc)     = prettyUserEvalException exc
+
+prettyInternalEvalException :: InternalEvalException -> [Text]
+prettyInternalEvalException = \case
+  RuntimeScopeError r ->
+    indentMany r
+    <> [ "is not in scope." ]
+  RuntimeTypeError err ->
+    [ "I encountered a type error during evaluation:" ]
+    <> [ indentSingle err ]
+  PrematureGC ->
+    [ "Trying to access an address that has already been garbage-collected." ]
+  DanglingPointer ->
+    [ "Trying to access an address that is not on the abstract machine heap." ]
+  UnhandledPatternMatch ->
+    [ "Unhandled pattern match failure." ]
+
+indentSingle :: Text -> Text
+indentSingle = ("  " <>)
+
+indentMany :: LayoutPrinter a => a -> [Text]
+indentMany = map ind . Text.lines .  prettyLayout
+  where
+    ind = ("  " <>)
+
+prettyUserEvalException :: UserEvalException -> [Text]
+prettyUserEvalException = \case
+  BlackholeForced expr ->
+    [ "Infinite loop detected while trying to evaluate:"
+    , prettyLayout expr ]
+  EqualityOnUnsupportedType -> ["Trying to check equality on types that do not support it."]
+  NonExhaustivePatterns val ->
+    [ "Value" ]
+    <> indentMany val
+    <> [ "has no corresponding pattern." ]
+  StackOverflow ->
+    [ "Stack overflow: "
+    , "Recursion depth of " <> Text.show maximumStackSize
+    , "exceeded." ]
+  Stuck r ->
+    [ "I could not continue evaluating, because I needed to know the value of" ]
+    <> indentMany r
+    <> [ "but it is an assumed term." ]
+
+maximumStackSize :: Int
+maximumStackSize = 200
+
+-- The initial environment has to be built by pre-allocation.
+initialEnvironment :: Machine Environment
+initialEnvironment = do
+  falseRef <- AllocateValue falseVal
+  trueRef  <- AllocateValue trueVal
+  nilRef   <- AllocateValue ValNil
+  evalContractRef <- AllocateValue =<< evalContractVal
+  eventCRef <- AllocateValue eventCVal
+  fulfilRef <- AllocateValue fulfilVal
+  pure $
+    Map.fromList
+      [ (TypeCheck.falseUnique, falseRef)
+      , (TypeCheck.trueUnique,  trueRef)
+      , (TypeCheck.emptyUnique, nilRef)
+      , (TypeCheck.evalContractUnique, evalContractRef)
+      , (TypeCheck.eventCUnique, eventCRef)
+      , (TypeCheck.fulfilUnique, fulfilRef)
+      ]

--- a/jl4-core/src/L4/EvaluateLazy/Machine.hs
+++ b/jl4-core/src/L4/EvaluateLazy/Machine.hs
@@ -103,14 +103,7 @@ instance Applicative Machine where
   pure = Config
 
 instance Monad Machine where
-  Config a >>= k = k a
-  Exception e >>= _k = Exception e
-  WithPoppedFrame k' >>= k = WithPoppedFrame (k' >=> k)
-  PushFrame a >>= k = Bind (PushFrame a) (\_ -> k ())
-  Allocate' a >>= k = Bind (Allocate' a) k
-  PokeThunk rf k' >>= k = Bind (PokeThunk rf k') k
-  NewUnique >>= k = Bind NewUnique k
-  Bind m k' >>= k = Bind m (k' >=> k)
+  (>>=) = Bind
 
 pattern Allocate :: Expr Resolved -> (Reference -> Environment) -> Machine (Reference, Environment)
 pattern Allocate expr k = Allocate' (Recursive expr k)
@@ -531,6 +524,7 @@ runBinOpEquals (ValConstructor n1 rs1) (ValConstructor n2 rs2)
           PushFrame (EqConstructor1 r2 rss)
           EvalRef r1
   | otherwise                                           = Backward $ ValBool False
+-- TODO: we probably also want to check ValObligations for equality
 runBinOpEquals _                       _                = UserException EqualityOnUnsupportedType
 
 pattern ValBool :: Bool -> WHNF


### PR DESCRIPTION
- introduce a new monad `Machine` that only contains the instructions of the machine 
- interpret  this Monad into `Eval` to run the machine 
- make each of the forward and backwards Machine instruction sequences return a `Config` that can the be use to interpret the respecting functions with, to make the mutual recursion explicit. 