### PR TITLE
Allow nested arguments for the L4 backend in jl4-decision-service

### DIFF
--- a/jl4-decision-service/src/Backend/Api.hs
+++ b/jl4-decision-service/src/Backend/Api.hs
@@ -67,7 +67,7 @@ instance FromJSON FnLiteral where
           ps <- traverse (\(k, v) -> fmap (Aeson.toText k,) (parseJSON v)) (Aeson.toList o)
           pure $ FnObject ps
 
-data RunFunction = RunFunction
+newtype RunFunction = RunFunction
   { -- | Run a function with parameters
     runFunction ::
       [(Text, Maybe FnLiteral)] ->
@@ -101,7 +101,7 @@ data ResponseWithReason = ResponseWithReason
   deriving anyclass (FromJSON, ToJSON)
 
 -- | Wrap our reasoning into a top-level field.
-data Reasoning = Reasoning
+newtype Reasoning = Reasoning
   { payload :: ReasoningTree
   }
   deriving (Show, Read, Ord, Eq, Generic)


### PR DESCRIPTION
Perform type-directed deserialisation of nested objects and arrays.
Closes #326 and #329

* [ ] Should finally add some integration tests, probably via servant-test.