### PR TITLE
Ladder backend: Add a prelim VizHandler monad, and refactor eval app handler to use that. Stub out the inlineExprs handler

### DIFF
--- a/jl4-lsp/app/LSP/L4/Handlers.hs
+++ b/jl4-lsp/app/LSP/L4/Handlers.hs
@@ -47,7 +47,7 @@ import LSP.Core.Types.Diagnostics
 import LSP.Core.Types.Location
 import qualified LSP.L4.Viz.Ladder as Ladder
 import qualified LSP.L4.Viz.CustomProtocol as Ladder
-import LSP.L4.Viz.CustomProtocol (IsLadderRequestParams, getVerDocId)
+import LSP.L4.Viz.CustomProtocol (IsLadderRequestParams)
 import LSP.Logger
 import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Protocol.Message
@@ -564,11 +564,11 @@ checkVizVersion
   -> VizHandler method ()
 checkVizVersion reqParams recentViz = do
   let vizConfig = Ladder.getVizConfig . (.vizState) $ recentViz
-  if getVerDocId reqParams == vizConfig.verTxtDocId
+  if reqParams.verDocId == vizConfig.verTxtDocId
     then pure ()
     else throwError $ TResponseError
       { _code = InL LSPErrorCodes_ContentModified
-      , _message = "Document version mismatch. Visualizer version: " <> Text.show (getVerDocId reqParams)._version <>
+      , _message = "Document version mismatch. Visualizer version: " <> Text.show (reqParams.verDocId)._version <>
           ", whereas server's version is: " <> Text.show vizConfig.verTxtDocId._version
       , _xdata = Nothing
       }

--- a/jl4-lsp/app/LSP/L4/Handlers.hs
+++ b/jl4-lsp/app/LSP/L4/Handlers.hs
@@ -350,6 +350,10 @@ handlers recorder =
                 LogReceivedCustomRequest evalParams.verDocId._uri
                 ("Eval result: " <> Text.show result)
               pure result
+
+    , requestHandler (SMethod_CustomMethod (Proxy @Ladder.InlineExprsMethodName)) $ \ide params -> do
+        liftIO $ runVizHandlerM $ handleCustomVizRequest recorder (Proxy @Ladder.InlineExprsMethodName) (params :: MessageParams (Method_CustomMethod InlineExprsMethodName)) ide $ 
+          \(_inlineExprsParams :: Ladder.InlineExprsRequestParams) _tcRes _recentViz -> undefined
     ]
 
 activeFileDiagnosticsInRange :: ShakeExtras -> NormalizedUri -> Range -> STM [FileDiagnostic]

--- a/jl4-lsp/app/LSP/L4/Handlers.hs
+++ b/jl4-lsp/app/LSP/L4/Handlers.hs
@@ -46,7 +46,8 @@ import qualified LSP.Core.Shake as Shake
 import LSP.Core.Types.Diagnostics
 import LSP.Core.Types.Location
 import qualified LSP.L4.Viz.Ladder as Ladder
-import           LSP.L4.Viz.CustomProtocol as Ladder
+import qualified LSP.L4.Viz.CustomProtocol as Ladder
+import LSP.L4.Viz.CustomProtocol (IsLadderRequestParams, getVerDocId)
 import LSP.Logger
 import qualified Language.LSP.Protocol.Lens as J
 import Language.LSP.Protocol.Message
@@ -353,7 +354,7 @@ handlers recorder =
                 pure result
 
     , requestHandler (SMethod_CustomMethod (Proxy @Ladder.InlineExprsMethodName)) $ \ide params ->
-        liftIO $ runVizHandlerM $ withVizRequestContext recorder (Proxy @Ladder.InlineExprsMethodName) (params :: MessageParams (Method_CustomMethod InlineExprsMethodName)) ide $
+        liftIO $ runVizHandlerM $ withVizRequestContext recorder (Proxy @Ladder.InlineExprsMethodName) (params :: MessageParams (Method_CustomMethod Ladder.InlineExprsMethodName)) ide $
           \(_inlineExprsParams :: Ladder.InlineExprsRequestParams) _tcRes _recentViz -> undefined
     ]
 

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -11,7 +11,7 @@ import GHC.Generics (Generic)
 import Data.Proxy (Proxy(..))
 import GHC.TypeLits  (Symbol, KnownSymbol, symbolVal)
 import Language.LSP.Protocol.Types as LSP
-import LSP.L4.Viz.VizExpr
+import LSP.L4.Viz.VizExpr as V
 
 ------------------------------------------------------
 -- l4/evalApp Request Params and Response Payload
@@ -19,20 +19,20 @@ import LSP.L4.Viz.VizExpr
 
 -- | Payload / params for EvalAppRequest
 data EvalAppRequestParams = EvalAppRequestParams
-  { appExpr :: ID,
+  { appExpr  :: V.ID
     {- | I don't want to bother defining a BoolValue just for this;
         can be cleaned up in the future.
         Also, prob better to make the @args@ UBoolLit exprs or smtg
     -}
-    args :: [UBoolValue],
-    verDocId :: LSP.VersionedTextDocumentIdentifier
+  , args     :: [V.UBoolValue]
+  , verDocId :: LSP.VersionedTextDocumentIdentifier
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 -- | l4/evalApp response payload
 newtype EvalAppResult = EvalAppResult
-  { value :: UBoolValue }
+  { value :: V.UBoolValue }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -12,6 +12,7 @@ import Data.Proxy (Proxy(..))
 import GHC.TypeLits  (Symbol, KnownSymbol, symbolVal)
 import Language.LSP.Protocol.Types as LSP
 import LSP.L4.Viz.VizExpr as V
+import GHC.Records (HasField)
 
 ------------------------------------------------------
 -- l4/evalApp Request Params and Response Payload
@@ -51,4 +52,16 @@ class KnownSymbol a => IsCustomMethod (a :: Symbol) where
   getMethodName :: Proxy a -> T.Text
   getMethodName = T.pack . symbolVal
 
-instance IsCustomMethod EvalAppMethodName
+instance IsCustomMethod EvalAppMethodName------------------------------------------------------
+------------------------------------------------------
+--  IsLadderRequestParams typeclass
+------------------------------------------------------
+
+class (GHC.Records.HasField "verDocId" params VersionedTextDocumentIdentifier, 
+       FromJSON params) 
+      => IsLadderRequestParams params where
+  getVerDocId :: params -> VersionedTextDocumentIdentifier
+  getVerDocId = (.verDocId)
+  
+instance IsLadderRequestParams EvalAppRequestParams
+instance IsLadderRequestParams InlineExprsRequestParams

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -63,21 +63,6 @@ data InlineExprsRequestParams = InlineExprsRequestParams
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
--- | l4/inlineExprs response payload
--- (Keeping it simple for now: just want to know whether the request was successful)
-data InlineExprsSuccess = InlineExprsSuccess
-  deriving stock (Eq, Show)
-
-instance ToJSON InlineExprsSuccess where
-  toJSON _ = object ["$type" .= ("InlineExprsSuccess" :: T.Text)]
-
-instance FromJSON InlineExprsSuccess where
-  parseJSON = withObject "InlineExprsSuccess" $ \obj -> do
-    typeTag <- obj .: "$type"
-    if typeTag == "InlineExprsSuccess"
-      then pure InlineExprsSuccess
-      else fail $ "Expected $type field to be 'InlineExprsSuccess' but got: " <> typeTag
-
 ------------------------------------------------------
 --  Custom methods for LSP
 ------------------------------------------------------

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 
 {-| Custom extensions to the LSP and payload types for JL4
-    See also @ts-shared/jl4-client-rpc/custom-protocol.ts@
+  See also 
+  - @ts-shared/jl4-client-rpc/custom-protocol.ts@ for RPC-related TS types
+  - @ts-shared/viz-expr/eval-on-backend.ts@ for the params/response payload TS types
 -}
 module LSP.L4.Viz.CustomProtocol where
 
 import qualified Base.Text as T
-import Data.Aeson   (FromJSON, ToJSON)
+import Data.Aeson (FromJSON(..), ToJSON(..), object, (.:), (.=), withObject)
 import GHC.Generics (Generic)
 import Data.Proxy (Proxy(..))
 import GHC.TypeLits  (Symbol, KnownSymbol, symbolVal)
@@ -34,15 +36,57 @@ data EvalAppRequestParams = EvalAppRequestParams
 -- | l4/evalApp response payload
 newtype EvalAppResult = EvalAppResult
   { value :: V.UBoolValue }
+  deriving stock (Eq, Show)
+
+instance ToJSON EvalAppResult where
+  toJSON (EvalAppResult val) = object [
+    "$type" .= ("EvalAppResult" :: T.Text),
+    "value" .= val
+    ]
+
+instance FromJSON EvalAppResult where
+  parseJSON = withObject "EvalAppResult" $ \obj -> do
+    typeTag <- obj .: "$type"
+    if typeTag == ("EvalAppResult" :: T.Text)
+      then EvalAppResult <$> obj .: "value"
+      else fail $ "Expected $type field to be 'EvalAppResult' but got: " <> T.unpack typeTag
+
+------------------------------------------------------
+-- l4/inlineExprs Request Params and Response Payload
+------------------------------------------------------
+
+-- | Payload / params for InlineExprsRequest
+data InlineExprsRequestParams = InlineExprsRequestParams
+  { uniques  :: [Int]
+  , verDocId :: LSP.VersionedTextDocumentIdentifier
+  }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
+-- | l4/inlineExprs response payload
+-- (Keeping it simple for now: just want to know whether the request was successful)
+data InlineExprsSuccess = InlineExprsSuccess
+  deriving stock (Eq, Show)
+
+instance ToJSON InlineExprsSuccess where
+  toJSON _ = object ["$type" .= ("InlineExprsSuccess" :: T.Text)]
+
+instance FromJSON InlineExprsSuccess where
+  parseJSON = withObject "InlineExprsSuccess" $ \obj -> do
+    typeTag <- obj .: "$type"
+    if typeTag == "InlineExprsSuccess"
+      then pure InlineExprsSuccess
+      else fail $ "Expected $type field to be 'InlineExprsSuccess' but got: " <> typeTag
+
 ------------------------------------------------------
---  l4/evalApp custom method for LSP
+--  Custom methods for LSP
 ------------------------------------------------------
 
 type EvalAppMethodName :: Symbol
 type EvalAppMethodName = "l4/evalApp"
+
+type InlineExprsMethodName :: Symbol
+type InlineExprsMethodName = "l4/inlineExprs"
 
 ------------------------------------------------------
 --  IsCustomMethod typeclass
@@ -52,7 +96,9 @@ class KnownSymbol a => IsCustomMethod (a :: Symbol) where
   getMethodName :: Proxy a -> T.Text
   getMethodName = T.pack . symbolVal
 
-instance IsCustomMethod EvalAppMethodName------------------------------------------------------
+instance IsCustomMethod EvalAppMethodName
+instance IsCustomMethod InlineExprsMethodName
+
 ------------------------------------------------------
 --  IsLadderRequestParams typeclass
 ------------------------------------------------------

--- a/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
+++ b/jl4-lsp/src/LSP/L4/Viz/CustomProtocol.hs
@@ -91,8 +91,6 @@ instance IsCustomMethod InlineExprsMethodName
 class (GHC.Records.HasField "verDocId" params VersionedTextDocumentIdentifier, 
        FromJSON params) 
       => IsLadderRequestParams params where
-  getVerDocId :: params -> VersionedTextDocumentIdentifier
-  getVerDocId = (.verDocId)
   
 instance IsLadderRequestParams EvalAppRequestParams
 instance IsLadderRequestParams InlineExprsRequestParams


### PR DESCRIPTION
Depends on #440 

VizHandler refactor
* Add VizHandler monad and helpers, and IsLadderRequestParams typeclass
* Handlers.hs: Refactor the eval app handler to use VizHandler

Params, payloads types for inlining exprs (+ some clean up of eval app tojson)
* CustomProtocol.hs: Fix EvalAppResult's ToJSon encoding
* CustomProtocol.hs: Add custom method type for inlining exprs
* Stub out the InliningExprs handler in the VizHandler monad

Will implement the logic for whether this or that subexpr's `canInline` is true/false in the next PR, along with the handler for inlining exprs