### PR TITLE
Viz: Don't show Viz codelens (by throwing error) if Decide does not return a boolean (#419)

### DIFF
--- a/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/Ladder.hs
@@ -161,7 +161,6 @@ getVizConfig vs = vs.cfg
 
 data VizError
   = InvalidProgramNoDecidesFound
-  | InvalidProgramDecidesMustNotHaveMoreThanOneGiven
   deriving stock (Eq, Generic, Show)
   deriving anyclass (NFData)
 
@@ -170,8 +169,6 @@ prettyPrintVizError :: VizError -> Text
 prettyPrintVizError = \ case
   InvalidProgramNoDecidesFound ->
     "The program isn't the right sort for visualization: there are no DECIDE rules that can be visualized."
-  InvalidProgramDecidesMustNotHaveMoreThanOneGiven ->
-    "Visualization failed: DECIDE rules must reference no more than one GIVEN variable."
 
 ------------------------------------------------------
 -- Entrypoint: Visualise


### PR DESCRIPTION
Closes #419 

* Remove obsoleted VizError variant
* Throw InvalidDecideMustHaveBoolRetType error if the Decide under consideration does not return a boolean