### PR TITLE
Ladder backend: Finish implementing the eval app handler

### DIFF
--- a/jl4-core/src/Base.hs
+++ b/jl4-core/src/Base.hs
@@ -27,6 +27,7 @@ import Data.Text as X (Text)
 import Data.TreeDiff.Class as X (ToExpr)
 import Data.Void as X
 import GHC.Generics as X (Generic)
+import Optics.Core as X ((&), (.~))
 import Optics.AffineFold as X
 import Optics.Getter as X
 import Optics.Lens as X

--- a/jl4-core/src/L4/EvaluateLazy.hs
+++ b/jl4-core/src/L4/EvaluateLazy.hs
@@ -166,7 +166,7 @@ nfDirective (MkEvalDirective r expr env) = do
 
 data EvalDirectiveResult =
   MkEvalDirectiveResult
-    { range  :: !SrcRange -- ^ of the (L)EVAL / CONTRACT directive
+    { range  :: !(Maybe SrcRange) -- ^ of the (L)EVAL / CONTRACT directive
     , result :: Either EvalException NF
     }
   deriving stock (Generic, Show)

--- a/jl4-core/src/L4/EvaluateLazy.hs
+++ b/jl4-core/src/L4/EvaluateLazy.hs
@@ -166,7 +166,7 @@ nfDirective (MkEvalDirective r expr env) = do
 
 data EvalDirectiveResult =
   MkEvalDirectiveResult
-    { range  :: !(Maybe SrcRange) -- ^ of the (L)EVAL / CONTRACT directive
+    { range  :: Maybe SrcRange -- ^ of the (L)EVAL / CONTRACT directive
     , result :: Either EvalException NF
     }
   deriving stock (Generic, Show)

--- a/jl4-core/src/L4/EvaluateLazy.hs
+++ b/jl4-core/src/L4/EvaluateLazy.hs
@@ -2,6 +2,7 @@
 module L4.EvaluateLazy
 ( EvalDirectiveResult (..)
 , execEvalModuleWithEnv
+, execEvalExprInContextOfModule
 , prettyEvalException
 )
 where
@@ -13,6 +14,7 @@ import L4.EvaluateLazy.Machine
 import Control.Concurrent
 import L4.Evaluate.ValueLazy
 import L4.Parser.SrcSpan (SrcRange)
+import L4.Annotation
 import L4.Syntax
 
 -----------------------------------------------------------------------------
@@ -242,3 +244,31 @@ evalModuleAndDirectives env m = do
   -- Depending on future export semantics, this may have to change.
   pure (env', results)
 
+
+{- | Evaluate an expression in the context of a module and initial environment.
+
+Didn't try to cache even more computation with rules, 
+because the current Rule type seems to
+be Uri-focused, and so you'll emd up needing to pretty print and then re-parse.
+Also, it's not clear how much caching can actually be done,
+given that we won't be re-using the result from this.
+ -}
+execEvalExprInContextOfModule :: Expr Resolved -> (Environment, Module Resolved) -> IO (Maybe EvalDirectiveResult)
+execEvalExprInContextOfModule expr (env, m) = do
+  let
+    evalExprDirective =
+      Directive emptyAnno $ LazyEval emptyAnno expr
+    -- Didn't make a new module that imported the context module,
+    -- because making the import requires a Resolved.
+    moduleWithoutDirectives = over moduleTopDecls (filter $ not . isDirective) m
+  (_, res) <- execEvalModuleWithEnv env (evalExprDirective `prependToModule` moduleWithoutDirectives)
+  case res of
+    [result] -> pure (Just result)
+    _        -> pure Nothing
+  where
+    isDirective :: TopDecl Resolved -> Bool
+    isDirective (Directive _ _) = True
+    isDirective _ = False
+
+    prependToModule :: TopDecl Resolved -> Module Resolved -> Module Resolved
+    prependToModule newDecl = over moduleTopDecls (newDecl :)

--- a/jl4-core/src/L4/EvaluateLazy/Machine.hs
+++ b/jl4-core/src/L4/EvaluateLazy/Machine.hs
@@ -898,7 +898,7 @@ emptyEnvironment = Map.empty
 
 data EvalDirective =
   MkEvalDirective
-    { range :: !(Maybe SrcRange) -- ^ of the (L)EVAL directive
+    { range :: Maybe SrcRange -- ^ of the (L)EVAL directive
     , expr  :: !(Expr Resolved) -- ^ expression to evaluate
     , env   :: !Environment -- ^ environment to evaluate the expression in
     }

--- a/jl4-core/src/L4/EvaluateLazy/Machine.hs
+++ b/jl4-core/src/L4/EvaluateLazy/Machine.hs
@@ -18,6 +18,7 @@ module L4.EvaluateLazy.Machine
 , evalRef
 , emptyEnvironment
 , prettyEvalException
+, boolView
 )
 where
 
@@ -596,7 +597,7 @@ valBool False = falseVal
 valBool True  = trueVal
 
 -- | Checks if a value is a Boolean constructor.
-boolView :: WHNF -> Maybe Bool
+boolView :: Value a -> Maybe Bool
 boolView val =
   case val of
     ValConstructor n []

--- a/jl4-core/src/L4/EvaluateLazy/Machine.hs
+++ b/jl4-core/src/L4/EvaluateLazy/Machine.hs
@@ -758,7 +758,7 @@ evalTopDecl _env (Import _ann _import_) =
 
 evalDirective :: Environment -> Directive Resolved -> Machine [EvalDirective]
 evalDirective env (LazyEval ann expr) =
-  pure ((\ r -> MkEvalDirective r expr env) <$> toList (rangeOf ann))
+  pure [MkEvalDirective (rangeOf ann) expr env]
 evalDirective _env (StrictEval _ann _expr) =
   pure []
 evalDirective _env (Check _ann _expr) =
@@ -898,7 +898,7 @@ emptyEnvironment = Map.empty
 
 data EvalDirective =
   MkEvalDirective
-    { range :: !SrcRange -- ^ of the (L)EVAL directive
+    { range :: !(Maybe SrcRange) -- ^ of the (L)EVAL directive
     , expr  :: !(Expr Resolved) -- ^ expression to evaluate
     , env   :: !Environment -- ^ environment to evaluate the expression in
     }

--- a/jl4-core/src/L4/Syntax.hs
+++ b/jl4-core/src/L4/Syntax.hs
@@ -323,6 +323,12 @@ updateImport imported i@(MkImport ann n _) = case mapMaybe (\(importName, import
   (u' : _) -> MkImport ann n (Just u')
   [] -> i
 
+moduleTopDecls :: Lens' (Module n) [TopDecl n]
+moduleTopDecls = lens
+                 (\(MkModule _ _ (MkSection _ _ _ decls)) -> decls)
+                 (\(MkModule ann nuri (MkSection sann sresolved maka _oldDecls)) decls ->
+                     MkModule ann nuri (MkSection sann sresolved maka decls))
+
 -- ----------------------------------------------------------------------------
 -- Source Annotations
 -- ----------------------------------------------------------------------------

--- a/jl4-lsp/app/LSP/L4/Handlers.hs
+++ b/jl4-lsp/app/LSP/L4/Handlers.hs
@@ -361,7 +361,6 @@ handlers recorder =
               
               (Just tcRes, Just recentViz) 
                 | evalParams.verDocId == recentViz.vizState.env.verTxtDocId -> do
-                    logWith recorder Debug $ LogReceivedCustomRequest evalParams.verDocId._uri ("Evaluating with params: " <> Text.pack (show evalParams))
                     mEvalDeps <- liftIO $ runAction "l4/evalApp" ide $ use (AttachCallStack [recentViz.vizState.env.moduleUri] GetLazyEvaluationDependencies) recentViz.vizState.env.moduleUri
                     case mEvalDeps of
                       Nothing -> throwError $ TResponseError
@@ -370,8 +369,6 @@ handlers recorder =
                         , _xdata = Nothing
                         }
                       Just (evalEnv, _) -> do
-                        logWith recorder Debug $ LogReceivedCustomRequest evalParams.verDocId._uri 
-                          ("Got eval deps, env size: " <> Text.pack (show (length (show evalEnv))))
                         result <- evalApp tcRes evalParams recentViz evalEnv
                         logWith recorder Debug $ LogReceivedCustomRequest evalParams.verDocId._uri 
                           ("Eval result: " <> Text.pack (show result))

--- a/jl4-lsp/src/LSP/Core/Shake.hs
+++ b/jl4-lsp/src/LSP/Core/Shake.hs
@@ -155,7 +155,6 @@ import Base.Text (Text)
 import GHC.Generics
 import Data.Hashable (Hashable)
 import qualified LSP.L4.Viz.Ladder as Ladder
-import qualified LSP.L4.Viz.VizExpr as Ladder
 
 data Log
   = LogCreateHieDbExportsMapStart
@@ -297,7 +296,6 @@ data RecentlyVisualised = RecentlyVisualised
   { pos     :: !SrcPos
   , name    :: !RawName
   , type'   :: !(Type' Resolved)
-  , funDecl :: !Ladder.FunDecl
   , vizState  :: !Ladder.VizState
   }
   deriving stock (Show, Eq)

--- a/jl4-lsp/src/LSP/Core/Shake.hs
+++ b/jl4-lsp/src/LSP/Core/Shake.hs
@@ -298,7 +298,7 @@ data RecentlyVisualised = RecentlyVisualised
   , name    :: !RawName
   , type'   :: !(Type' Resolved)
   , funDecl :: !Ladder.FunDecl
-  , vizEnv  :: !Ladder.VizEnv
+  , vizState  :: !Ladder.VizState
   }
   deriving stock (Show, Eq)
 

--- a/jl4-lsp/src/LSP/Core/Shake.hs
+++ b/jl4-lsp/src/LSP/Core/Shake.hs
@@ -293,12 +293,12 @@ data ShakeExtras = ShakeExtras
     }
 
 data RecentlyVisualised = RecentlyVisualised
-  { pos     :: !SrcPos
-  , name    :: !RawName
-  , type'   :: !(Type' Resolved)
+  { pos       :: !SrcPos
+  , name      :: !RawName
+  , type'     :: !(Type' Resolved)
   , vizState  :: !Ladder.VizState
   }
-  deriving stock (Show, Eq)
+  deriving stock (Show)
 
 type GetStalePersistent = NormalizedUri -> IdeAction (Maybe (Dynamic,PositionDelta,Maybe Int32))
 

--- a/jl4-lsp/src/LSP/Core/Shake.hs
+++ b/jl4-lsp/src/LSP/Core/Shake.hs
@@ -154,6 +154,8 @@ import qualified Data.Text.Mixed.Rope as Rope
 import Base.Text (Text)
 import GHC.Generics
 import Data.Hashable (Hashable)
+import qualified LSP.L4.Viz.Ladder as Ladder
+import qualified LSP.L4.Viz.VizExpr as Ladder
 
 data Log
   = LogCreateHieDbExportsMapStart
@@ -291,8 +293,13 @@ data ShakeExtras = ShakeExtras
     , mostRecentlyVisualized :: TMVar RecentlyVisualised
     }
 
-data RecentlyVisualised
-  = RecentlyVisualised {pos :: !SrcPos, name :: !RawName, type' :: !(Type' Resolved), simplify :: !Bool}
+data RecentlyVisualised = RecentlyVisualised
+  { pos     :: !SrcPos
+  , name    :: !RawName
+  , type'   :: !(Type' Resolved)
+  , funDecl :: !Ladder.FunDecl
+  , vizEnv  :: !Ladder.VizEnv
+  }
   deriving stock (Show, Eq)
 
 type GetStalePersistent = NormalizedUri -> IdeAction (Maybe (Dynamic,PositionDelta,Maybe Int32))

--- a/jl4-lsp/src/LSP/L4/Actions.hs
+++ b/jl4-lsp/src/LSP/L4/Actions.hs
@@ -219,11 +219,14 @@ visualise mtcRes (getRecVis, setRecVis) verTextDocId msrcPos = do
             , Ladder.prettyPrintVizError vizError
             ]
   where
-    {- | Make a new VizEnv by combining (i) old config (e.g. whether to simplify) from the RecentlyVisualized (which itself contains a VizEnv)
+    {- | Make a new VizConfig by combining (i) old config (e.g. whether to simplify) from the RecentlyVisualized (which itself contains a VizConfig)
     with (ii) up-to-date versions of potentially stale info (verTxtDocId, tcRes) -}
-    updateVizEnv :: VersionedTextDocumentIdentifier -> TypeCheckResult -> RecentlyVisualised -> Ladder.VizEnv
-    updateVizEnv verTxtDocId tcRes recentlyVisualised =
-      Ladder.mkVizEnv verTxtDocId tcRes.substitution recentlyVisualised.vizState.env.shouldSimplify
+    updateVizConfig :: VersionedTextDocumentIdentifier -> TypeCheckResult -> RecentlyVisualised -> Ladder.VizConfig
+    updateVizConfig verTxtDocId tcRes recentlyVisualised = 
+      Ladder.getVizConfig recentlyVisualised.vizState
+        & set #verTxtDocId verTxtDocId
+        & set #moduleUri (toNormalizedUri verTxtDocId._uri)
+        & set #substitution tcRes.substitution
 
     -- TODO: in the future we want to be a bit more clever wrt. which
     -- DECIDE/MEANS we snap to. We can use the type of the 'Decide' here

--- a/jl4-lsp/src/LSP/L4/Actions.hs
+++ b/jl4-lsp/src/LSP/L4/Actions.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns, DataKinds #-}
 module LSP.L4.Actions where
 
 import Base
@@ -110,13 +110,13 @@ gotoDefinition pos m positionMapping = do
 -- ----------------------------------------------------------------------------
 
 evalApp
-  :: forall m method.
+  :: forall m.
   (MonadIO m)
   => TypeCheckResult
   -> Ladder.EvalAppRequestParams
   -> RecentlyVisualised
   -> EL.Environment
-  -> ExceptT (TResponseError method) m Aeson.Value
+  -> ExceptT (TResponseError ('Method_CustomMethod Ladder.EvalAppMethodName)) m Aeson.Value
 evalApp tcRes evalParams recentViz evalEnv =
   case Ladder.lookupEvalAppMaker recentViz.vizState evalParams.appExpr of
     Nothing -> defaultResponseError "No eval app directive maker found" -- TODO: Improve error codehere

--- a/jl4-lsp/src/LSP/L4/Actions.hs
+++ b/jl4-lsp/src/LSP/L4/Actions.hs
@@ -135,7 +135,7 @@ evalApp tcRes evalParams recentViz evalEnv =
         case EL.boolView val of
           Just b  -> pure $ EvalAppResult (toUBoolValue b)
           Nothing -> throwExpectBoolResultError
-      Right EL.ToDeep    -> throwExpectBoolResultError
+      Right EL.ToDeep    -> defaultResponseError "Evaluation exceeded maximum depth limit"
       Left err           -> defaultResponseError $ Text.unlines $ EL.prettyEvalException err
 
     throwExpectBoolResultError :: ExceptT (TResponseError method) m a

--- a/jl4-lsp/src/LSP/L4/Actions.hs
+++ b/jl4-lsp/src/LSP/L4/Actions.hs
@@ -217,22 +217,21 @@ visualise mtcRes (getRecVis, setRecVis) verTextDocId msrcPos = do
 
   -- Makes a 'RecentlyVisualised' iff the given 'Decide' has a valid range and a resolved type.
   -- Assumes the given vizEnv is up-to-date.
-  let recentlyVisualisedDecide (MkDecide Anno {range = Just range, extra = Extension {resolvedInfo = Just (TypeInfo ty _)}} _tydec appform _expr) vizState funDecl
+  let recentlyVisualisedDecide (MkDecide Anno {range = Just range, extra = Extension {resolvedInfo = Just (TypeInfo ty _)}} _tydec appform _expr) vizState
         = Just RecentlyVisualised
           { pos = range.start
           , name = rawName $ getName appform
           , type' = applyFinalSubstitution vizState.env.substitution vizState.env.moduleUri ty
-          , funDecl = funDecl
           , vizState = vizState
           }
-      recentlyVisualisedDecide _ _ _ = Nothing
+      recentlyVisualisedDecide _ _ = Nothing
 
   case mdecide of
     Nothing -> pure (InR Null)
     Just (decide, vizEnv) ->
       case Ladder.doVisualize decide vizEnv of
         Right (vizProgramInfo, vizState) -> do
-          traverse_ (lift . setRecVis) $ recentlyVisualisedDecide decide vizState vizProgramInfo.funDecl
+          traverse_ (lift . setRecVis) $ recentlyVisualisedDecide decide vizState
           pure $ InL $ Aeson.toJSON vizProgramInfo
         Left vizError ->
           defaultResponseError $ Text.unlines

--- a/jl4-lsp/src/LSP/L4/Actions.hs
+++ b/jl4-lsp/src/LSP/L4/Actions.hs
@@ -139,7 +139,7 @@ visualise mtcRes (getRecVis, setRecVis) verTextDocId msrcPos = do
         -- https://hackage.haskell.org/package/lsp-types-2.3.0.1/docs/Language-LSP-Protocol-Types.html#t:VersionedTextDocumentIdentifier
         _ -> defaultResponseError "The program was changed in the time between pressing the code lens and rendering the program"
 
-  -- Makes a 'RecentlyVisualised' record iff the given 'Decide' has a valid range and a resolved type.
+  -- Makes a 'RecentlyVisualised' iff the given 'Decide' has a valid range and a resolved type.
   -- Assumes the given vizEnv is up-to-date.
   let recentlyVisualisedDecide (MkDecide Anno {range = Just range, extra = Extension {resolvedInfo = Just (TypeInfo ty _)}} _tydec appform _expr) vizEnv funDecl
         = Just RecentlyVisualised 

--- a/jl4-lsp/src/LSP/L4/Rules.hs
+++ b/jl4-lsp/src/LSP/L4/Rules.hs
@@ -658,7 +658,7 @@ jl4Rules rootDirectory recorder = do
     evalLazyResultToDiagnostic :: EvaluateLazy.EvalDirectiveResult -> Diagnostic
     evalLazyResultToDiagnostic (EvaluateLazy.MkEvalDirectiveResult range res) = do
       Diagnostic
-        { _range = srcRangeToLspRange (Just range)
+        { _range = srcRangeToLspRange range
         , _severity = Just LSP.DiagnosticSeverity_Information
         , _code = Nothing
         , _codeDescription = Nothing

--- a/jl4-lsp/src/LSP/L4/Rules.hs
+++ b/jl4-lsp/src/LSP/L4/Rules.hs
@@ -43,7 +43,6 @@ import LSP.Logger
 import LSP.SemanticTokens
 import Language.LSP.Protocol.Types
 import qualified Language.LSP.Protocol.Types as LSP
-import Optics ((&), (.~))
 import Data.Either (partitionEithers)
 import qualified L4.ExactPrint as ExactPrint
 import qualified Data.List as List

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -22,7 +22,7 @@ data EvalAppRequestParams = EvalAppRequestParams
   { appExpr :: ID,
     {- | I don't want to bother defining a BoolValue just for this;
         can be cleaned up in the future.
-        Also, prob better to make UBoolLit exprs or smtg
+        Also, prob better to make the @args@ UBoolLit exprs or smtg
     -}
     args :: [UBoolValue],
     verDocId :: LSP.VersionedTextDocumentIdentifier

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -20,8 +20,10 @@ import LSP.L4.Viz.VizExpr
 -- | Payload / params for EvalAppRequest
 data EvalAppRequestParams = EvalAppRequestParams
   { appExpr :: ID,
-    -- | I don't want to bother defining a BoolValue just for this;
-    -- can be cleaned up in the future
+    {- | I don't want to bother defining a BoolValue just for this;
+        can be cleaned up in the future.
+        Also, prob better to make UBoolLit exprs or smtg
+    -}
     args :: [UBoolValue],
     verDocId :: LSP.VersionedTextDocumentIdentifier
   }

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -127,7 +127,8 @@ prepEvalAppMaker vid = \case
     in #evalAppMakers %= Map.insert vid.id maker
   _ -> pure ()
 
--- | Helper
+-- Viz state helpers
+
 lookupEvalAppMaker :: VizState -> V.ID -> Maybe (V.EvalAppRequestParams -> TopDecl Resolved)
 lookupEvalAppMaker vs vid = Map.lookup vid.id vs.evalAppMakers
 
@@ -187,10 +188,10 @@ translateDecide :: Decide Resolved -> Viz V.FunDecl
 translateDecide (MkDecide _ (MkTypeSig _ givenSig _) (MkAppForm _ funResolved _ _) body) =
   do
     shouldSimplify <- getShouldSimplify
-    uid            <- getFresh
+    vid            <- getFresh
     vizBody        <- translateExpr shouldSimplify body
     pure $ V.MkFunDecl
-      uid
+      vid
       -- didn't want a backtick'd name in the header
       (mkSimpleVizName funResolved)
       (paramNamesFromGivens givenSig)
@@ -264,17 +265,17 @@ defaultUBoolVarValue :: V.UBoolValue
 defaultUBoolVarValue = V.UnknownV
 
 leafFromVizName :: V.ID -> V.Name -> Viz IRExpr
-leafFromVizName uid vname = do
-  pure $ V.UBoolVar uid vname defaultUBoolVarValue
+leafFromVizName vid vname = do
+  pure $ V.UBoolVar vid vname defaultUBoolVarValue
 
 leaf :: Text -> Text -> Viz IRExpr
 leaf subject complement = do
-  uid <- getFresh
+  vid <- getFresh
   tempUniqueTODO <- getFresh
   -- tempUniqueTODO: I'd like to defer properly handling the V.Name for `leaf` and the kinds of cases it's used for.
   -- I'll return to this when we explicitly/properly handle more cases in translateExpr
   -- (I'm currently focusing on state in the frontend in the simpler case of App with no args)
-  pure $ V.UBoolVar uid (V.MkName tempUniqueTODO.id $ subject <> " " <> complement) defaultUBoolVarValue
+  pure $ V.UBoolVar vid (V.MkName tempUniqueTODO.id $ subject <> " " <> complement) defaultUBoolVarValue
 
 ------------------------------------------------------
 -- Name helpers

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-{-# HLINT ignore "Redundant lambda" #-}
 
 module LSP.L4.Viz.Ladder (
   -- * Entrypoint
@@ -126,6 +124,7 @@ getShouldSimplify = do
   cfg <- getVizCfg
   pure cfg.shouldSimplify
 
+{-# ANN prepEvalAppMaker ("HLINT: ignore Redundant lambda" :: String) #-}
 {- | Assumes that the program is well-scoped and well-typed -}
 prepEvalAppMaker :: V.ID -> Expr Resolved -> Viz ()
 prepEvalAppMaker vid = \ case

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -10,7 +10,8 @@ module LSP.L4.Viz.Ladder (
   mkVizEnv,
 
   -- * Helpers
-  prettyPrintVizError
+  prettyPrintVizError,
+  lookupApp
   ) where
 
 import Control.DeepSeq
@@ -106,14 +107,13 @@ getShouldSimplify = do
   env <- getVizEnv
   pure env.shouldSimplify
 
--- lookupApp :: V.ID -> Viz (Maybe (Expr Resolved))
--- lookupApp id = do
---   appExprs <- use #appExprs
---   pure $ Map.lookup id.id appExprs
-
 storeApp :: V.ID -> Expr Resolved -> Viz ()
 storeApp vid expr = do
   #appExprs %= Map.insert vid.id expr
+
+-- | Helper
+lookupApp :: V.ID -> VizState -> Maybe (Expr Resolved)
+lookupApp vid vs = Map.lookup vid.id vs.appExprs
 
 ------------------------------------------------------
 -- VizError
@@ -139,7 +139,7 @@ prettyPrintVizError = \ case
 
 -- | Entrypoint: Generate boolean circuits of the given 'Decide'.
 doVisualize :: Decide Resolved -> VizEnv -> Either VizError (RenderAsLadderInfo, VizState)
-doVisualize decide env = 
+doVisualize decide env =
   let (result, vizState) = (vizProgram decide).getVizE (mkInitialVizState env)
   in case result of
     Left err         -> Left err

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -14,6 +14,7 @@ module LSP.L4.Viz.Ladder (
   -- * Viz State helpers
   lookupEvalAppMaker,
   getVizConfig,
+  
   -- * Other helpers
   prettyPrintVizError,
   ) where

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -6,7 +6,7 @@ module LSP.L4.Viz.Ladder (
   -- * Entrypoint
   doVisualize,
 
-  -- * VizEnv, VizState
+  -- * VizConfig, VizState
   VizConfig (..),
   mkVizConfig,
   VizState (..),
@@ -125,12 +125,12 @@ getShouldSimplify = do
 
 {- | Assumes that the program is well-scoped and well-typed -}
 prepEvalAppMaker :: V.ID -> Expr Resolved -> Viz ()
-prepEvalAppMaker vid = \case
+prepEvalAppMaker vid = \ case
   App appAnno appResolved _ -> do
     localDecls <- getLocalDecls
     let maker = \V.EvalAppRequestParams{args} ->
           Directive emptyAnno $ LazyEval emptyAnno $
-            Where emptyAnno 
+            Where emptyAnno
               (App appAnno appResolved $ map toBoolExpr args)
               localDecls
     #evalAppMakers %= Map.insert vid.id maker
@@ -337,7 +337,7 @@ isBooleanType ty = do
 ------------------------------------------------------
 
 toBoolExpr :: V.UBoolValue -> Expr Resolved
-toBoolExpr = \case
+toBoolExpr = \ case
   V.FalseV   -> App emptyAnno TC.falseRef []
   V.TrueV    -> App emptyAnno TC.trueRef []
   V.UnknownV -> error "impossible for now"

--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -69,7 +69,7 @@ data VizEnv = MkVizEnv
 data VizState = MkVizState
   { env      :: !VizEnv
   , maxId    :: !ID
-  , appExprs :: Map Int (Expr Resolved)
+  , appExprs :: !(Map Int (Expr Resolved))
   -- ^ Unique of V.ID => App exprs
   }
   deriving stock (Show, Generic, Eq)

--- a/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
@@ -42,6 +42,7 @@ data IRExpr
   | App ID Name [IRExpr]
   deriving (Show, Eq, Generic)
 
+{- | See  viz-expr-to-lir.ts and ladder.svelte.ts for examples of how the IRIds get used -}
 newtype ID = MkID
   { id :: Int
   }

--- a/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
@@ -6,7 +6,7 @@ import Autodocodec.Aeson ()
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List.NonEmpty as NE
-import Data.Text (Text)
+import Base.Text (Text)
 import Data.Tuple.Optics
 import GHC.Generics (Generic)
 import Optics

--- a/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/VizExpr.hs
@@ -13,8 +13,8 @@ import Optics
 import qualified Language.LSP.Protocol.Types as LSP
 
 data RenderAsLadderInfo = MkRenderAsLadderInfo
-  { verDocId :: LSP.VersionedTextDocumentIdentifier
-  , funDecl      :: FunDecl
+  { verDocId  :: LSP.VersionedTextDocumentIdentifier
+  , funDecl   :: FunDecl
   }
   deriving stock (Show, Generic, Eq)
 

--- a/jl4/tests/Main.hs
+++ b/jl4/tests/Main.hs
@@ -164,7 +164,7 @@ checkFile isOk file = do
  where
   typeErrorToMessage err = (JL4.rangeOf err, JL4.prettyCheckErrorWithContext err)
   evalDirectiveResultToMessage (JL4.MkEvalDirectiveResult r res _) = (Just r, either JL4.prettyEvalException (List.singleton . Print.prettyLayout) res)
-  evalLazyDirectiveResultToMessage (JL4Lazy.MkEvalDirectiveResult r res) = (Just r, either JL4Lazy.prettyEvalException (List.singleton . Print.prettyLayout) res)
+  evalLazyDirectiveResultToMessage (JL4Lazy.MkEvalDirectiveResult r res) = (r, either JL4Lazy.prettyEvalException (List.singleton . Print.prettyLayout) res)
   renderMessage (r, txt) = cliErrorMessage r txt
 
 data CliError

--- a/ts-apps/decision-logic-visualizer/src/lib/eval/eval.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/eval/eval.ts
@@ -154,6 +154,7 @@ export const Evaluator: LadderEvaluator = {
             argsForApp,
             verDocId
           )
+          console.log('eval.ts: eval app lspResponse', lspResponse)
           if (!lspResponse) {
             throw new Error(`Problem evaluating App ${expr}`)
           }


### PR DESCRIPTION
## Key things that this PR does

* eval app handler: Return LSPErrorCodes_ContentModified if server's version does not match version in eval app request from client
* Flesh out the eval app handler on the backend.
  * Prep an 'app expr maker' when the Decide is first visualized, to be used when the client sends an eval App request.
  * When handling the request, we basically extend the module with an eval directive and return the result of that
  * Augment the eval directive with whatever local decls are in scope, to handle the sort of local decl examples below
* Add and expose `execEvalExprInContextOfModule` from EvaluateLazy. This is in the vein of what @kosmikus recommended, except that I filter out any existing directives instead of making a module with an import (because making the import requires a Resolved)
* Add a `moduleTopDecls :: Lens' (Module n) [TopDecl n]` lens to Syntax.hs
* EvalLazy: Make `range` optional in `EvalDirectiveResult` and `EvalDirective` records

Unrelated changes
* Export Optics.Core's (&), (.~) from Base
* Standardize on `vid` instead of `uid` convention in Ladder backend

Note that the current UI is TBD. Will be standardizing some of the UI stuff in follow-up frontend-focused PRs.

I would have tried to make this more of a Rule as @MangoIV had suggested, but I had already implemented most of this by the time the suggestion was raised. And in any case, the way I'm currently doing it already uses rules like that for getting eval deps (i.e.,it does exploit at least some opportunities for caching computation).

## Examples and limitations

Examples that work the way one might expect:
```
{--------------------------------------------------------
-- function is a top decl
--------------------------------------------------------}

GIVEN p IS A BOOLEAN
      q IS A BOOLEAN
GIVETH A BOOLEAN
DECIDE toplvlMyOr IS p OR q

GIVEN arg1 IS BOOLEAN
      arg2 IS BOOLEAN
      arg3 IS BOOLEAN
DECIDE result1 IS
  arg1 AND toplvlMyOr arg2 arg3


{--------------------------------------------------------
-- function is locally defined
--------------------------------------------------------}
GIVEN arg1 IS BOOLEAN
      arg2 IS BOOLEAN
      arg3 IS BOOLEAN
DECIDE result2 IS
  arg1 AND myOr_ arg2 arg3 -- does shadowing with a local def not work?
    WHERE
      myOr_ MEANS GIVEN x, y IS A BOOLEAN YIELD (x OR y)
```

Examples that don't (and probably require further discussion re whether we want to support this sort of thing)

```

{--------------------------------------------------------
Simple edge case involving a locally defined boolean literal
-- Intuitively, one shouldn't be able to change the value of `locallyDefinedArg` in the visualizer

(Yes, there's a similar issue even without local defs, when we visualize boolean literals, but the plan is to add boolean lits and make it impossible to 're-assign' the values of boolean literals.
But just adding boolean literals to the VizExpr/IRExpr AST wouldn't be enough
to get what I think is the intuitive behavior in *this* case.)
--------------------------------------------------------}
GIVEN arg1 IS BOOLEAN
DECIDE resultLocalDefBoolLit IS
  toplvlMyOr arg1 locallyDefinedArg
    WHERE
      locallyDefinedArg MEANS FALSE


{--------------------------------------------------------
Edge case 2: locally defined boolean var that
             is derivative on other boolean vars

Notice that `arg1Andarg2` does not change 
even after the values of arg1 and arg2 have been assigned
---------------------------------------------------------}
GIVEN arg1, arg2 IS BOOLEAN
DECIDE resultDerivedLocalDef IS
  arg2 OR toplvlMyOr arg1 arg1Andarg2
    WHERE
      arg1Andarg2 MEANS arg1 AND arg2 
```