### PR TITLE
Viz: Make it possible to select / highlight the whole NOT subgraph by selecting the NotStart node. And misc refactoring / cleaning up

### DIFF
--- a/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/data/viz-expr-to-lir.ts
@@ -150,7 +150,9 @@ function transform(
       } = transform(nodeInfo, veToLir, neg.negand, ladderEnv)
 
       // Make the NOT subgraph
-      const notStart = vertex(new NotStartLirNode(nodeInfo, negand).getId())
+      const notStart = vertex(
+        new NotStartLirNode(nodeInfo, negand, neg).getId()
+      )
       const notEnd = vertex(new NotEndLirNode(nodeInfo).getId())
 
       const notGraph = sandwichWithSourceAndSink(notStart, notEnd, negand)

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -313,7 +313,6 @@
 Misc SF UI TODOs:
 
 * Make it clearer that the bool var nodes are clickable
-(should at least change the cursor to a pointer on mouseover)
 -->
 
 <!-- The consumer containing div must set the height to, e.g., 96svh if that's what's wanted -->

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/flow-base.svelte
@@ -7,6 +7,7 @@
   import { LirContext } from '$lib/layout-ir/core.js'
   import {
     type LadderLirNode,
+    type SelectableLadderLirNode,
     isNNFLadderGraphLirNode,
   } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
   import { useLadderEnv } from '$lib/ladder-env.js'
@@ -192,6 +193,8 @@
         LadderGraph event listener
   **********************************************/
 
+  let selectedNodes: SelectableLadderLirNode[] = []
+
   /**
    * Most naive version: When a non-positional change occurs in the LadderGraphLirNode,
    * we generate and re-render the SF graph.
@@ -212,6 +215,17 @@
       // console.log('newSfGraph NODES', NODES)
 
       updateResultDisplay()
+
+      const newSelectedNodes = isNNFLadderGraphLirNode(ladderGraph)
+        ? ladderGraph.getSelectedNodes(context)
+        : []
+      if (newSelectedNodes.length !== selectedNodes.length) {
+        setTimeout(() => {
+          doLayout() // Paths can get visually mis-aligned otherwise
+          // Need a small delay to ensure that the nodes have been measured
+        }, 100)
+        selectedNodes = newSelectedNodes
+      }
     }
   }
 
@@ -247,10 +261,7 @@
   }
 
   function doLayout() {
-    if (
-      debouncedSfNodes$Initialized.current &&
-      NODES.every((node) => node.measured?.height && node.measured?.width)
-    ) {
+    if (NODES.every((node) => node.measured?.height && node.measured?.width)) {
       // Layout
       const layoutedElements = getLayoutedElements(
         dagreConfig,

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-non-bundling-node-base-styles.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-non-bundling-node-base-styles.svelte
@@ -1,14 +1,14 @@
-<!-- Wrapper that provides the base styles for contentful nodes -->
+<!-- Wrapper that provides the base styles for non-bundling nodes -->
 <script lang="ts" module>
   import type { Snippet } from 'svelte'
 
-  interface WithContentfulNodeStylesProps {
+  interface WithNonBundlingNodeBaseStylesProps {
     children: Snippet
   }
 </script>
 
 <script lang="ts">
-  let { children }: WithContentfulNodeStylesProps = $props()
+  let { children }: WithNonBundlingNodeBaseStylesProps = $props()
 </script>
 
 <div class="base-sf-node-styles transition-opacity duration-300">

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-selectable-node-context-menu.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/helpers/with-selectable-node-context-menu.svelte
@@ -11,6 +11,7 @@
     context: LirContext
     node: SelectableLadderLirNode
     ladderGraph: NNFLadderGraphLirNode
+    onSelect?: () => void
     children: Snippet
   }
 </script>
@@ -18,12 +19,17 @@
 <script lang="ts">
   import * as ContextMenu from '$lib/ui-primitives/context-menu/index.js'
 
-  let { context, node, ladderGraph, children }: SelectableNodeContextMenuProps =
-    $props()
-
-  const onSelect = () => {
+  const defaultOnSelect = () => {
     ladderGraph.toggleNodeSelection(context, node)
   }
+
+  let {
+    context,
+    node,
+    ladderGraph,
+    onSelect = defaultOnSelect,
+    children,
+  }: SelectableNodeContextMenuProps = $props()
 </script>
 
 <ContextMenu.Root>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/app.svelte
@@ -14,7 +14,7 @@
   } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
 
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
-  import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
+  import WithNonBundlingNodeBaseStyles from '$lib/displayers/flow/helpers/with-non-bundling-node-base-styles.svelte'
   import WithSelectableNodeContextMenu from '$lib/displayers/flow/helpers/with-selectable-node-context-menu.svelte'
   import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
@@ -77,7 +77,7 @@
   </ValueIndicator>
 {/snippet}
 
-<WithContentfulNodeStyles>
+<WithNonBundlingNodeBaseStyles>
   <!-- bg-gray
  to evoke the idea of a fn being a 'black box'
 (but not using solid black b/c don't want too much contrast between this and a uboolvarnode) -->
@@ -110,7 +110,7 @@
       {/if}
     </WithNormalHandles>
   </div>
-</WithContentfulNodeStyles>
+</WithNonBundlingNodeBaseStyles>
 
 <style>
   .app-node-border {

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/false-expr.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/false-expr.svelte
@@ -2,7 +2,7 @@
   import { FalseExprLirNode } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
   import type { LadderNodeDisplayerProps } from '../svelteflow-types.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
-  import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
+  import WithNonBundlingNodeBaseStyles from '$lib/displayers/flow/helpers/with-non-bundling-node-base-styles.svelte'
   import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
   let { data }: LadderNodeDisplayerProps = $props()
@@ -10,7 +10,7 @@
 
 <!-- select-none to prevent text selection, to hint that this is a constant.
  Also no cursor-pointer -->
-<WithContentfulNodeStyles>
+<WithNonBundlingNodeBaseStyles>
   <ValueIndicator
     value={(data.node as FalseExprLirNode).getValue(data.context)}
     additionalClasses={[
@@ -25,4 +25,4 @@
       </div>
     </WithNormalHandles>
   </ValueIndicator>
-</WithContentfulNodeStyles>
+</WithNonBundlingNodeBaseStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/not-end.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/not-end.svelte
@@ -4,37 +4,57 @@
     type LadderNodeDisplayerProps,
   } from '../svelteflow-types.js'
   import { Handle } from '@xyflow/svelte'
+  import { useLadderEnv } from '$lib/ladder-env.js'
+  import {
+    isNNFLadderGraphLirNode,
+    NotEndLirNode,
+  } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
+  import WithNonBundlingNodeBaseStyles from '$lib/displayers/flow/helpers/with-non-bundling-node-base-styles.svelte'
 
   let { data }: LadderNodeDisplayerProps = $props()
+
+  const ladderGraph = useLadderEnv()
+    .getTopFunDeclLirNode(data.context)
+    .getBody(data.context)
+
+  // Highlight if the parent NOT group is selected
+  // (which in turn will be the case if the NotStart node is selected)
+  const isSelected = $derived(
+    isNNFLadderGraphLirNode(ladderGraph) &&
+      ladderGraph.nodeIsSelected(data.context, data.node as NotEndLirNode)
+  )
 
   const graphicSize = 84
 </script>
 
-<div class={['base-sf-node-styles', ...data.node.getAllClasses(data.context)]}>
-  <Handle
-    type="target"
-    position={defaultSFHandlesInfo.targetPosition}
-    style="opacity:0.3"
-  />
-  <!-- <div class="text-3xl fontmono"><pre>{'>'}</pre></div> -->
-  <svg
-    width="90%"
-    height={graphicSize * 0.45}
-    viewBox="0 0 60 100"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <!-- Right Angle Bracket '>' -->
-    <path
-      d="M0,0 L60,50 L0,100"
-      fill="none"
-      stroke="var(--ladder-node-color)"
-      stroke-width="3"
-      stroke-linecap="round"
+<WithNonBundlingNodeBaseStyles>
+  <div class={[...data.node.getAllClasses(data.context)]}>
+    <Handle
+      type="target"
+      position={defaultSFHandlesInfo.targetPosition}
+      style="opacity:0.3"
     />
-  </svg>
-  <Handle
-    type="source"
-    position={defaultSFHandlesInfo.sourcePosition}
-    style="opacity:0"
-  />
-</div>
+    <svg
+      width="90%"
+      height={graphicSize * 0.45}
+      viewBox="0 0 60 100"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <!-- Right Angle Bracket '>' -->
+      <path
+        d="M0,0 L60,50 L0,100"
+        fill="none"
+        stroke={isSelected
+          ? 'var(--color-highlighted-path-in-flow)'
+          : 'var(--ladder-node-color)'}
+        stroke-width={isSelected ? '4' : '3'}
+        stroke-linecap="round"
+      />
+    </svg>
+    <Handle
+      type="source"
+      position={defaultSFHandlesInfo.sourcePosition}
+      style="opacity:0"
+    />
+  </div>
+</WithNonBundlingNodeBaseStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/not-end.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/not-end.svelte
@@ -47,7 +47,9 @@
         stroke={isSelected
           ? 'var(--color-highlighted-path-in-flow)'
           : 'var(--ladder-node-color)'}
-        stroke-width={isSelected ? '4' : '3'}
+        stroke-width={isSelected
+          ? 'calc(3px + var(--path-highlight-delta))'
+          : '3px'}
         stroke-linecap="round"
       />
     </svg>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/not-start.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/not-start.svelte
@@ -4,23 +4,31 @@
     type LadderNodeDisplayerProps,
   } from '../svelteflow-types.js'
   import { Handle } from '@xyflow/svelte'
+  import { useLadderEnv } from '$lib/ladder-env.js'
+  import {
+    type LadderLirNode,
+    isNNFLadderGraphLirNode,
+    isSelectableLadderLirNode,
+    NotStartLirNode,
+  } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
+  import WithNonBundlingNodeBaseStyles from '$lib/displayers/flow/helpers/with-non-bundling-node-base-styles.svelte'
+  import WithSelectableNodeContextMenu from '$lib/displayers/flow/helpers/with-selectable-node-context-menu.svelte'
 
   let { data }: LadderNodeDisplayerProps = $props()
+
+  const ladderGraph = useLadderEnv()
+    .getTopFunDeclLirNode(data.context)
+    .getBody(data.context)
+
+  const isSelected = $derived(
+    isNNFLadderGraphLirNode(ladderGraph) &&
+      ladderGraph.nodeIsSelected(data.context, data.node as NotStartLirNode)
+  )
 
   const graphicSize = 100
 </script>
 
-<div
-  class={[
-    'base-sf-node-styles m-0 p-0',
-    ...data.node.getAllClasses(data.context),
-  ]}
->
-  <Handle
-    type="target"
-    position={defaultSFHandlesInfo.targetPosition}
-    style="opacity: 0.4"
-  />
+{#snippet coreNotStartUI()}
   <svg
     width="92%"
     height={graphicSize * 0.5}
@@ -28,12 +36,14 @@
     xmlns="http://www.w3.org/2000/svg"
   >
     <!-- Left Angle Bracket '<'
-    -->
+-->
     <path
       d="M40,10 L5,50 L40,90"
       fill="none"
-      stroke="var(--ladder-node-color)"
-      stroke-width="3"
+      stroke={isSelected
+        ? 'var(--color-highlighted-path-in-flow)'
+        : 'var(--ladder-node-color)'}
+      stroke-width={isSelected ? '4' : '3'}
       stroke-linecap="round"
     />
 
@@ -44,24 +54,66 @@
       font-size="42"
       dominant-baseline="middle"
       text-anchor="middle"
+      fill={isSelected
+        ? 'var(--color-highlighted-path-in-flow)'
+        : 'var(--ladder-node-color)'}
     >
       NOT
     </text>
 
     <!-- Vertical Line '|' -->
     <!-- <line
-      x1="100"
-      y1="10"
-      x2="100"
-      y2="90"
-      stroke="var(--ladder-node-color)"
-      stroke-width="2"
-      stroke-linecap="round"
-    /> -->
+x1="100"
+y1="10"
+x2="100"
+y2="90"
+stroke="var(--ladder-node-color)"
+stroke-width="2"
+stroke-linecap="round"
+/> -->
   </svg>
-  <Handle
-    type="source"
-    position={defaultSFHandlesInfo.sourcePosition}
-    style="opacity: 0.3"
-  />
-</div>
+{/snippet}
+
+<WithNonBundlingNodeBaseStyles>
+  <div class={['m-0 p-0', ...data.node.getAllClasses(data.context)]}>
+    <Handle
+      type="target"
+      position={defaultSFHandlesInfo.targetPosition}
+      style="opacity: 0.4"
+    />
+    {#if isNNFLadderGraphLirNode(ladderGraph)}
+      <WithSelectableNodeContextMenu
+        context={data.context}
+        node={data.node as NotStartLirNode}
+        {ladderGraph}
+        onSelect={() => {
+          const notGraph = (data.node as NotStartLirNode).getWholeNotGraph(
+            data.context,
+            ladderGraph
+          )
+          if (!notGraph) {
+            throw new Error('Not graph not found')
+          }
+          const nodes = notGraph
+            .getVertices()
+            .map((v) => data.context.get(v))
+            .filter((node): node is LadderLirNode => node !== undefined)
+            .filter(isSelectableLadderLirNode)
+          nodes.forEach((node) => {
+            // TODO: Might not want to actually select the negand too
+            ladderGraph.toggleNodeSelection(data.context, node)
+          })
+        }}
+      >
+        {@render coreNotStartUI()}
+      </WithSelectableNodeContextMenu>
+    {:else}
+      {@render coreNotStartUI()}
+    {/if}
+    <Handle
+      type="source"
+      position={defaultSFHandlesInfo.sourcePosition}
+      style="opacity: 0.3"
+    />
+  </div>
+</WithNonBundlingNodeBaseStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/not-start.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/not-start.svelte
@@ -43,7 +43,9 @@
       stroke={isSelected
         ? 'var(--color-highlighted-path-in-flow)'
         : 'var(--ladder-node-color)'}
-      stroke-width={isSelected ? '4' : '3'}
+      stroke-width={isSelected
+        ? 'calc(3px + var(--path-highlight-delta))'
+        : '3px'}
       stroke-linecap="round"
     />
 

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/true-expr.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/true-expr.svelte
@@ -2,7 +2,7 @@
   import { TrueExprLirNode } from '$lib/layout-ir/ladder-graph/ladder.svelte.js'
   import type { LadderNodeDisplayerProps } from '../svelteflow-types.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
-  import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
+  import WithNonBundlingNodeBaseStyles from '$lib/displayers/flow/helpers/with-non-bundling-node-base-styles.svelte'
   import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
   let { data }: LadderNodeDisplayerProps = $props()
@@ -10,7 +10,7 @@
 
 <!-- select-none to prevent text selection, to hint that this is a constant.
  Also no cursor-pointer -->
-<WithContentfulNodeStyles>
+<WithNonBundlingNodeBaseStyles>
   <ValueIndicator
     value={(data.node as TrueExprLirNode).getValue(data.context)}
     additionalClasses={[
@@ -25,4 +25,4 @@
       </div></WithNormalHandles
     >
   </ValueIndicator>
-</WithContentfulNodeStyles>
+</WithNonBundlingNodeBaseStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
+++ b/ts-apps/decision-logic-visualizer/src/lib/displayers/flow/sf-custom-nodes/ubool-var.svelte
@@ -11,7 +11,7 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
   import * as Tooltip from '$lib/ui-primitives/tooltip/index.js'
   import { cycle } from '$lib/eval/type.js'
   import WithNormalHandles from '$lib/displayers/flow/helpers/with-normal-handles.svelte'
-  import WithContentfulNodeStyles from '$lib/displayers/flow/helpers/with-contentful-node-styles.svelte'
+  import WithNonBundlingNodeBaseStyles from '$lib/displayers/flow/helpers/with-non-bundling-node-base-styles.svelte'
   import WithSelectableNodeContextMenu from '$lib/displayers/flow/helpers/with-selectable-node-context-menu.svelte'
   import ValueIndicator from '$lib/displayers/flow/helpers/value-indicator.svelte'
 
@@ -72,7 +72,7 @@ https://github.com/xyflow/xyflow/blob/migrate/svelte5/packages/svelte/src/lib/co
 TODO: Look into why this is the case --- are they not re-mounting the ubool-var component? 
 -->
 
-<WithContentfulNodeStyles>
+<WithNonBundlingNodeBaseStyles>
   <ValueIndicator
     value={node.getValue(data.context, ladderGraph)}
     additionalClasses={[
@@ -103,4 +103,4 @@ TODO: Look into why this is the case --- are they not re-mounting the ubool-var 
       {/if}
     </WithNormalHandles>
   </ValueIndicator>
-</WithContentfulNodeStyles>
+</WithNonBundlingNodeBaseStyles>

--- a/ts-apps/decision-logic-visualizer/src/lib/ladder-env.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/ladder-env.ts
@@ -85,7 +85,6 @@ export class LadderEnv {
   }
 
   // Constants
-  // TODO: Move constants to LadderEnv
 
   getExplanatoryAndEdgeLabel() {
     return this.config.constants.EXPLANATORY_AND_EDGE_LABEL

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
@@ -776,12 +776,16 @@ export type SelectableLadderLirNode =
   | UBoolVarLirNode
   | AppLirNode
   | NotStartLirNode
+  | NotEndLirNode
 
 export function isSelectableLadderLirNode(
   node: LadderLirNode
 ): node is SelectableLadderLirNode {
   return (
-    isUBoolVarLirNode(node) || isAppLirNode(node) || isNotStartLirNode(node)
+    isUBoolVarLirNode(node) ||
+    isAppLirNode(node) ||
+    isNotStartLirNode(node) ||
+    isNotEndLirNode(node)
   )
 }
 
@@ -931,6 +935,7 @@ export class NotStartLirNode extends BaseFlowLirNode implements FlowLirNode {
   constructor(
     nodeInfo: LirNodeInfo,
     private readonly negand: DirectedAcyclicGraph<LirId>,
+    private readonly originalExpr: IRExpr,
     position: Position = DEFAULT_INITIAL_POSITION
   ) {
     super(nodeInfo, position)
@@ -940,6 +945,14 @@ export class NotStartLirNode extends BaseFlowLirNode implements FlowLirNode {
     return this.negand
   }
 
+  getOriginalExpr(_context: LirContext) {
+    return this.originalExpr
+  }
+
+  getWholeNotGraph(_context: LirContext, ladderGraph: LadderGraphLirNode) {
+    return ladderGraph.getVizExprToLirGraph().get(this.originalExpr.id)
+  }
+
   toPretty(_context: LirContext) {
     return 'NOT ('
   }
@@ -947,6 +960,10 @@ export class NotStartLirNode extends BaseFlowLirNode implements FlowLirNode {
   toString(): string {
     return 'NOT_START_LIR_NODE'
   }
+}
+
+export function isNotEndLirNode(node: LadderLirNode): node is NotEndLirNode {
+  return node instanceof NotEndLirNode
 }
 
 export class NotEndLirNode extends BaseFlowLirNode implements FlowLirNode {

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
@@ -772,6 +772,13 @@ export type LadderLirNode =
   | TrueExprLirNode
   | FalseExprLirNode
 
+/** The name is perhaps misleading: these are nodes that can be given a highlighted / selected style;
+ * but not all the nodes here can be selected for highlighting by the user.
+ * E.g., you will not be able to select a NotEnd node in the graph
+ * by right-clicking on it --- the NOT subgraph
+ * is selected by right-clicking on the NotSTART node.
+ * TODO: Would be good to come up with a better name.
+ */
 export type SelectableLadderLirNode =
   | UBoolVarLirNode
   | AppLirNode

--- a/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
+++ b/ts-apps/decision-logic-visualizer/src/lib/layout-ir/ladder-graph/ladder.svelte.ts
@@ -712,8 +712,8 @@ export class NNFLadderGraphLirNode extends BaseLadderGraphLirNode {
     this.#nodeSelectionTracker?.selectNodesAndUpdate(context, nodes, this)
   }
 
-  getNodeSelectionTracker() {
-    return this.#nodeSelectionTracker
+  getSelectedNodes(context: LirContext) {
+    return this.#nodeSelectionTracker.getSelectedForHighlightPaths(context)
   }
 
   getPathsList(_context: LirContext) {

--- a/ts-apps/decision-logic-visualizer/src/style.css
+++ b/ts-apps/decision-logic-visualizer/src/style.css
@@ -142,8 +142,12 @@
 
   /* Stroke width */
   --stroke-width-default: 1px;
+  --path-highlight-delta: 2px;
+  --node-border-highlight-delta: 2px;
   /* TODO: Think about whether the default should be 2px */
-  --highlighted-stroke-width: calc(var(--stroke-width-default) + 2px);
+  --highlighted-stroke-width: calc(
+    var(--stroke-width-default) + var(--path-highlight-delta)
+  );
 
   /* Stroke color */
   --ladder-stroke-color-default: var(--color-primary);
@@ -285,7 +289,7 @@ that a node might have (e.g., the darker background of (the 'function part' of) 
 /* Override border properties when highlighted */
 .highlighted-ladder-node {
   --ladder-node-border-width: calc(
-    var(--ladder-node-border-width-default) + 1px
+    var(--ladder-node-border-width-default) + var(--node-border-highlight-delta)
   );
   --ladder-node-border-color: var(--color-highlighted-path-in-flow);
 }


### PR DESCRIPTION
* Make it possible to select / highlight the whole NOT subgraph by selecting the NotStart node
* Re-layout when node selection changes, so that paths won't end up looking visually mis-aligned.

---------

* Refactor: Make it easier to change the amount by which path width changes on highlight
* Refactor: Rename with-contentful-node-styles to with-non-bundling-node-base-styles
* Make it impossible for non-Ladder-Graph consumers to use the node selection tracker object without going through LadderGraphLirNode