### PR TITLE
Fix JSONENCODE/JSONDECODE roundtrip for ONE OF (enum) types

### DIFF
--- a/jl4/examples/ok/jsonencode-enums.l4
+++ b/jl4/examples/ok/jsonencode-enums.l4
@@ -42,8 +42,13 @@ DECIDE myGarden IS Garden WITH
 
 DECIDE encodedGarden IS JSONENCODE myGarden
 
+GIVETH AN EITHER STRING Garden
+decodedGarden MEANS JSONDECODE encodedGarden
+
 #EVAL encodedColor
 #EVAL encodedPlant
 #EVAL encodedColorList
 #EVAL encodedPotato
+#EVAL myGarden
 #EVAL encodedGarden
+#EVAL decodedGarden

--- a/jl4/examples/ok/tests/jsonencode-enums.ep.golden
+++ b/jl4/examples/ok/tests/jsonencode-enums.ep.golden
@@ -42,8 +42,13 @@ DECIDE myGarden IS Garden WITH
 
 DECIDE encodedGarden IS JSONENCODE myGarden
 
+GIVETH AN EITHER STRING Garden
+decodedGarden MEANS JSONDECODE encodedGarden
+
 #EVAL encodedColor
 #EVAL encodedPlant
 #EVAL encodedColorList
 #EVAL encodedPotato
+#EVAL myGarden
 #EVAL encodedGarden
+#EVAL decodedGarden

--- a/jl4/examples/ok/tests/jsonencode-enums.golden
+++ b/jl4/examples/ok/tests/jsonencode-enums.golden
@@ -1,13 +1,17 @@
 Parsing successful
 Typechecking successful
 Evaluation successful
-jsonencode-enums.l4:45:1-19:
+jsonencode-enums.l4:48:1-19:
   "\"Red\""
-jsonencode-enums.l4:46:1-19:
+jsonencode-enums.l4:49:1-19:
   "\"Solanum tuberosum\""
-jsonencode-enums.l4:47:1-23:
+jsonencode-enums.l4:50:1-23:
   "[\"Red\",\"Green\",\"Blue\"]"
-jsonencode-enums.l4:48:1-20:
+jsonencode-enums.l4:51:1-20:
   "{\"latinName\":\"Solanum tuberosum\",\"commonName\":\"Potato\"}"
-jsonencode-enums.l4:49:1-20:
+jsonencode-enums.l4:52:1-15:
+  Garden OF "Kitchen Garden", (LIST `Solanum tuberosum`, `Daucus carota`)
+jsonencode-enums.l4:53:1-20:
   "{\"name\":\"Kitchen Garden\",\"plants\":[\"Solanum tuberosum\",\"Daucus carota\"]}"
+jsonencode-enums.l4:54:1-20:
+  RIGHT OF (Garden OF "Kitchen Garden", (LIST `Solanum tuberosum`, `Daucus carota`))

--- a/jl4/examples/ok/tests/jsonencode-enums.nlg.golden
+++ b/jl4/examples/ok/tests/jsonencode-enums.nlg.golden
@@ -2,4 +2,6 @@
 `encodedPlant`
 `encodedColorList`
 `encodedPotato`
+`myGarden`
 `encodedGarden`
+`decodedGarden`


### PR DESCRIPTION

## Summary

- Fix JSONENCODE: enum values now encode as `"EnumName"` instead of `{}`
- Fix JSONDECODE: JSON strings now decode back to enum values when target type is ONE OF
- Enums now roundtrip correctly through JSON serialization

## Example

```l4
DECLARE LatinName IS ONE OF `Solanum tuberosum`
                            `Ipomoea batatas`

DECLARE Garden HAS
  name IS A STRING
  plants IS A LIST OF LatinName

DECIDE myGarden IS Garden WITH
  name IS "Kitchen Garden"
  plants IS LIST `Solanum tuberosum`

-- Before: {"plants":[{}]}
-- After:  {"plants":["Solanum tuberosum"]}
DECIDE encoded IS JSONENCODE myGarden

-- Decodes back to enum values, not strings
GIVETH AN EITHER STRING Garden
decoded MEANS JSONDECODE encoded
```

## Test plan

- [x] All 441 tests pass
- [x] New roundtrip test in `jsonencode-enums.l4`


💘 Generated with Crush