### PR TITLE
Viz: Refactor: Simplify / improve some handling and updating of values

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -10,8 +10,6 @@
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
   import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
   import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
-  import { onDestroy } from 'svelte'
-  import type { LirContext, LirId } from '$lib/layout-ir/core.js'
 
   let { data }: AppDisplayerProps = $props()
 
@@ -19,25 +17,12 @@
   const ladderGraph = useLadderEnv()
     .getTopFunDeclLirNode(data.context)
     .getBody(data.context)
-
-  // The values of the arguments of the App
-  const argValues = $state(data.args.map((arg) => arg.getValue(data.context)))
-  const onArgValueChange = (context: LirContext, id: LirId) => {
-    data.args.forEach((arg, i) => {
-      if (id === arg.getId()) {
-        argValues[i] = arg.getValue(context)
-      }
-    })
-  }
-  const unsub = useLadderEnv().getLirRegistry().subscribe(onArgValueChange)
-
-  onDestroy(() => unsub.unsubscribe())
 </script>
 
 <!-- App Arg UI -->
 {#snippet argUI(arg: (typeof data.args)[number], i: number)}
   <ValueIndicator
-    value={argValues[i]}
+    value={data.args.map((arg) => arg.getValue(data.context))[i]}
     additionalClasses={[
       'border',
       'border-black',

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -13,7 +13,6 @@
 
   let { data }: AppDisplayerProps = $props()
 
-  // Get LadderEnv, L4 Connection
   const ladderGraph = useLadderEnv()
     .getTopFunDeclLirNode(data.context)
     .getBody(data.context)

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -21,7 +21,7 @@
 <!-- App Arg UI -->
 {#snippet argUI(arg: (typeof data.args)[number], i: number)}
   <ValueIndicator
-    value={data.args.map((arg) => arg.getValue(data.context))[i]}
+    value={data.args.map((arg) => arg.getValue(data.context, ladderGraph))[i]}
     additionalClasses={[
       'border',
       'border-black',
@@ -35,7 +35,7 @@
       onclick={async () => {
         console.log('clicked: ', arg.getLabel(data.context), arg.getId())
 
-        const newValue = cycle(arg.getValue(data.context))
+        const newValue = cycle(arg.getValue(data.context, ladderGraph))
         await ladderGraph.submitNewBinding(data.context, {
           unique: arg.getUnique(data.context),
           value: newValue,

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -16,6 +16,9 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
 
   // Get LadderEnv, L4 Connection
   const ladderEnv = useLadderEnv()
+  const ladderGraph = ladderEnv
+    .getTopFunDeclLirNode(data.context)
+    .getBody(data.context)
   const l4Conn = ladderEnv.getL4Connection()
 
   const node = data.context.get(data.originalLirId) as UBoolVarLirNode
@@ -31,11 +34,8 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
           onclick={() => {
             console.log('inline lir id', data.originalLirId.toString())
 
-            const uniq = (
-              data.context.get(data.originalLirId) as UBoolVarLirNode
-            ).getUnique(data.context)
             l4Conn.inlineExprs(
-              [uniq],
+              [node.getUnique(data.context)],
               ladderEnv.getVersionedTextDocIdentifier()
             )
           }}
@@ -54,7 +54,7 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
 
 <WithContentfulNodeStyles>
   <ValueIndicator
-    value={node.getValue(data.context)}
+    value={node.getValue(data.context, ladderGraph)}
     additionalClasses={['ubool-var-node-border', ...data.classes]}
   >
     <WithNormalHandles>
@@ -63,11 +63,7 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
         <button
           class="label-wrapper-for-content-bearing-sf-node cursor-pointer"
           onclick={() => {
-            const ladderGraph = ladderEnv
-              .getTopFunDeclLirNode(data.context)
-              .getBody(data.context)
-
-            const newValue = cycle(node.getValue(data.context))
+            const newValue = cycle(node.getValue(data.context, ladderGraph))
             ladderGraph.submitNewBinding(data.context, {
               unique: node.getUnique(data.context),
               value: newValue,

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -2,8 +2,6 @@
 https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/components/nodes/DefaultNode.svelte
 -->
 <script lang="ts">
-  import { onDestroy } from 'svelte'
-  import type { LirContext, LirId } from '$lib/layout-ir/core.js'
   import type { UBoolVarDisplayerProps } from '../svelteflow-types.js'
   import { useLadderEnv } from '$lib/ladder-env.js'
   import { UBoolVarLirNode } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
@@ -20,22 +18,7 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   const ladderEnv = useLadderEnv()
   const l4Conn = ladderEnv.getL4Connection()
 
-  // The value of the UBoolVar
-  let uboolvarValue = $state(
-    (data.context.get(data.originalLirId) as UBoolVarLirNode).getValue(
-      data.context
-    )
-  )
-  const onValueChange = (context: LirContext, id: LirId) => {
-    if (id === data.originalLirId) {
-      uboolvarValue = (
-        context.get(data.originalLirId) as UBoolVarLirNode
-      ).getValue(context)
-    }
-  }
-  const unsub = ladderEnv.getLirRegistry().subscribe(onValueChange)
-
-  onDestroy(() => unsub.unsubscribe())
+  const node = data.context.get(data.originalLirId) as UBoolVarLirNode
 </script>
 
 {#snippet inlineUI()}
@@ -71,7 +54,7 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
 
 <WithContentfulNodeStyles>
   <ValueIndicator
-    value={uboolvarValue}
+    value={node.getValue(data.context)}
     additionalClasses={['ubool-var-node-border', ...data.classes]}
   >
     <WithNormalHandles>
@@ -83,7 +66,6 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
             const ladderGraph = ladderEnv
               .getTopFunDeclLirNode(data.context)
               .getBody(data.context)
-            const node = data.context.get(data.originalLirId) as UBoolVarLirNode
 
             const newValue = cycle(node.getValue(data.context))
             ladderGraph.submitNewBinding(data.context, {

--- a/ts-apps/decision-logic-visualizer/src/lib/eval/assignment.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/eval/assignment.ts
@@ -1,6 +1,5 @@
 import type { Unique } from '@repo/viz-expr'
 import type { UBoolVal } from './type.js'
-import type { LirId } from '../layout-ir/core.js'
 
 /** A mapping from Unique to UBoolVal */
 export class Assignment {
@@ -45,37 +44,5 @@ export class Assignment {
 
   clone() {
     return new Assignment(this.#subst.slice())
-  }
-}
-
-/**
- * Coreferents: mapping from Unique to Set<LirId>
- */
-export class Corefs {
-  // A Unique is a non-negative integer
-  #coreferents: Array<Set<LirId>>
-
-  static fromEntries(entries: Array<[Unique, LirId]>): Corefs {
-    const initialCoreferents: Array<Set<LirId>> = []
-    entries.forEach(([unique, lirId]) => {
-      if (!initialCoreferents[unique]) {
-        initialCoreferents[unique] = new Set([lirId])
-      } else {
-        initialCoreferents[unique].add(lirId)
-      }
-    })
-    return new Corefs(initialCoreferents)
-  }
-
-  private constructor(initialCoreferents: Array<Set<LirId>>) {
-    this.#coreferents = initialCoreferents
-  }
-
-  getCoreferents(unique: Unique) {
-    return this.#coreferents[unique] ?? new Set<LirId>()
-  }
-
-  dispose() {
-    this.#coreferents = []
   }
 }


### PR DESCRIPTION
* Refactor: Simplify the updating of value in the AppLirNode displayer and UBoolVarLirNode displayer, by leveraging how SF nodes' `data` seems reactive
* Refactor: Remove redundant state related to uboolvarnodes' values (and redundant logic synchronizing such state)