### PR TITLE
Viz: Refactor: Have displayers trigger and check for node selection by interacting with LadderGraphLirNode, instead of the NodeSelectionTracker

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-selectable-node-context-menu.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-selectable-node-context-menu.svelte
@@ -2,13 +2,11 @@
 <script lang="ts" module>
   import { type Snippet } from 'svelte'
   import type { LirContext } from '$lib/layout-ir/core'
-  import type { LadderNodeSelectionTracker } from '$lib/layout-ir/paths-list.js'
   import type { SelectableLadderLirNode } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
 
   interface SelectableNodeContextMenuProps {
     context: LirContext
     node: SelectableLadderLirNode
-    nodeSelectionTracker: LadderNodeSelectionTracker
     children: Snippet
   }
 </script>
@@ -17,21 +15,16 @@
   import * as ContextMenu from '$lib/ui-primitives/context-menu/index.js'
   import { useLadderEnv } from '$lib/ladder-env'
 
-  let {
-    context,
-    node,
-    nodeSelectionTracker,
-    children,
-  }: SelectableNodeContextMenuProps = $props()
+  let { context, node, children }: SelectableNodeContextMenuProps = $props()
 
-  const ladderEnv = useLadderEnv()
-  const ladderGraph = ladderEnv.getTopFunDeclLirNode(context).getBody(context)
+  const ladderGraph = useLadderEnv()
+    .getTopFunDeclLirNode(context)
+    .getBody(context)
   const onSelect = () => {
-    node.toggleSelection(context, nodeSelectionTracker, ladderGraph)
+    ladderGraph.toggleNodeSelection(context, node)
   }
 </script>
 
-<!-- TODO: Node highlight styles not wroking yet -->
 <ContextMenu.Root>
   <ContextMenu.Trigger>
     {@render children()}

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -22,7 +22,6 @@
   const ladderGraph = useLadderEnv()
     .getTopFunDeclLirNode(data.context)
     .getBody(data.context)
-  const nodeSelectionTracker = ladderGraph.getNodeSelectionTracker(data.context)
 
   const node = data.node as AppLirNode
 </script>
@@ -87,12 +86,8 @@
     ]}
   >
     <WithNormalHandles>
-      {#if nodeSelectionTracker}
-        <WithSelectableNodeContextMenu
-          context={data.context}
-          {node}
-          {nodeSelectionTracker}
-        >
+      {#if ladderGraph.getNodeSelectionTracker(data.context)}
+        <WithSelectableNodeContextMenu context={data.context} {node}>
           {@render coreAppUI()}
         </WithSelectableNodeContextMenu>
       {:else}

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -11,8 +11,6 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
   import WithSelectableNodeContextMenu from '$lib/displayers/flow/helpers/with-selectable-node-context-menu.svelte'
   import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
-  import type { LirContext, LirId } from '$lib/layout-ir/core.js'
-  import { onDestroy } from 'svelte'
 
   let { data }: LadderNodeDisplayerProps = $props()
 
@@ -26,18 +24,6 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   const nodeSelectionTracker = ladderGraph.getNodeSelectionTracker(data.context)
 
   const node = data.node as UBoolVarLirNode
-
-  // Selected state and updates thereof
-  let selected = $state(false)
-  const onSelectionChange = (context: LirContext, id: LirId) => {
-    if (id === node.getId() && nodeSelectionTracker) {
-      selected = node.isSelected(context, nodeSelectionTracker)
-      console.log('onSelectionChange', selected)
-    }
-  }
-
-  const unsub = ladderEnv.getLirRegistry().subscribe(onSelectionChange)
-  onDestroy(() => unsub.unsubscribe())
 </script>
 
 {#snippet inlineUI()}
@@ -88,7 +74,9 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
   <ValueIndicator
     value={node.getValue(data.context, ladderGraph)}
     additionalClasses={[
-      selected ? 'highlighted-ladder-node' : '',
+      ladderGraph.nodeIsSelected(data.context, node)
+        ? 'highlighted-ladder-node'
+        : '',
       'ubool-var-node-border',
       ...node.getAllClasses(data.context),
     ]}
@@ -98,7 +86,6 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
         <WithSelectableNodeContextMenu
           context={data.context}
           node={data.node as UBoolVarLirNode}
-          {nodeSelectionTracker}
         >
           {@render coreUBoolVarUI()}
         </WithSelectableNodeContextMenu>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/paths-list.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/paths-list.svelte
@@ -68,7 +68,7 @@
 
     // Update state in the LadderNodeSelectionTracker with the new selected lin paths
     // (This in turn triggers updates to the derived state / projections)
-    nodeSelectionTracker.selectNodesAndUpdateProjections(
+    nodeSelectionTracker.selectNodesAndUpdate(
       context,
       selectedLinPaths.flatMap((p) => p.getSelectableVertices(context)),
       ladderGraph

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/paths-list.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/paths-list.ts
@@ -212,7 +212,7 @@ export class LadderNodeSelectionTracker {
     return this.#selected.has(node.getId())
   }
 
-  private updateProjections(
+  private updateDerivedState(
     context: LirContext,
     ladderGraph: LadderGraphLirNode
   ) {
@@ -254,29 +254,26 @@ export class LadderNodeSelectionTracker {
     ladderGraph.highlightSubgraphEdges(context, graphToHighlight)
   }
 
-  resetSelectedNodes(context: LirContext) {
-    const prevSelected = this.getSelectedForHighlightPaths(context)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  clearSelectedNodes(_context: LirContext) {
     this.#selected = new Set()
-    prevSelected.forEach((node) =>
-      this.lirRegistry.publish(context, node.getId())
-    )
   }
 
-  selectNodesAndUpdateProjections(
+  selectNodesAndUpdate(
     context: LirContext,
     nodes: Array<SelectableLadderLirNode>,
     ladderGraph: LadderGraphLirNode
   ) {
-    this.resetSelectedNodes(context)
+    this.clearSelectedNodes(context)
 
     this.#selected = new Set(nodes.map((node) => node.getId()))
     nodes.forEach((node) => this.lirRegistry.publish(context, node.getId()))
 
-    this.updateProjections(context, ladderGraph)
+    this.updateDerivedState(context, ladderGraph)
   }
 
-  /** Toggle whether a specific node is selected for highlighting (and update projections) */
-  toggleNodeSelectionAndUpdateProjections(
+  /** Toggle whether a specific node is selected for highlighting (and update derived state) */
+  toggleNodeSelectionAndUpdate(
     context: LirContext,
     node: SelectableLadderLirNode,
     ladderGraph: LadderGraphLirNode
@@ -288,7 +285,7 @@ export class LadderNodeSelectionTracker {
     }
     this.lirRegistry.publish(context, node.getId())
 
-    this.updateProjections(context, ladderGraph)
+    this.updateDerivedState(context, ladderGraph)
   }
 
   /** Given the selected nodes, figure out what lin paths through the ladder graph, if any, these correspond to */


### PR DESCRIPTION
Have displayers trigger and check for node selection by interacting with LadderGraphLirNode, instead of the NodeSelectionTracker. This obviates the need to duplicate state about whether the node is selected in the node displayer

<img width="1518" alt="image" src="https://github.com/user-attachments/assets/d1ab3f7b-046e-4af4-b3fd-ff04898b72bf" />
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/070f8614-42ea-4db0-a51c-703dc86e49e2" />

