### PR TITLE
Add floating action buttons to show and hide Example Selector with a sidebar overlay

### DIFF
--- a/ts-apps/jl4-web/src/routes/+page.svelte
+++ b/ts-apps/jl4-web/src/routes/+page.svelte
@@ -469,10 +469,17 @@
     title="Open examples sidebar"
     style="left: 2.5rem; top: 1.5rem;"
   >
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-      <line x1="4" y1="7" x2="20" y2="7"/>
-      <line x1="4" y1="12" x2="20" y2="12"/>
-      <line x1="4" y1="17" x2="20" y2="17"/>
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+    >
+      <line x1="4" y1="7" x2="20" y2="7" />
+      <line x1="4" y1="12" x2="20" y2="12" />
+      <line x1="4" y1="17" x2="20" y2="17" />
     </svg>
   </button>
 {/if}
@@ -485,21 +492,37 @@
   title="Share the current file"
   disabled={persistButtonBlocked}
 >
-  <FontAwesomeIcon icon={faShareAlt} style="font-size: 24px; vertical-align: middle;" />
+  <FontAwesomeIcon
+    icon={faShareAlt}
+    style="font-size: 24px; vertical-align: middle;"
+  />
 </button>
 
 <!-- Sidebar Overlay -->
-<div class="sidebar-overlay {showSidebar ? 'open' : ''}" onclick={() => (showSidebar = false)} tabindex="-1" aria-hidden={!showSidebar}></div>
+<div
+  class="sidebar-overlay {showSidebar ? 'open' : ''}"
+  onclick={() => (showSidebar = false)}
+  tabindex="-1"
+  aria-hidden={!showSidebar}
+></div>
 
 <!-- Sidebar Panel (overlay) -->
 <aside class="sidebar {showSidebar ? 'open' : ''}" aria-label="Examples menu">
   <button
     class="close-btn"
     onclick={() => (showSidebar = false)}
-    aria-label="Close sidebar">
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-      <line x1="6" y1="6" x2="18" y2="18"/>
-      <line x1="6" y1="18" x2="18" y2="6"/>
+    aria-label="Close sidebar"
+  >
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+    >
+      <line x1="6" y1="6" x2="18" y2="18" />
+      <line x1="6" y1="18" x2="18" y2="6" />
     </svg>
   </button>
   <ExampleSelector onExampleSelect={handleExampleSelect} />
@@ -557,18 +580,20 @@
     height: 48px;
     border-radius: 50%;
     background: #fff;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 300;
     border: none;
     cursor: pointer;
-    transition: box-shadow 0.2s, background 0.2s;
+    transition:
+      box-shadow 0.2s,
+      background 0.2s;
     color: rgba(30, 29, 28, 0.698);
   }
   .fab:hover {
-    box-shadow: 0 4px 16px rgba(0,0,0,0.18);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
     background: #f3f2f1;
     color: rgba(30, 29, 28, 1);
   }


### PR DESCRIPTION
A re-implementation of #602 that is more stylistically aligned with the changes in #596

<img width="949" alt="image" src="https://github.com/user-attachments/assets/a3105708-1f78-4318-878f-c2d7df29df94" />
<img width="957" alt="image" src="https://github.com/user-attachments/assets/c18e793b-fefa-42d0-ad1d-3f12c30721e8" />