### PR TITLE
Viz: Make tooltip show up more quickly. Move Tooltip.Provider out of uboolvar displayer --- wrap FlowBase with the tooltip provider component, so that tooltip-related state can be shared by all tooltips in FlowBase.  (#480)

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow.svelte
@@ -6,6 +6,7 @@ when trying to make ladder diagrams. -->
   import type { LadderFlowDisplayerProps } from './flow-props.js'
   import FlowBase from './flow-base.svelte'
   import LadderEnvProvider from '$lib/displayers/ladder-env-provider.svelte'
+  import * as Tooltip from '$lib/ui-primitives/tooltip/index.js'
 
   const { context, node, env }: LadderFlowDisplayerProps = $props()
 
@@ -26,8 +27,22 @@ when trying to make ladder diagrams. -->
 <!-- SvelteFlowProvider supplies SF hooks used by FlowBase -->
 <SvelteFlowProvider>
   <LadderEnvProvider {env}>
-    <div style="height: 100%">
-      <FlowBase {context} {node} bind:this={baseFlowComponent} />
-    </div>
+    <!--
+      Note: we are effectively standardizing on using the tooltip component from Shadcn-Svelte/Bits-UI.
+
+      On Tooltip.Provider, from [Shadcn-Svelte/Bits-UI docs](https://bits-ui.com/docs/components/tooltip):
+
+      > The Tooltip.Provider component is required to be an ancestor of the Tooltip.Root component. It provides shared state for the tooltip components used within it.  
+
+      So, e.g., the delayDuration specified below will apply to all Tooltip.Roots in FlowBase (unless explicitly overridden).
+
+      IMPORTANT: Cannot put Tooltip.Provider in +layout.svelte,
+      likely because of complications with SvelteFlowProvider.
+      -->
+    <Tooltip.Provider delayDuration={100}>
+      <div style="height: 100%">
+        <FlowBase {context} {node} bind:this={baseFlowComponent} />
+      </div>
+    </Tooltip.Provider>
   </LadderEnvProvider>
 </SvelteFlowProvider>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/value-indicator.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/value-indicator.svelte
@@ -1,0 +1,37 @@
+<!-- A non-color-based indicator of the value,
+ along with the color-specific bg color
+ and the border styles for the caller node -->
+<script lang="ts" module>
+  import type { UBoolVal } from '$lib/eval/type.js'
+  import type { Snippet } from 'svelte'
+  import { match } from 'ts-pattern'
+
+  interface ValueIndicatorProps {
+    value: UBoolVal
+    /** Additional CSS classes to add to the outermost div */
+    additionalClasses: string[]
+    children: Snippet
+  }
+</script>
+
+<script lang="ts">
+  let { value, additionalClasses, children }: ValueIndicatorProps = $props()
+</script>
+
+<!-- Need the parent to be relatively positioned,
+ for the absolute positioning to work -->
+<div class={['relative', ...additionalClasses, ...value.getClasses()]}>
+  {@render children()}
+  <div
+    class="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2
+    w-4 text-[0.7rem] px-1
+    text-white bg-cyan-800
+    rounded-full"
+  >
+    {match(value)
+      .with({ $type: 'TrueV' }, () => '✓')
+      .with({ $type: 'FalseV' }, () => '✗')
+      .with({ $type: 'UnknownV' }, () => null)
+      .exhaustive()}
+  </div>
+</div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-contentful-node-styles.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-contentful-node-styles.svelte
@@ -11,6 +11,6 @@
   let { children }: WithContentfulNodeStylesProps = $props()
 </script>
 
-<div class="base-sf-node-styles transition-opacity duration-300 relative">
+<div class="base-sf-node-styles transition-opacity duration-300">
   {@render children()}
 </div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/false-expr.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/false-expr.svelte
@@ -3,6 +3,7 @@
   import type { UBoolVarDisplayerProps } from '../svelteflow-types.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
   import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
+  import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
   let { data }: UBoolVarDisplayerProps = $props()
 </script>
@@ -10,13 +11,18 @@
 <!-- select-none to prevent text selection, to hint that this is a constant.
  Also no cursor-pointer -->
 <WithContentfulNodeStyles>
-  <div class={['bool-lit-node-border', 'select-none', ...data.classes]}>
+  <ValueIndicator
+    value={(data.context.get(data.originalLirId) as FalseExprLirNode).getValue(
+      data.context
+    )}
+    additionalClasses={['bool-lit-node-border', 'select-none', ...data.classes]}
+  >
     <WithNormalHandles>
       <div class="label-wrapper-for-content-bearing-sf-node">
         {(data.context.get(data.originalLirId) as FalseExprLirNode).toPretty(
           data.context
         )}
-      </div>
-    </WithNormalHandles>
-  </div>
+      </div></WithNormalHandles
+    >
+  </ValueIndicator>
 </WithContentfulNodeStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/true-expr.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/true-expr.svelte
@@ -3,6 +3,7 @@
   import type { BoolLitDisplayerProps } from '../svelteflow-types.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
   import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
+  import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
   let { data }: BoolLitDisplayerProps = $props()
 </script>
@@ -10,13 +11,18 @@
 <!-- select-none to prevent text selection, to hint that this is a constant.
  Also no cursor-pointer -->
 <WithContentfulNodeStyles>
-  <div class={['bool-lit-node-border', 'select-none', ...data.classes]}>
+  <ValueIndicator
+    value={(data.context.get(data.originalLirId) as TrueExprLirNode).getValue(
+      data.context
+    )}
+    additionalClasses={['bool-lit-node-border', 'select-none', ...data.classes]}
+  >
     <WithNormalHandles>
       <div class="label-wrapper-for-content-bearing-sf-node">
         {(data.context.get(data.originalLirId) as TrueExprLirNode).toPretty(
           data.context
         )}
-      </div>
-    </WithNormalHandles>
-  </div>
+      </div></WithNormalHandles
+    >
+  </ValueIndicator>
 </WithContentfulNodeStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -18,30 +18,28 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
 
 {#snippet inlineUI()}
   <div class="absolute bottom-1 right-1">
-    <Tooltip.Provider>
-      <Tooltip.Root>
-        <Tooltip.Trigger>
-          <button
-            aria-label="Unfold to definition"
-            class="px-0.5 text-[0.625rem] rounded border border-border bg-background hover:bg-accent hover:text-accent-foreground transition-colors duration-150"
-            onclick={() => {
-              console.log('inline lir id', data.originalLirId.toString())
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          aria-label="Unfold to definition"
+          class="px-0.5 text-[0.625rem] rounded border border-border bg-background hover:bg-accent hover:text-accent-foreground transition-colors duration-150"
+          onclick={() => {
+            console.log('inline lir id', data.originalLirId.toString())
 
-              const uniq = (
-                data.context.get(data.originalLirId) as UBoolVarLirNode
-              ).getUnique(data.context)
-              l4Conn.inlineExprs(
-                [uniq],
-                ladderEnv.getVersionedTextDocIdentifier()
-              )
-            }}
-          >
-            +
-          </button>
-        </Tooltip.Trigger>
-        <Tooltip.Content>Unfold to definition</Tooltip.Content>
-      </Tooltip.Root>
-    </Tooltip.Provider>
+            const uniq = (
+              data.context.get(data.originalLirId) as UBoolVarLirNode
+            ).getUnique(data.context)
+            l4Conn.inlineExprs(
+              [uniq],
+              ladderEnv.getVersionedTextDocIdentifier()
+            )
+          }}
+        >
+          +
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content>Unfold to definition</Tooltip.Content>
+    </Tooltip.Root>
   </div>
 {/snippet}
 

--- a/ts-apps/decision-logic-visualizer/src/lib/eval/eval.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/eval/eval.ts
@@ -71,15 +71,19 @@ export const Evaluator: LadderEvaluator = {
     ): Promise<EvalResult> {
       return match(ladder)
         .with({ $type: 'TrueE' }, () => {
+          const result = new TrueVal()
+          const newIntermediate = intermediate.set(ladder.id, result)
           return {
-            result: new TrueVal(),
-            intermediate: intermediate,
+            result,
+            intermediate: newIntermediate,
           }
         })
         .with({ $type: 'FalseE' }, () => {
+          const result = new FalseVal()
+          const newIntermediate = intermediate.set(ladder.id, result)
           return {
-            result: new FalseVal(),
-            intermediate: intermediate,
+            result,
+            intermediate: newIntermediate,
           }
         })
         .with({ $type: 'UBoolVar' }, (expr: EvUBoolVar) => {

--- a/ts-apps/decision-logic-visualizer/src/lib/eval/type.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/eval/type.ts
@@ -4,8 +4,9 @@ import * as VE from '@repo/viz-expr'
 import {
   TrueValCSSClass,
   FalseValCSSClass,
+  UnknownValCSSClass,
 } from '$lib/layout-ir/ladder-graph/node-styles.js'
-import type { BoolValCSSClass } from '$lib/layout-ir/ladder-graph/node-styles.js'
+import type { UBoolValCSSClass } from '$lib/layout-ir/ladder-graph/node-styles.js'
 
 import { match } from 'ts-pattern'
 
@@ -29,7 +30,7 @@ export function toVEBoolValue(val: UBoolVal): VE.UBoolValue {
 
 interface UBoolV {
   $type: TrueVal['$type'] | FalseVal['$type'] | UnknownVal['$type']
-  getClasses(): BoolValCSSClass[]
+  getClasses(): UBoolValCSSClass[]
   toPretty(): string
 }
 
@@ -76,7 +77,7 @@ export class UnknownVal implements UBoolV {
   constructor() {}
 
   getClasses() {
-    return []
+    return [UnknownValCSSClass]
   }
 
   toPretty() {

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
@@ -6,6 +6,8 @@ import {
   UnknownVal,
   veExprToEvExpr,
   toUBoolVal,
+  TrueVal,
+  FalseVal,
 } from '../../eval/type.js'
 import { Assignment, Corefs } from '../../eval/assignment.js'
 import { Evaluator, type EvalResult } from '$lib/eval/eval.js'
@@ -758,6 +760,7 @@ export function isFalseExprLirNode(
 
 export class FalseExprLirNode extends BaseFlowLirNode implements FlowLirNode {
   #name: Name
+  #value = new FalseVal()
 
   constructor(
     nodeInfo: LirNodeInfo,
@@ -768,8 +771,8 @@ export class FalseExprLirNode extends BaseFlowLirNode implements FlowLirNode {
     this.#name = name
   }
 
-  override getAllClasses(context: LirContext): LadderNodeCSSClass[] {
-    return [...super.getAllClasses(context), 'false-val']
+  getValue(_context: LirContext) {
+    return this.#value
   }
 
   toPretty(_context: LirContext) {
@@ -783,6 +786,7 @@ export class FalseExprLirNode extends BaseFlowLirNode implements FlowLirNode {
 
 export class TrueExprLirNode extends BaseFlowLirNode implements FlowLirNode {
   #name: Name
+  #value = new TrueVal()
 
   constructor(
     nodeInfo: LirNodeInfo,
@@ -793,8 +797,8 @@ export class TrueExprLirNode extends BaseFlowLirNode implements FlowLirNode {
     this.#name = name
   }
 
-  override getAllClasses(context: LirContext): LadderNodeCSSClass[] {
-    return [...super.getAllClasses(context), 'true-val']
+  getValue(_context: LirContext) {
+    return this.#value
   }
 
   toPretty(_context: LirContext) {
@@ -865,17 +869,13 @@ export class UBoolVarLirNode extends BaseFlowLirNode implements VarLirNode {
     }
   }
 
-  override getAllClasses(_context: LirContext): LadderNodeCSSClass[] {
-    // console.log('modifierCSSClasses', this.modifierCSSClasses)
-    return [...this.#value.getClasses(), ...this.modifierCSSClasses]
-  }
-
   getValue(_context: LirContext): UBoolVal {
     return this.#value
   }
 
-  _setValue(_context: LirContext, value: UBoolVal) {
+  _setValue(context: LirContext, value: UBoolVal) {
     this.#value = value
+    this.getRegistry().publish(context, this.getId())
   }
 
   toPretty(context: LirContext) {

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/node-styles.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/node-styles.ts
@@ -1,8 +1,12 @@
-export type BoolValCSSClass = typeof TrueValCSSClass | typeof FalseValCSSClass
+export type UBoolValCSSClass =
+  | typeof TrueValCSSClass
+  | typeof FalseValCSSClass
+  | typeof UnknownValCSSClass
 export const TrueValCSSClass = 'true-val' as const
 export const FalseValCSSClass = 'false-val' as const
+export const UnknownValCSSClass = 'bg-white' as const
 
 export type NodeStyleModifierCSSClass = typeof FadedNodeCSSClass
 export const FadedNodeCSSClass = 'nonviable-ladder-element' as const
 
-export type LadderNodeCSSClass = BoolValCSSClass | NodeStyleModifierCSSClass
+export type LadderNodeCSSClass = UBoolValCSSClass | NodeStyleModifierCSSClass

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -165,6 +165,18 @@
   --color-false-value: var(--color-rose-200);
 }
 
+/***************************************
+         UBoolVarNode border 
+****************************************/
+
+.ubool-var-node-border {
+  border: var(--ladder-node-border, var(--ladder-node-border-default));
+  border-radius: var(
+    --ladder-node-border-radius,
+    var(--ladder-node-border-radius-default)
+  );
+}
+
 /*************************************
   Utility SF styles
 *************************************/
@@ -177,23 +189,6 @@ that a node might have (e.g., the darker background of (the 'function part' of) 
 
 @utility false-val {
   background-color: var(--color-false-value) !important;
-}
-
-/* A non-color-based indicator of the value */
-.true-val::after {
-  content: '✓';
-  @apply absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2;
-  @apply w-4 text-[0.7rem] px-1;
-  @apply text-white bg-cyan-800;
-  @apply rounded-full;
-}
-
-.false-val::after {
-  content: '✗';
-  @apply absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2;
-  @apply w-4 text-[0.7rem] px-1;
-  @apply text-white bg-cyan-800;
-  @apply rounded-full;
 }
 
 @utility base-sf-node-styles {


### PR DESCRIPTION
Closes #480 