### PR TITLE
Fix macOS build: add --dry-run to avoid building before cache restore

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -52,11 +52,11 @@ jobs:
           cabal-version: "latest"
           cabal-update: true
 
-      - name: Configure and build
+      - name: Configure and generate build plan
         run: |
           cabal update
           cabal configure --disable-tests --disable-documentation
-          cabal build exe:jl4-lsp
+          cabal build exe:jl4-lsp --dry-run
 
       - name: Restore cached dependencies
         uses: actions/cache/restore@v4


### PR DESCRIPTION
The macOS job was missing --dry-run in the 'Configure and build' step, causing it to build all dependencies BEFORE the cache was restored. This effectively doubled the build time (30-35 min instead of ~7 min).

All other platforms already had --dry-run.