### PR TITLE
Ladder backend: Stub out a draft / dummy handler for the custom request `l4/evalApp` that parses request params but just returns Null for now (#376)

### DIFF
--- a/jl4-lsp/app/LSP/L4/Handlers.hs
+++ b/jl4-lsp/app/LSP/L4/Handlers.hs
@@ -276,7 +276,7 @@ handlers recorder =
 
             pure (Right (InL items))
     , requestHandler SMethod_TextDocumentCodeLens $ \ide params -> do
-        verTextDocId <- liftIO $ runAction "codeLens.getVersionedTextDoc" ide $
+        verTextDocId <- liftIO $ runAction "codeLens.getVersionedTextDocId" ide $
           FileStore.getVersionedTextDoc $ params ^. J.textDocument
 
         typeCheck <- liftIO $ runAction "typecheck" ide $

--- a/jl4-lsp/app/LSP/L4/Handlers.hs
+++ b/jl4-lsp/app/LSP/L4/Handlers.hs
@@ -30,6 +30,7 @@ import Data.Text (Text)
 import qualified Base.Text as Text
 import qualified Data.Text.Lazy as LazyText
 import GHC.Generics
+import Data.Proxy (Proxy (..))
 import LSP.L4.Base
 import LSP.L4.Config
 import LSP.L4.Rules hiding (Log (..))
@@ -44,6 +45,7 @@ import qualified LSP.Core.Shake as Shake
 import LSP.Core.Types.Diagnostics
 import LSP.Core.Types.Location
 import qualified LSP.L4.Viz.Ladder as Ladder
+import LSP.L4.Viz.CustomProtocol as Ladder
 import LSP.Logger
 import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Protocol.Message
@@ -84,6 +86,7 @@ data Log
   | LogRequestedCompletionsFor !Text
   | LogFileStore FileStore.Log
   | LogMultipleDecideClauses !Uri
+  | LogReceivedCustomRequest !Uri !Text          -- ^ Uri CustomMethodName
   | LogSuppliedTooManyArguments [Aeson.Value]
   | LogExecutingCommand !Text
   | LogShake Shake.Log
@@ -101,6 +104,7 @@ instance Pretty Log where
     LogExecutingCommand cmd -> "Executing command:" <+> pretty cmd
     LogFileStore msg -> pretty msg
     LogShake msg -> pretty msg
+    LogReceivedCustomRequest uri method -> "Received custom request:" <+> pretty (getUri uri) <+> pretty method
 
 -- ----------------------------------------------------------------------------
 -- Reactor
@@ -327,6 +331,21 @@ handlers recorder =
 
         let locs = map (\range -> Location (fromNormalizedUri range.moduleUri) (srcRangeToLspRange (Just range))) $ lookupReference pos refs
         pure (Right (InL locs))
+
+    -- custom requests
+    , requestHandler (SMethod_CustomMethod (Proxy @Ladder.EvalAppMethodName)) $ \_ide params -> do
+        let methodName = getMethodName (Proxy @Ladder.EvalAppMethodName)
+        case Aeson.fromJSON params :: Aeson.Result EvalAppRequestParams of
+          Aeson.Success evalParams -> do
+            logWith recorder Debug $ LogReceivedCustomRequest evalParams.verDocId._uri methodName
+            -- Haven't implemented the actual call to eval yet; just returning null for now
+            pure $ Right Aeson.Null
+          Aeson.Error err -> do
+            pure $ Left $ TResponseError
+              { _code = InR ErrorCodes_InvalidRequest
+              , _message = "Invalid params for " <> methodName <> ": " <> Text.pack err
+              , _xdata = Nothing
+              }
     ]
 
 activeFileDiagnosticsInRange :: ShakeExtras -> NormalizedUri -> Range -> STM [FileDiagnostic]

--- a/jl4-lsp/jl4-lsp.cabal
+++ b/jl4-lsp/jl4-lsp.cabal
@@ -107,6 +107,7 @@ library
     LSP.L4.Oneshot
     LSP.L4.Viz.VizExpr
     LSP.L4.Viz.Ladder
+    LSP.L4.Viz.CustomProtocol
 
 executable jl4-lsp
   import: defaults

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 
--- | Custom extensions to the LSP and payload types for JL4
+{-| Custom extensions to the LSP and payload types for JL4
+    See also @ts-shared/jl4-client-rpc/custom-protocol.ts@
+-}
 module LSP.L4.Viz.CustomProtocol where
 
 import qualified Base.Text as T

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DataKinds #-}
+
+-- | Custom extensions to the LSP and payload types for JL4
+module LSP.L4.Viz.CustomProtocol where
+
+import qualified Base.Text as T
+import Data.Aeson   (FromJSON, ToJSON)
+import GHC.Generics (Generic)
+import Data.Proxy (Proxy(..))
+import GHC.TypeLits  (Symbol, KnownSymbol, symbolVal)
+import Language.LSP.Protocol.Types as LSP
+import LSP.L4.Viz.VizExpr
+
+------------------------------------------------------
+-- l4/evalApp Request Params and Response Payload
+------------------------------------------------------
+
+-- | Payload / params for EvalAppRequest
+data EvalAppRequestParams = EvalAppRequestParams
+  { appExpr :: ID,
+    -- | I don't want to bother defining a BoolValue just for this;
+    -- can be cleaned up in the future
+    args :: [UBoolValue],
+    verDocId :: LSP.VersionedTextDocumentIdentifier
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- | l4/evalApp response payload
+newtype EvalAppResult = EvalAppResult
+  { value :: UBoolValue }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+------------------------------------------------------
+--  l4/evalApp custom method for LSP
+------------------------------------------------------
+
+type EvalAppMethodName :: Symbol
+type EvalAppMethodName = "l4/evalApp"
+
+------------------------------------------------------
+--  IsCustomMethod typeclass
+------------------------------------------------------
+
+class KnownSymbol a => IsCustomMethod (a :: Symbol) where
+  getMethodName :: Proxy a -> T.Text
+  getMethodName = T.pack . symbolVal
+
+instance IsCustomMethod EvalAppMethodName


### PR DESCRIPTION
Changes:
* Fix typo from a previous pr
* Init `LSP.L4.Viz.CustomProtocol` with `EvalAppMethodName` and backend version of the payloads for `l4/evalApp`
* Handlers.hs: Stub out draft / dummy handler for `l4/evalApp`; just return null for now

The following screenshot demonstrates how the server will handle the request and respond with Null when we click on `arg1`.

<img width="1445" alt="image" src="https://github.com/user-attachments/assets/7d34cf41-6ba5-46b2-89be-2d0295d65413" />

* Note, again, that you'll need to set dev mode to true to see this.
* Don't worry about UI for arg1 --- the UI won't update till we actually send a False or True or Unknown result back.
