### PR TITLE
Implement ":" as a synonym for "IS"

### DIFF
--- a/jl4-core/src/L4/Lexer.hs
+++ b/jl4-core/src/L4/Lexer.hs
@@ -95,6 +95,7 @@ data TokenType =
   | TImplies
   | TDividedBy
   | TOtherSymbolic !Text
+  | TColon
     -- keywords
   | TKGiven
   | TKGiveth
@@ -394,6 +395,7 @@ symbols =
     , ("||", TOr           )
     , ("=>", TImplies      )
     , ("/" , TDividedBy    )
+    , (":" , TColon)
     ]
 
 keywords :: Map Text TokenType
@@ -886,6 +888,7 @@ displayTokenType tt =
     TImplies          -> "=>"
     TDividedBy        -> "/"
     TOtherSymbolic t  -> t
+    TColon           -> ":"
     TKGiven           -> "GIVEN"
     TKGiveth          -> "GIVETH"
     TKDecide          -> "DECIDE"
@@ -1021,6 +1024,7 @@ posTokenCategory =
     TImplies -> COperator
     TDividedBy -> COperator
     TOtherSymbolic _ -> CSymbol
+    TColon -> CSymbol
     TKGiven -> CKeyword
     TKGiveth -> CKeyword
     TKDecide -> CKeyword

--- a/jl4-core/src/L4/Parser.hs
+++ b/jl4-core/src/L4/Parser.hs
@@ -524,6 +524,9 @@ enumOrSynonymDecl =
        annoLexeme (spacedToken_ TKIs)
     *> (enumDecl <|> synonymDecl)
 
+separator :: Parser (Lexeme PosToken)
+separator = spacedToken_ TKIs <|> hidden (spacedToken_ TColon)
+
 enumDecl :: Compose Parser WithAnno (TypeDecl Name)
 enumDecl =
   EnumDecl emptyAnno
@@ -735,7 +738,7 @@ reqParam =
   attachAnno $
     MkTypedName emptyAnno
       <$> annoHole name
-      <*  annoLexeme (spacedToken_ TKIs)
+      <*  annoLexeme separator
 --      <*  optional article
       <*> annoHole type'
 
@@ -744,7 +747,7 @@ param =
   attachAnno $
     MkOptionallyTypedName emptyAnno
       <$> annoHole name
-      <*> optional (annoLexeme (spacedToken_ TKIs) *> {- optional article *> -} annoHole type')
+      <*> optional (annoLexeme separator *> {- optional article *> -} annoHole type')
 
 -- |
 -- An expression is a base expression followed by
@@ -1083,7 +1086,7 @@ namedExpr current  =
   attachAnno $
     MkNamedExpr emptyAnno
       <$> annoHole   name
-      <*  annoLexeme (spacedToken_ TKIs)
+      <*  annoLexeme separator
       <*  optional article
       <*> annoHole   (indentedExpr current)
 

--- a/jl4/examples/ok/record.l4
+++ b/jl4/examples/ok/record.l4
@@ -8,3 +8,22 @@ HAS name IS A STRING, colour IS A Colour
 DECLARE Folder2
 HAS name IS A STRING
     colour IS A Colour
+
+DECLARE Folder3
+HAS name: A STRING
+    colour: A Colour
+
+DECLARE Folder4
+HAS name: STRING
+    colour: Colour
+
+DECLARE Folder4
+HAS name: STRING, colour: A Colour
+
+DECLARE Folder5
+HAS name: STRING, colour IS A Colour
+
+GIVEN a: TYPE
+DECLARE Folder6 HAS
+    name: a
+    colour IS A a

--- a/jl4/examples/ok/tests/record.ep.golden
+++ b/jl4/examples/ok/tests/record.ep.golden
@@ -8,3 +8,22 @@ HAS name IS A STRING, colour IS A Colour
 DECLARE Folder2
 HAS name IS A STRING
     colour IS A Colour
+
+DECLARE Folder3
+HAS name: A STRING
+    colour: A Colour
+
+DECLARE Folder4
+HAS name: STRING
+    colour: Colour
+
+DECLARE Folder4
+HAS name: STRING, colour: A Colour
+
+DECLARE Folder5
+HAS name: STRING, colour IS A Colour
+
+GIVEN a: TYPE
+DECLARE Folder6 HAS
+    name: a
+    colour IS A a


### PR DESCRIPTION
In particular, in the following cases:

* Function Arguments
* Type Arguments
* Record field definitions

Articles are valid with `:`, e.g.
```
GIVEN a: A BOOLEAN
foo a MEANS a AND a
```

The token ":" is always hidden and will not be displayed in error messages to the user.

Closes #461 