### PR TITLE
Fix Nix build by inlining test fixture instead of Template Haskell fi…

### DIFF
--- a/jl4-core/jl4-core.cabal
+++ b/jl4-core/jl4-core.cabal
@@ -134,6 +134,5 @@ test-suite jl4-core-test
     base,
     hspec,
     jl4-core,
-    template-haskell,
     text,
     time


### PR DESCRIPTION
…le reading

Template Haskell's compile-time file I/O fails in Nix's isolated build environment because relative paths don't resolve correctly. Replace Template Haskell readFile with inline fixture content using T.unlines, matching the pattern already used by multilineFixture in the same file.

Changes:
- Inline mixfix-with-variables.l4 fixture content as text list
- Remove TemplateHaskell language pragma and related imports
- Remove template-haskell from test suite build dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)