### PR TITLE
fix: Preserve JSON string types in decision service API

### DIFF
--- a/jl4-decision-service/jl4-decision-service.cabal
+++ b/jl4-decision-service/jl4-decision-service.cabal
@@ -124,6 +124,7 @@ test-suite jl4-decision-service-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+    ApiSpec
     AskOrderingSpec
     DiskLoadingSpec
     Paths_jl4_decision_service
@@ -145,6 +146,7 @@ test-suite jl4-decision-service-test
     containers ^>=0.6.7,
     stm ^>=2.5.1.0,
     base >=4.7 && <5,
+    aeson,
     directory,
     filepath,
     hspec,

--- a/jl4-decision-service/src/Backend/Jl4.hs
+++ b/jl4-decision-service/src/Backend/Jl4.hs
@@ -354,8 +354,13 @@ valueToFnLiteral = \case
   Eval.ValUnappliedConstructor name ->
     pure $ FnLitString $ prettyLayout name
   Eval.ValConstructor resolved [] ->
-    -- Constructors such as TRUE and FALSE
-    pure $ FnLitString $ prettyLayout $ getActual resolved
+    -- Special case boolean constructors (preserve original casing for others)
+    let name = prettyLayout $ getActual resolved
+     in case Text.toUpper name of
+          "TRUE" -> pure $ FnLitBool True
+          "FALSE" -> pure $ FnLitBool False
+          -- Other nullary constructors become strings (original casing preserved)
+          _ -> pure $ FnLitString name
   Eval.ValConstructor resolved vals -> do
     lits <- traverse nfToFnLiteral vals
     pure $

--- a/jl4-decision-service/src/Schema.hs
+++ b/jl4-decision-service/src/Schema.hs
@@ -252,18 +252,17 @@ instance ToParamSchema FnLiteral where
 
 instance ToSchema FnLiteral where
   declareNamedSchema p = do
-    intSchema <- declareSchemaRef (Proxy @Int)
     mTextSchema <- declareSchemaRef (Proxy @Text)
-    fracSchema <- declareSchemaRef (Proxy @Double)
     boolSchema <- declareSchemaRef (Proxy @Bool)
     fnLiteralSchema <- declareSchemaRef (Proxy @FnLiteral)
     pure $
       NamedSchema (Just "Literal") $
         toParamSchema p
           & oneOf
-            ?~ [ intSchema
+            ?~ [ -- Use a single number schema for both Int and Double
+                 -- (JSON doesn't distinguish between integer and floating-point)
+                 Inline $ mempty & type_ ?~ OpenApiNumber
                , mTextSchema
-               , fracSchema
                , boolSchema
                , Inline $
                   mempty

--- a/jl4-decision-service/test/ApiSpec.hs
+++ b/jl4-decision-service/test/ApiSpec.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ApiSpec (spec) where
+
+import Backend.Api
+import Data.Aeson (decode)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Types as Aeson
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "FnLiteral JSON parsing" $ do
+    it "should preserve JSON String type (not coerce to number)" $ do
+      -- Bug report: "5" was being parsed as FnLitInt 5
+      let jsonString = "{\"value\": \"5\"}"
+      let parsed = decode jsonString :: Maybe Aeson.Object
+      case parsed of
+        Nothing -> expectationFailure "Failed to parse JSON"
+        Just obj -> do
+          case KeyMap.lookup "value" obj of
+            Nothing -> expectationFailure "Missing 'value' field"
+            Just val -> do
+              let literal = Aeson.parseMaybe Aeson.parseJSON val :: Maybe FnLiteral
+              literal `shouldBe` Just (FnLitString "5")
+
+    it "should parse JSON Number as FnLitInt" $ do
+      let jsonNumber = "{\"value\": 5}"
+      let parsed = decode jsonNumber :: Maybe Aeson.Object
+      case parsed of
+        Nothing -> expectationFailure "Failed to parse JSON"
+        Just obj -> do
+          case KeyMap.lookup "value" obj of
+            Nothing -> expectationFailure "Missing 'value' field"
+            Just val -> do
+              let literal = Aeson.parseMaybe Aeson.parseJSON val :: Maybe FnLiteral
+              literal `shouldBe` Just (FnLitInt 5)
+
+    it "should keep 'five' as FnLitString" $ do
+      let jsonString = "{\"value\": \"five\"}"
+      let parsed = decode jsonString :: Maybe Aeson.Object
+      case parsed of
+        Nothing -> expectationFailure "Failed to parse JSON"
+        Just obj -> do
+          case KeyMap.lookup "value" obj of
+            Nothing -> expectationFailure "Missing 'value' field"
+            Just val -> do
+              let literal = Aeson.parseMaybe Aeson.parseJSON val :: Maybe FnLiteral
+              literal `shouldBe` Just (FnLitString "five")
+
+    it "should parse JSON Number with decimal as FnLitDouble" $ do
+      let jsonNumber = "{\"value\": 5.5}"
+      let parsed = decode jsonNumber :: Maybe Aeson.Object
+      case parsed of
+        Nothing -> expectationFailure "Failed to parse JSON"
+        Just obj -> do
+          case KeyMap.lookup "value" obj of
+            Nothing -> expectationFailure "Missing 'value' field"
+            Just val -> do
+              let literal = Aeson.parseMaybe Aeson.parseJSON val :: Maybe FnLiteral
+              literal `shouldBe` Just (FnLitDouble 5.5)
+
+    it "should keep '5.5' string as FnLitString (not convert to double)" $ do
+      let jsonString = "{\"value\": \"5.5\"}"
+      let parsed = decode jsonString :: Maybe Aeson.Object
+      case parsed of
+        Nothing -> expectationFailure "Failed to parse JSON"
+        Just obj -> do
+          case KeyMap.lookup "value" obj of
+            Nothing -> expectationFailure "Missing 'value' field"
+            Just val -> do
+              let literal = Aeson.parseMaybe Aeson.parseJSON val :: Maybe FnLiteral
+              literal `shouldBe` Just (FnLitString "5.5")
+
+    it "should preserve large integers beyond Int bounds" $ do
+      -- Test that integers larger than maxBound :: Int are preserved
+      let largeInt = 9999999999999999999 :: Integer
+      let jsonNumber = "{\"value\": 9999999999999999999}"
+      let parsed = decode jsonNumber :: Maybe Aeson.Object
+      case parsed of
+        Nothing -> expectationFailure "Failed to parse JSON"
+        Just obj -> do
+          case KeyMap.lookup "value" obj of
+            Nothing -> expectationFailure "Missing 'value' field"
+            Just val -> do
+              let literal = Aeson.parseMaybe Aeson.parseJSON val :: Maybe FnLiteral
+              literal `shouldBe` Just (FnLitInt largeInt)
+
+  describe "FnLiteral FromHttpApiData (query parameters)" $ do
+    it "should infer type from query parameter string" $ do
+      -- Query parameters don't have type information, so inference is needed
+      parseTextAsFnLiteral "5" `shouldBe` FnLitInt 5
+      parseTextAsFnLiteral "5.5" `shouldBe` FnLitDouble 5.5
+      parseTextAsFnLiteral "true" `shouldBe` FnLitBool True
+      parseTextAsFnLiteral "false" `shouldBe` FnLitBool False
+      parseTextAsFnLiteral "five" `shouldBe` FnLitString "five"
+
+    it "should parse quoted strings as FnLitString" $ do
+      parseTextAsFnLiteral "\"five\"" `shouldBe` FnLitString "five"
+      parseTextAsFnLiteral "\"5\"" `shouldBe` FnLitString "5"


### PR DESCRIPTION
## Summary

- Fixed bug where string values like `"5"` were being coerced to numbers when received via JSON API
- JSON `String` values now stay as `FnLitString` (no automatic type inference)
- `ToJSON` now uses proper JSON types (`Number`, `Bool`) instead of converting everything to strings
- L4 `TRUE`/`FALSE` constructors now become `FnLitBool` instead of `FnLitString`
- Fixed OpenAPI schema validation by combining `Int`/`Double` into single `number` type (JSON doesn't distinguish)

## Test plan

- [x] Added `ApiSpec.hs` with tests verifying `"5"` stays as string
- [x] All 770+ tests pass (`cabal test all`)
- [x] Query parameter parsing still infers types for backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)