### PR TITLE
Add Haskell LSP support to Crush configuration

### DIFF
--- a/crush.json
+++ b/crush.json
@@ -3,6 +3,12 @@
   "lsp": {
     "l4": {
       "command": "jl4-lsp"
+    },
+    "haskell": {
+      "command": "haskell-language-server-wrapper",
+      "args": [
+        "--lsp"
+      ]
     }
   },
   "permissions": {


### PR DESCRIPTION

## Summary

- Adds `haskell-language-server-wrapper` configuration to `crush.json`
- Enables LSP support for Haskell files when developing jl4-core and other Haskell modules
- Improves developer experience with type hints, go-to-definition, and diagnostics in Crush

## Test plan

- [ ] Verify Haskell LSP activates when opening `.hs` files in Crush
- [ ] Confirm no conflicts with existing L4 LSP configuration


💘 Generated with Crush