### PR TITLE
Viz: Fix value UI bug for App of args. Make the non-color-based value indicator more robust and modular with `ValueIndicator` (instead of using a css pseudo elt)

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/value-indicator.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/value-indicator.svelte
@@ -8,18 +8,19 @@
 
   interface ValueIndicatorProps {
     value: UBoolVal
-    borderClasses: string[]
+    /** Additional CSS classes to add to the outermost div */
+    additionalClasses: string[]
     children: Snippet
   }
 </script>
 
 <script lang="ts">
-  let { value, borderClasses, children }: ValueIndicatorProps = $props()
+  let { value, additionalClasses, children }: ValueIndicatorProps = $props()
 </script>
 
 <!-- Need the parent to be relatively positioned,
  for the absolute positioning to work -->
-<div class={['relative', ...borderClasses, ...value.getClasses()]}>
+<div class={['relative', ...additionalClasses, ...value.getClasses()]}>
   {@render children()}
   <div
     class="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/value-indicator.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/value-indicator.svelte
@@ -6,7 +6,7 @@
   import type { Snippet } from 'svelte'
   import { match } from 'ts-pattern'
 
-  interface WithValueIndicatorProps {
+  interface ValueIndicatorProps {
     value: UBoolVal
     borderClasses: string[]
     children: Snippet
@@ -14,7 +14,7 @@
 </script>
 
 <script lang="ts">
-  let { value, borderClasses, children }: WithValueIndicatorProps = $props()
+  let { value, borderClasses, children }: ValueIndicatorProps = $props()
 </script>
 
 <!-- Need the parent to be relatively positioned,

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-contentful-node-styles.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-contentful-node-styles.svelte
@@ -11,6 +11,6 @@
   let { children }: WithContentfulNodeStylesProps = $props()
 </script>
 
-<div class="base-sf-node-styles transition-opacity duration-300 relative">
+<div class="base-sf-node-styles transition-opacity duration-300">
   {@render children()}
 </div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-value-indicator.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-value-indicator.svelte
@@ -1,0 +1,36 @@
+<!-- A non-color-based indicator of the value,
+ along with the color-specific bg color
+ and the border styles for the caller node -->
+<script lang="ts" module>
+  import type { UBoolVal } from '$lib/eval/type.js'
+  import type { Snippet } from 'svelte'
+  import { match } from 'ts-pattern'
+
+  interface WithValueIndicatorProps {
+    value: UBoolVal
+    borderClasses: string[]
+    children: Snippet
+  }
+</script>
+
+<script lang="ts">
+  let { value, borderClasses, children }: WithValueIndicatorProps = $props()
+</script>
+
+<!-- Need the parent to be relatively positioned,
+ for the absolute positioning to work -->
+<div class={['relative', ...borderClasses, ...value.getClasses()]}>
+  {@render children()}
+  <div
+    class="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2
+    w-4 text-[0.7rem] px-1
+    text-white bg-cyan-800
+    rounded-full"
+  >
+    {match(value)
+      .with({ $type: 'TrueV' }, () => '✓')
+      .with({ $type: 'FalseV' }, () => '✗')
+      .with({ $type: 'UnknownV' }, () => null)
+      .exhaustive()}
+  </div>
+</div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -31,7 +31,7 @@
   }
   const unsub = useLadderEnv().getLirRegistry().subscribe(onArgValueChange)
 
-  onDestroy(unsub.unsubscribe)
+  onDestroy(() => unsub.unsubscribe())
 </script>
 
 <!-- App Arg UI -->

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -9,7 +9,7 @@
   import { useLadderEnv } from '$lib/ladder-env.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
   import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
-  import WithValueIndicator from '$lib/displayers/flow/helpers/with-value-indicator.svelte'
+  import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
   import { onDestroy } from 'svelte'
   import type { LirContext, LirId } from '$lib/layout-ir/core.js'
 
@@ -48,7 +48,7 @@
         <!-- Args (see also note above)-->
         <div class="flex flex-wrap gap-1 justify-center">
           {#each data.args as arg, i}
-            <WithValueIndicator
+            <ValueIndicator
               value={argValues[i]}
               borderClasses={['border', 'border-black', 'rounded-lg']}
             >
@@ -75,7 +75,7 @@
               >
                 {arg.getLabel(data.context)}
               </button>
-            </WithValueIndicator>
+            </ValueIndicator>
           {/each}
         </div>
       </div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -67,7 +67,9 @@
   <!-- bg-gray
  to evoke the idea of a fn being a 'black box'
 (but not using solid black b/c don't want too much contrast between this and a uboolvarnode) -->
-  <!-- TODO: Add a value indicator for the App itself -->
+  <!-- TODO: Add a value indicator for the App itself 
+       NOTE: We do NOT want cursor-pointer for the App UI itself.
+  -->
   <div class={['bg-gray-100 app-node-border', ...data.classes]}>
     <WithNormalHandles>
       <div

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -34,10 +34,34 @@
   onDestroy(unsub.unsubscribe)
 </script>
 
+<!-- App Arg UI -->
+{#snippet argUI(arg: (typeof data.args)[number], i: number)}
+  <ValueIndicator
+    value={argValues[i]}
+    borderClasses={['border', 'border-black', 'rounded-lg']}
+  >
+    <button
+      class={['p-2', 'text-xs', ...arg.getAllClasses(data.context)]}
+      onclick={async () => {
+        console.log('clicked: ', arg.getLabel(data.context), arg.getId())
+
+        const newValue = cycle(arg.getValue(data.context))
+        await ladderGraph.submitNewBinding(data.context, {
+          unique: arg.getUnique(data.context),
+          value: newValue,
+        })
+      }}
+    >
+      {arg.getLabel(data.context)}
+    </button>
+  </ValueIndicator>
+{/snippet}
+
 <WithContentfulNodeStyles>
   <!-- bg-gray
  to evoke the idea of a fn being a 'black box'
 (but not using solid black b/c don't want too much contrast between this and a uboolvarnode) -->
+  <!-- TODO: Add a value indicator for the App itself -->
   <div class={['bg-gray-100 app-node-border', ...data.classes]}>
     <WithNormalHandles>
       <div
@@ -50,34 +74,7 @@
         <!-- Args (see also note above)-->
         <div class="flex flex-wrap gap-1 justify-center">
           {#each data.args as arg, i}
-            <ValueIndicator
-              value={argValues[i]}
-              borderClasses={['border', 'border-black', 'rounded-lg']}
-            >
-              <button
-                class={[
-                  'p-2',
-                  'text-xs',
-                  'cursor-pointer',
-                  ...arg.getAllClasses(data.context),
-                ]}
-                onclick={async () => {
-                  console.log(
-                    'clicked: ',
-                    arg.getLabel(data.context),
-                    arg.getId()
-                  )
-
-                  const newValue = cycle(arg.getValue(data.context))
-                  await ladderGraph.submitNewBinding(data.context, {
-                    unique: arg.getUnique(data.context),
-                    value: newValue,
-                  })
-                }}
-              >
-                {arg.getLabel(data.context)}
-              </button>
-            </ValueIndicator>
+            {@render argUI(arg, i)}
           {/each}
         </div>
       </div>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -45,8 +45,9 @@
       ...arg.getAllClasses(data.context),
     ]}
   >
+    <!-- Yes, we need cursor-pointer here. -->
     <button
-      class={['p-2', 'text-xs']}
+      class={['p-2', 'text-xs', 'cursor-pointer']}
       onclick={async () => {
         console.log('clicked: ', arg.getLabel(data.context), arg.getId())
 

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -38,10 +38,15 @@
 {#snippet argUI(arg: (typeof data.args)[number], i: number)}
   <ValueIndicator
     value={argValues[i]}
-    borderClasses={['border', 'border-black', 'rounded-lg']}
+    additionalClasses={[
+      'border',
+      'border-black',
+      'rounded-lg',
+      ...arg.getAllClasses(data.context),
+    ]}
   >
     <button
-      class={['p-2', 'text-xs', ...arg.getAllClasses(data.context)]}
+      class={['p-2', 'text-xs']}
       onclick={async () => {
         console.log('clicked: ', arg.getLabel(data.context), arg.getId())
 

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -15,10 +15,12 @@
 
   let { data }: AppDisplayerProps = $props()
 
+  // Get LadderEnv, L4 Connection
   const ladderGraph = useLadderEnv()
     .getTopFunDeclLirNode(data.context)
     .getBody(data.context)
 
+  // The values of the arguments of the App
   const argValues = $state(data.args.map((arg) => arg.getValue(data.context)))
   const onArgValueChange = (context: LirContext, id: LirId) => {
     data.args.forEach((arg, i) => {

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/false-expr.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/false-expr.svelte
@@ -3,6 +3,7 @@
   import type { UBoolVarDisplayerProps } from '../svelteflow-types.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
   import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
+  import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
   let { data }: UBoolVarDisplayerProps = $props()
 </script>
@@ -10,13 +11,18 @@
 <!-- select-none to prevent text selection, to hint that this is a constant.
  Also no cursor-pointer -->
 <WithContentfulNodeStyles>
-  <div class={['bool-lit-node-border', 'select-none', ...data.classes]}>
+  <ValueIndicator
+    value={(data.context.get(data.originalLirId) as FalseExprLirNode).getValue(
+      data.context
+    )}
+    additionalClasses={['bool-lit-node-border', 'select-none', ...data.classes]}
+  >
     <WithNormalHandles>
       <div class="label-wrapper-for-content-bearing-sf-node">
         {(data.context.get(data.originalLirId) as FalseExprLirNode).toPretty(
           data.context
         )}
-      </div>
-    </WithNormalHandles>
-  </div>
+      </div></WithNormalHandles
+    >
+  </ValueIndicator>
 </WithContentfulNodeStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/true-expr.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/true-expr.svelte
@@ -3,6 +3,7 @@
   import type { BoolLitDisplayerProps } from '../svelteflow-types.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
   import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
+  import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
   let { data }: BoolLitDisplayerProps = $props()
 </script>
@@ -10,13 +11,18 @@
 <!-- select-none to prevent text selection, to hint that this is a constant.
  Also no cursor-pointer -->
 <WithContentfulNodeStyles>
-  <div class={['bool-lit-node-border', 'select-none', ...data.classes]}>
+  <ValueIndicator
+    value={(data.context.get(data.originalLirId) as TrueExprLirNode).getValue(
+      data.context
+    )}
+    additionalClasses={['bool-lit-node-border', 'select-none', ...data.classes]}
+  >
     <WithNormalHandles>
       <div class="label-wrapper-for-content-bearing-sf-node">
         {(data.context.get(data.originalLirId) as TrueExprLirNode).toPretty(
           data.context
         )}
-      </div>
-    </WithNormalHandles>
-  </div>
+      </div></WithNormalHandles
+    >
+  </ValueIndicator>
 </WithContentfulNodeStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -11,7 +11,7 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   import { cycle } from '$lib/eval/type.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
   import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
-  import WithValueIndicator from '$lib/displayers/flow/helpers/with-value-indicator.svelte'
+  import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
   let { data }: UBoolVarDisplayerProps = $props()
 
@@ -67,7 +67,7 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
 -->
 
 <WithContentfulNodeStyles>
-  <WithValueIndicator
+  <ValueIndicator
     value={uboolvarValue}
     borderClasses={['ubool-var-node-border']}
   >
@@ -95,5 +95,5 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
         {/if}
       </WithNormalHandles>
     </div>
-  </WithValueIndicator>
+  </ValueIndicator>
 </WithContentfulNodeStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -74,6 +74,7 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
     additionalClasses={['ubool-var-node-border', ...data.classes]}
   >
     <WithNormalHandles>
+      <!-- Yes, we need cursor-pointer here. -->
       <button
         class="label-wrapper-for-content-bearing-sf-node cursor-pointer"
         onclick={() => {

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -34,7 +34,7 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   }
   const unsub = ladderEnv.getLirRegistry().subscribe(onValueChange)
 
-  onDestroy(unsub.unsubscribe)
+  onDestroy(() => unsub.unsubscribe())
 </script>
 
 {#snippet inlineUI()}

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -15,9 +15,11 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
 
   let { data }: UBoolVarDisplayerProps = $props()
 
+  // Get LadderEnv, L4 Connection
   const ladderEnv = useLadderEnv()
   const l4Conn = ladderEnv.getL4Connection()
 
+  // The value of the UBoolVar
   let uboolvarValue = $state(
     (data.context.get(data.originalLirId) as UBoolVarLirNode).getValue(
       data.context

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -71,31 +71,29 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
 <WithContentfulNodeStyles>
   <ValueIndicator
     value={uboolvarValue}
-    borderClasses={['ubool-var-node-border']}
+    additionalClasses={['ubool-var-node-border', ...data.classes]}
   >
-    <div class={data.classes}>
-      <WithNormalHandles>
-        <button
-          class="label-wrapper-for-content-bearing-sf-node cursor-pointer"
-          onclick={() => {
-            const ladderGraph = ladderEnv
-              .getTopFunDeclLirNode(data.context)
-              .getBody(data.context)
-            const node = data.context.get(data.originalLirId) as UBoolVarLirNode
+    <WithNormalHandles>
+      <button
+        class="label-wrapper-for-content-bearing-sf-node cursor-pointer"
+        onclick={() => {
+          const ladderGraph = ladderEnv
+            .getTopFunDeclLirNode(data.context)
+            .getBody(data.context)
+          const node = data.context.get(data.originalLirId) as UBoolVarLirNode
 
-            const newValue = cycle(node.getValue(data.context))
-            ladderGraph.submitNewBinding(data.context, {
-              unique: node.getUnique(data.context),
-              value: newValue,
-            })
-          }}
-        >
-          {data.name.label}
-        </button>
-        {#if data.canInline}
-          {@render inlineUI()}
-        {/if}
-      </WithNormalHandles>
-    </div>
+          const newValue = cycle(node.getValue(data.context))
+          ladderGraph.submitNewBinding(data.context, {
+            unique: node.getUnique(data.context),
+            value: newValue,
+          })
+        }}
+      >
+        {data.name.label}
+      </button>
+      {#if data.canInline}
+        {@render inlineUI()}
+      {/if}
+    </WithNormalHandles>
   </ValueIndicator>
 </WithContentfulNodeStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/eval/eval.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/eval/eval.ts
@@ -71,15 +71,19 @@ export const Evaluator: LadderEvaluator = {
     ): Promise<EvalResult> {
       return match(ladder)
         .with({ $type: 'TrueE' }, () => {
+          const result = new TrueVal()
+          const newIntermediate = intermediate.set(ladder.id, result)
           return {
-            result: new TrueVal(),
-            intermediate: intermediate,
+            result,
+            intermediate: newIntermediate,
           }
         })
         .with({ $type: 'FalseE' }, () => {
+          const result = new FalseVal()
+          const newIntermediate = intermediate.set(ladder.id, result)
           return {
-            result: new FalseVal(),
-            intermediate: intermediate,
+            result,
+            intermediate: newIntermediate,
           }
         })
         .with({ $type: 'UBoolVar' }, (expr: EvUBoolVar) => {

--- a/ts-apps/decision-logic-visualizer/src/lib/eval/type.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/eval/type.ts
@@ -4,8 +4,9 @@ import * as VE from '@repo/viz-expr'
 import {
   TrueValCSSClass,
   FalseValCSSClass,
+  UnknownValCSSClass,
 } from '$lib/layout-ir/ladder-graph/node-styles.js'
-import type { BoolValCSSClass } from '$lib/layout-ir/ladder-graph/node-styles.js'
+import type { UBoolValCSSClass } from '$lib/layout-ir/ladder-graph/node-styles.js'
 
 import { match } from 'ts-pattern'
 
@@ -29,7 +30,7 @@ export function toVEBoolValue(val: UBoolVal): VE.UBoolValue {
 
 interface UBoolV {
   $type: TrueVal['$type'] | FalseVal['$type'] | UnknownVal['$type']
-  getClasses(): BoolValCSSClass[]
+  getClasses(): UBoolValCSSClass[]
   toPretty(): string
 }
 
@@ -76,7 +77,7 @@ export class UnknownVal implements UBoolV {
   constructor() {}
 
   getClasses() {
-    return []
+    return [UnknownValCSSClass]
   }
 
   toPretty() {

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
@@ -6,6 +6,8 @@ import {
   UnknownVal,
   veExprToEvExpr,
   toUBoolVal,
+  TrueVal,
+  FalseVal,
 } from '../../eval/type.js'
 import { Assignment, Corefs } from '../../eval/assignment.js'
 import { Evaluator, type EvalResult } from '$lib/eval/eval.js'
@@ -758,6 +760,7 @@ export function isFalseExprLirNode(
 
 export class FalseExprLirNode extends BaseFlowLirNode implements FlowLirNode {
   #name: Name
+  #value = new FalseVal()
 
   constructor(
     nodeInfo: LirNodeInfo,
@@ -768,8 +771,8 @@ export class FalseExprLirNode extends BaseFlowLirNode implements FlowLirNode {
     this.#name = name
   }
 
-  override getAllClasses(context: LirContext): LadderNodeCSSClass[] {
-    return [...super.getAllClasses(context), 'false-val']
+  getValue(_context: LirContext) {
+    return this.#value
   }
 
   toPretty(_context: LirContext) {
@@ -783,6 +786,7 @@ export class FalseExprLirNode extends BaseFlowLirNode implements FlowLirNode {
 
 export class TrueExprLirNode extends BaseFlowLirNode implements FlowLirNode {
   #name: Name
+  #value = new TrueVal()
 
   constructor(
     nodeInfo: LirNodeInfo,
@@ -793,8 +797,8 @@ export class TrueExprLirNode extends BaseFlowLirNode implements FlowLirNode {
     this.#name = name
   }
 
-  override getAllClasses(context: LirContext): LadderNodeCSSClass[] {
-    return [...super.getAllClasses(context), 'true-val']
+  getValue(_context: LirContext) {
+    return this.#value
   }
 
   toPretty(_context: LirContext) {
@@ -865,17 +869,13 @@ export class UBoolVarLirNode extends BaseFlowLirNode implements VarLirNode {
     }
   }
 
-  override getAllClasses(_context: LirContext): LadderNodeCSSClass[] {
-    // console.log('modifierCSSClasses', this.modifierCSSClasses)
-    return [...this.#value.getClasses(), ...this.modifierCSSClasses]
-  }
-
   getValue(_context: LirContext): UBoolVal {
     return this.#value
   }
 
-  _setValue(_context: LirContext, value: UBoolVal) {
+  _setValue(context: LirContext, value: UBoolVal) {
     this.#value = value
+    this.getRegistry().publish(context, this.getId())
   }
 
   toPretty(context: LirContext) {

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/node-styles.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/node-styles.ts
@@ -1,8 +1,12 @@
-export type BoolValCSSClass = typeof TrueValCSSClass | typeof FalseValCSSClass
+export type UBoolValCSSClass =
+  | typeof TrueValCSSClass
+  | typeof FalseValCSSClass
+  | typeof UnknownValCSSClass
 export const TrueValCSSClass = 'true-val' as const
 export const FalseValCSSClass = 'false-val' as const
+export const UnknownValCSSClass = 'bg-white' as const
 
 export type NodeStyleModifierCSSClass = typeof FadedNodeCSSClass
 export const FadedNodeCSSClass = 'nonviable-ladder-element' as const
 
-export type LadderNodeCSSClass = BoolValCSSClass | NodeStyleModifierCSSClass
+export type LadderNodeCSSClass = UBoolValCSSClass | NodeStyleModifierCSSClass

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -165,6 +165,18 @@
   --color-false-value: var(--color-rose-200);
 }
 
+/***************************************
+         UBoolVarNode border 
+****************************************/
+
+.ubool-var-node-border {
+  border: var(--ladder-node-border, var(--ladder-node-border-default));
+  border-radius: var(
+    --ladder-node-border-radius,
+    var(--ladder-node-border-radius-default)
+  );
+}
+
 /*************************************
   Utility SF styles
 *************************************/
@@ -177,23 +189,6 @@ that a node might have (e.g., the darker background of (the 'function part' of) 
 
 @utility false-val {
   background-color: var(--color-false-value) !important;
-}
-
-/* A non-color-based indicator of the value */
-.true-val::after {
-  content: '✓';
-  @apply absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2;
-  @apply w-4 text-[0.7rem] px-1;
-  @apply text-white bg-cyan-800;
-  @apply rounded-full;
-}
-
-.false-val::after {
-  content: '✗';
-  @apply absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2;
-  @apply w-4 text-[0.7rem] px-1;
-  @apply text-white bg-cyan-800;
-  @apply rounded-full;
 }
 
 @utility base-sf-node-styles {


### PR DESCRIPTION
* eval.ts: Fix bug in how boolean literals were handled (forgot to update the intermediate env)
* Add comments noting that we do need to specify `cursor-pointer` even for buttons -- prob b/c it gets overridden by some SvelteFlow style otherwise?
* Refactor app.svelte: extract ui for each app arg into a Svelte snippet
* Make the non-color-based value indicator more robust / less fragile and easier to reason about with `ValueIndicator`
*  Fix value UI bug for App of args.
* Add style for UnknownVal (bg-white)

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/72075358-4c4a-44ea-b1c4-a5cb6d5619f6" />
<img width="627" alt="image" src="https://github.com/user-attachments/assets/89087c60-4e72-4ed8-86c7-7f904632219d" />

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/1b9b6d6e-6383-4398-9689-b3cabcaf6122" />
