### PR TITLE
Inlining expr UI

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -7,6 +7,7 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   import { useLadderEnv } from '$lib/ladder-env.js'
   import { UBoolVarLirNode } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
   import { Handle } from '@xyflow/svelte'
+  import * as Tooltip from '$lib/ui-primitives/tooltip/index.js'
 
   let { data }: UBoolVarDisplayerProps = $props()
 
@@ -29,19 +30,31 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
   </div>
   {#if data.canInline}
     <div class="absolute bottom-1 right-1">
-      <button
-        class="px-0.5 text-[0.625rem] rounded border border-border bg-background hover:bg-accent hover:text-accent-foreground transition-colors duration-150"
-        onclick={() => {
-          console.log('inline lir id', data.originalLirId.toString())
+      <Tooltip.Provider>
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              class="px-0.5 text-[0.625rem] rounded border border-border bg-background hover:bg-accent hover:text-accent-foreground transition-colors duration-150"
+              onclick={() => {
+                console.log('inline lir id', data.originalLirId.toString())
 
-          const uniq = (
-            data.context.get(data.originalLirId) as UBoolVarLirNode
-          ).getUnique(data.context)
-          l4Conn.inlineExprs([uniq], ladderEnv.getVersionedTextDocIdentifier())
-        }}
-      >
-        +
-      </button>
+                const uniq = (
+                  data.context.get(data.originalLirId) as UBoolVarLirNode
+                ).getUnique(data.context)
+                l4Conn.inlineExprs(
+                  [uniq],
+                  ladderEnv.getVersionedTextDocIdentifier()
+                )
+              }}
+            >
+              +
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            <p>Unfold to definition</p>
+          </Tooltip.Content>
+        </Tooltip.Root>
+      </Tooltip.Provider>
     </div>
   {/if}
   <Handle type="source" position={defaultSFHandlesInfo.sourcePosition} />

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -40,7 +40,7 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
           l4Conn.inlineExprs([uniq], ladderEnv.getVersionedTextDocIdentifier())
         }}
       >
-        todo
+        +
       </button>
     </div>
   {/if}

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -34,6 +34,7 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
         <Tooltip.Root>
           <Tooltip.Trigger>
             <button
+              aria-label="Unfold to definition"
               class="px-0.5 text-[0.625rem] rounded border border-border bg-background hover:bg-accent hover:text-accent-foreground transition-colors duration-150"
               onclick={() => {
                 console.log('inline lir id', data.originalLirId.toString())

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/index.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/index.ts
@@ -1,0 +1,21 @@
+import { Tooltip as TooltipPrimitive } from "bits-ui";
+import Trigger from "./tooltip-trigger.svelte";
+import Content from "./tooltip-content.svelte";
+
+const Root = TooltipPrimitive.Root;
+const Provider = TooltipPrimitive.Provider;
+const Portal = TooltipPrimitive.Portal;
+
+export {
+	Root,
+	Trigger,
+	Content,
+	Provider,
+	Portal,
+	//
+	Root as Tooltip,
+	Content as TooltipContent,
+	Trigger as TooltipTrigger,
+	Provider as TooltipProvider,
+	Portal as TooltipPortal,
+};

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/index.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/index.ts
@@ -1,21 +1,21 @@
-import { Tooltip as TooltipPrimitive } from "bits-ui";
-import Trigger from "./tooltip-trigger.svelte";
-import Content from "./tooltip-content.svelte";
+import { Tooltip as TooltipPrimitive } from 'bits-ui'
+import Trigger from './tooltip-trigger.svelte'
+import Content from './tooltip-content.svelte'
 
-const Root = TooltipPrimitive.Root;
-const Provider = TooltipPrimitive.Provider;
-const Portal = TooltipPrimitive.Portal;
+const Root = TooltipPrimitive.Root
+const Provider = TooltipPrimitive.Provider
+const Portal = TooltipPrimitive.Portal
 
 export {
-	Root,
-	Trigger,
-	Content,
-	Provider,
-	Portal,
-	//
-	Root as Tooltip,
-	Content as TooltipContent,
-	Trigger as TooltipTrigger,
-	Provider as TooltipProvider,
-	Portal as TooltipPortal,
-};
+  Root,
+  Trigger,
+  Content,
+  Provider,
+  Portal,
+  //
+  Root as Tooltip,
+  Content as TooltipContent,
+  Trigger as TooltipTrigger,
+  Provider as TooltipProvider,
+  Portal as TooltipPortal,
+}

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/tooltip-content.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/tooltip-content.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 0,
+		side = "top",
+		children,
+		arrowClasses,
+		...restProps
+	}: TooltipPrimitive.ContentProps & {
+		arrowClasses?: string;
+	} = $props();
+</script>
+
+<TooltipPrimitive.Portal>
+	<TooltipPrimitive.Content
+		bind:ref
+		data-slot="tooltip-content"
+		{sideOffset}
+		{side}
+		class={cn(
+			"bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md px-3 py-1.5 text-xs",
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		<TooltipPrimitive.Arrow>
+			{#snippet child({ props })}
+				<div
+					class={cn(
+						"bg-primary z-50 size-2.5 rotate-45 rounded-[2px]",
+						side === "top" && "translate-x-1/2 translate-y-[calc(-50%_+_2px)]",
+						side === "bottom" && "-translate-x-1/2 -translate-y-[calc(-50%_+_1px)]",
+						side === "right" && "translate-x-[calc(50%_+_2px)] translate-y-1/2",
+						side === "left" && "-translate-y-[calc(50%_-_3px)]",
+						arrowClasses
+					)}
+					{...props}
+				></div>
+			{/snippet}
+		</TooltipPrimitive.Arrow>
+	</TooltipPrimitive.Content>
+</TooltipPrimitive.Portal>

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/tooltip-content.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/tooltip-content.svelte
@@ -1,47 +1,48 @@
 <script lang="ts">
-	import { Tooltip as TooltipPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+  import { Tooltip as TooltipPrimitive } from 'bits-ui'
+  import { cn } from '$lib/utils.js'
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		sideOffset = 0,
-		side = "top",
-		children,
-		arrowClasses,
-		...restProps
-	}: TooltipPrimitive.ContentProps & {
-		arrowClasses?: string;
-	} = $props();
+  let {
+    ref = $bindable(null),
+    class: className,
+    sideOffset = 0,
+    side = 'top',
+    children,
+    arrowClasses,
+    ...restProps
+  }: TooltipPrimitive.ContentProps & {
+    arrowClasses?: string
+  } = $props()
 </script>
 
 <TooltipPrimitive.Portal>
-	<TooltipPrimitive.Content
-		bind:ref
-		data-slot="tooltip-content"
-		{sideOffset}
-		{side}
-		class={cn(
-			"bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md px-3 py-1.5 text-xs",
-			className
-		)}
-		{...restProps}
-	>
-		{@render children?.()}
-		<TooltipPrimitive.Arrow>
-			{#snippet child({ props })}
-				<div
-					class={cn(
-						"bg-primary z-50 size-2.5 rotate-45 rounded-[2px]",
-						side === "top" && "translate-x-1/2 translate-y-[calc(-50%_+_2px)]",
-						side === "bottom" && "-translate-x-1/2 -translate-y-[calc(-50%_+_1px)]",
-						side === "right" && "translate-x-[calc(50%_+_2px)] translate-y-1/2",
-						side === "left" && "-translate-y-[calc(50%_-_3px)]",
-						arrowClasses
-					)}
-					{...props}
-				></div>
-			{/snippet}
-		</TooltipPrimitive.Arrow>
-	</TooltipPrimitive.Content>
+  <TooltipPrimitive.Content
+    bind:ref
+    data-slot="tooltip-content"
+    {sideOffset}
+    {side}
+    class={cn(
+      'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md px-3 py-1.5 text-xs',
+      className
+    )}
+    {...restProps}
+  >
+    {@render children?.()}
+    <TooltipPrimitive.Arrow>
+      {#snippet child({ props })}
+        <div
+          class={cn(
+            'bg-primary z-50 size-2.5 rotate-45 rounded-[2px]',
+            side === 'top' && 'translate-x-1/2 translate-y-[calc(-50%_+_2px)]',
+            side === 'bottom' &&
+              '-translate-x-1/2 -translate-y-[calc(-50%_+_1px)]',
+            side === 'right' && 'translate-x-[calc(50%_+_2px)] translate-y-1/2',
+            side === 'left' && '-translate-y-[calc(50%_-_3px)]',
+            arrowClasses
+          )}
+          {...props}
+        ></div>
+      {/snippet}
+    </TooltipPrimitive.Arrow>
+  </TooltipPrimitive.Content>
 </TooltipPrimitive.Portal>

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/tooltip-trigger.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/tooltip-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps = $props();
+</script>
+
+<TooltipPrimitive.Trigger bind:ref data-slot="tooltip-trigger" {...restProps} />

--- a/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/tooltip-trigger.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/ui-primitives/tooltip/tooltip-trigger.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { Tooltip as TooltipPrimitive } from "bits-ui";
+  import { Tooltip as TooltipPrimitive } from 'bits-ui'
 
-	let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps = $props();
+  let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps =
+    $props()
 </script>
 
 <TooltipPrimitive.Trigger bind:ref data-slot="tooltip-trigger" {...restProps} />


### PR DESCRIPTION
I've decided to go with the '+' symbol for node expansion. Unlike directional indicators (e.g., arrows pointing up/down/left/right), '+' conveys a non-directional, spatially neutral action that aligns better with how expansion works in our graph: the layout adjusts globally rather than unfolding in-place along a fixed axis. 

Using a neutral symbol avoids misleading spatial cues and keeps the interaction consistent with common UI expectations around “revealing more.” 

Alternative symbols (e.g., arrows or ellipses) were considered but seem less intuitive for this context, as they typically imply directional growth or continuation rather than full structural unfolding.