### PR TITLE
Improve error message when printing unapplied functions

### DIFF
--- a/jl4-core/src/L4/Print.hs
+++ b/jl4-core/src/L4/Print.hs
@@ -421,9 +421,9 @@ instance LayoutPrinter a => LayoutPrinter (Lazy.Value a) where
     Lazy.ValString t               -> surround (pretty $ escapeStringLiteral t) "\"" "\""
     Lazy.ValNil                    -> "EMPTY"
     Lazy.ValCons v1 v2             -> "(" <> printWithLayout v1 <> " FOLLOWED BY " <> printWithLayout v2 <> ")" -- TODO: parens
-    Lazy.ValClosure{}              -> "<function>"
-    Lazy.ValUnaryBuiltinFun{}      -> "<builtin-function>"
-    Lazy.ValBinaryBuiltinFun{}     -> "<function>"
+    Lazy.ValClosure{}              -> "<function: can't print a function -- are you calling it with enough arguments?>"
+    Lazy.ValUnaryBuiltinFun{}      -> "<builtin-function: can't print a function -- are you calling it with enough arguments?>"
+    Lazy.ValBinaryBuiltinFun{}     -> "<function: can't print a function -- are you calling it with enough arguments?>"
     Lazy.ValAssumed r              -> printWithLayout r
     Lazy.ValUnappliedConstructor r -> printWithLayout r
     Lazy.ValConstructor r vs       -> printWithLayout r <> case vs of

--- a/jl4/examples/ok/tests/elem.golden
+++ b/jl4/examples/ok/tests/elem.golden
@@ -29,5 +29,5 @@ elem.l4:62:1-23:
 elem.l4:63:1-23:
   Trying to check equality on types that do not support it
   These were the values you tried to compare:
-    <function>
-    <function>
+    <function: can't print a function -- are you calling it with enough arguments?>
+    <function: can't print a function -- are you calling it with enough arguments?>

--- a/jl4/examples/ok/tests/lazytrace-exception.golden
+++ b/jl4/examples/ok/tests/lazytrace-exception.golden
@@ -35,7 +35,7 @@ lazytrace-exception.l4:10:1-66:
   ││└ LIST TRUE, TRUE, something, ...
   │└ LIST TRUE, TRUE, TRUE, something, ...
   │┌ and
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN TRUE,
   │                 WHEN x FOLLOWED BY xs THEN     x
   │                 AND and OF xs
@@ -43,7 +43,7 @@ lazytrace-exception.l4:10:1-66:
   │ AND and OF xs
   │┌ and OF xs
   ││┌ and
-  ││└ <function>
+  ││└ <function: can't print a function -- are you calling it with enough arguments?>
   │├ CONSIDER list WHEN EMPTY THEN TRUE,
   ││                 WHEN x FOLLOWED BY xs THEN     x
   ││                 AND and OF xs
@@ -51,7 +51,7 @@ lazytrace-exception.l4:10:1-66:
   ││ AND and OF xs
   ││┌ and OF xs
   │││┌ and
-  │││└ <function>
+  │││└ <function: can't print a function -- are you calling it with enough arguments?>
   ││├ CONSIDER list WHEN EMPTY THEN TRUE,
   │││                 WHEN x FOLLOWED BY xs THEN     x
   │││                 AND and OF xs
@@ -59,7 +59,7 @@ lazytrace-exception.l4:10:1-66:
   │││ AND and OF xs
   │││┌ and OF xs
   ││││┌ and
-  ││││└ <function>
+  ││││└ <function: can't print a function -- are you calling it with enough arguments?>
   │││├ CONSIDER list WHEN EMPTY THEN TRUE,
   ││││                 WHEN x FOLLOWED BY xs THEN     x
   ││││                 AND and OF xs
@@ -121,7 +121,7 @@ lazytrace-exception.l4:19:1-52:
   ││└ LIST 2, 3, ..., ..., ...
   │└ LIST 1, 2, 3, ..., ..., ...
   │┌ sum
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├   go OF 0, l
   │ WHERE
   │   GIVEN acc
@@ -131,28 +131,28 @@ lazytrace-exception.l4:19:1-52:
   │                     WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF 0, l
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN acc,
   │                 WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
   │┌ acc PLUS x
   │└ 1
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN acc,
   │                 WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
   │┌ acc PLUS x
   │└ 3
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN acc,
   │                 WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
   │┌ acc PLUS x
   │└ 6
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN acc,
   │                 WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
@@ -160,7 +160,7 @@ lazytrace-exception.l4:19:1-52:
   ││• ↯ division by zero
   │└ ↯ division by zero
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN acc,
   │                 WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
@@ -168,7 +168,7 @@ lazytrace-exception.l4:19:1-52:
   ││• ↯ division by zero
   │└ ↯ division by zero
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN acc,
   │                 WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
@@ -176,7 +176,7 @@ lazytrace-exception.l4:19:1-52:
   ││• ↯ division by zero
   │└ ↯ division by zero
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN acc,
   │                 WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ acc

--- a/jl4/examples/ok/tests/lazytrace.golden
+++ b/jl4/examples/ok/tests/lazytrace.golden
@@ -7,28 +7,28 @@ lazytrace.l4:23:1-36:
   ┌ sum OF (everyOther OF example)
   │┌ everyOther OF example
   ││┌ everyOther
-  ││└ <function>
+  ││└ <function: can't print a function -- are you calling it with enough arguments?>
   │├ CONSIDER list WHEN x FOLLOWED BY y FOLLOWED BY ys THEN x FOLLOWED BY (everyOther OF ys),
   ││                 WHEN x FOLLOWED BY EMPTY THEN LIST x,
   ││                 WHEN EMPTY THEN EMPTY
   │├ x FOLLOWED BY (everyOther OF ys)
   ││┌ everyOther OF ys
   │││┌ everyOther
-  │││└ <function>
+  │││└ <function: can't print a function -- are you calling it with enough arguments?>
   ││├ CONSIDER list WHEN x FOLLOWED BY y FOLLOWED BY ys THEN x FOLLOWED BY (everyOther OF ys),
   │││                 WHEN x FOLLOWED BY EMPTY THEN LIST x,
   │││                 WHEN EMPTY THEN EMPTY
   ││├ x FOLLOWED BY (everyOther OF ys)
   │││┌ everyOther OF ys
   ││││┌ everyOther
-  ││││└ <function>
+  ││││└ <function: can't print a function -- are you calling it with enough arguments?>
   │││├ CONSIDER list WHEN x FOLLOWED BY y FOLLOWED BY ys THEN x FOLLOWED BY (everyOther OF ys),
   ││││                 WHEN x FOLLOWED BY EMPTY THEN LIST x,
   ││││                 WHEN EMPTY THEN EMPTY
   │││├ x FOLLOWED BY (everyOther OF ys)
   ││││┌ everyOther OF ys
   │││││┌ everyOther
-  │││││└ <function>
+  │││││└ <function: can't print a function -- are you calling it with enough arguments?>
   ││││├ CONSIDER list WHEN x FOLLOWED BY y FOLLOWED BY ys THEN x FOLLOWED BY (everyOther OF ys),
   │││││                 WHEN x FOLLOWED BY EMPTY THEN LIST x,
   │││││                 WHEN EMPTY THEN EMPTY
@@ -38,7 +38,7 @@ lazytrace.l4:23:1-36:
   ││└ LIST 9, 1
   │└ LIST 25, 9, 1
   │┌ sum
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├   go OF 0, list
   │ WHERE
   │   GIVEN acc
@@ -48,28 +48,28 @@ lazytrace.l4:23:1-36:
   │                  WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF 0, list
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER l WHEN EMPTY THEN acc,
   │              WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
   │┌ acc PLUS x
   │└ 25
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER l WHEN EMPTY THEN acc,
   │              WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
   │┌ acc PLUS x
   │└ 34
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER l WHEN EMPTY THEN acc,
   │              WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ go OF (acc PLUS x), xs
   │┌ acc PLUS x
   │└ 35
   │┌ go
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER l WHEN EMPTY THEN acc,
   │              WHEN x FOLLOWED BY xs THEN go OF (acc PLUS x), xs
   ├ acc

--- a/jl4/examples/ok/tests/lazytrace2.golden
+++ b/jl4/examples/ok/tests/lazytrace2.golden
@@ -28,7 +28,7 @@ lazytrace2.l4:25:1-32:
   │┌ MkPair OF 1, 2
   │└ MkPair OF 1, 2
   │┌ addPair
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER p WHEN MkPair p1
   │                         p2 THEN p1 PLUS p2
   ├ p1 PLUS p2
@@ -54,25 +54,25 @@ lazytrace2.l4:27:1-32:
   ││└ LIST 2, 3
   │└ LIST 1, 2, 3
   │┌ sumList
-  │└ <function>
+  │└ <function: can't print a function -- are you calling it with enough arguments?>
   ├ CONSIDER list WHEN EMPTY THEN 0,
   │                 WHEN z FOLLOWED BY zs THEN z PLUS (sumList OF zs)
   ├ z PLUS (sumList OF zs)
   │┌ sumList OF zs
   ││┌ sumList
-  ││└ <function>
+  ││└ <function: can't print a function -- are you calling it with enough arguments?>
   │├ CONSIDER list WHEN EMPTY THEN 0,
   ││                 WHEN z FOLLOWED BY zs THEN z PLUS (sumList OF zs)
   │├ z PLUS (sumList OF zs)
   ││┌ sumList OF zs
   │││┌ sumList
-  │││└ <function>
+  │││└ <function: can't print a function -- are you calling it with enough arguments?>
   ││├ CONSIDER list WHEN EMPTY THEN 0,
   │││                 WHEN z FOLLOWED BY zs THEN z PLUS (sumList OF zs)
   ││├ z PLUS (sumList OF zs)
   │││┌ sumList OF zs
   ││││┌ sumList
-  ││││└ <function>
+  ││││└ <function: can't print a function -- are you calling it with enough arguments?>
   │││├ CONSIDER list WHEN EMPTY THEN 0,
   ││││                 WHEN z FOLLOWED BY zs THEN z PLUS (sumList OF zs)
   │││├ 0


### PR DESCRIPTION
When evaluating an unapplied function (e.g., `#EVAL add` where `add` takes two arguments), the output now shows a helpful message: "<function: can't print a function -- are you calling it with enough arguments?>"

This helps users understand they need to provide all required arguments to a function before it can be evaluated to a printable value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)