### PR TITLE
fix(dev): bind all services to 0.0.0.0 for network accessibility

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -41,7 +41,7 @@ case "$MODE" in
 
   lsp-only)
     echo "Starting LSP server only (port $LSP_PORT)..."
-    cabal run exe:jl4-lsp -- ws --port "$LSP_PORT" --cwd "$LSP_CWD"
+    cabal run exe:jl4-lsp -- ws --host 0.0.0.0 --port "$LSP_PORT" --cwd "$LSP_CWD"
     ;;
 
   full)
@@ -53,7 +53,7 @@ case "$MODE" in
       
       # Start LSP Server
       echo "Starting LSP server on port $LSP_PORT..."
-      cabal run exe:jl4-lsp -- ws --port "$LSP_PORT" --cwd "$LSP_CWD" > /tmp/jl4-lsp.log 2>&1 &
+      cabal run exe:jl4-lsp -- ws --host 0.0.0.0 --port "$LSP_PORT" --cwd "$LSP_CWD" > /tmp/jl4-lsp.log 2>&1 &
       echo "LSP_PID=$!" >> "$PIDFILE"
       
       # Start Decision Service
@@ -120,7 +120,7 @@ case "$MODE" in
       echo "      Or run './dev-start.sh full --run' to start all in background"
       echo ""
       echo "Terminal 1 - LSP Server:"
-      echo "  cabal run exe:jl4-lsp -- ws --port $LSP_PORT --cwd $LSP_CWD"
+      echo "  cabal run exe:jl4-lsp -- ws --host 0.0.0.0 --port $LSP_PORT --cwd $LSP_CWD"
       echo ""
       echo "Terminal 2 - Decision Service:"
       echo "  cd jl4-decision-service && cabal run jl4-decision-service -- \\"

--- a/ts-apps/jl4-web/vite.config.ts
+++ b/ts-apps/jl4-web/vite.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   },
   server: {
     host: '0.0.0.0',
+    allowedHosts: true as unknown as undefined, // Vite 6.0.6+ security feature
   },
 })

--- a/ts-apps/l4-wizard/vite.config.ts
+++ b/ts-apps/l4-wizard/vite.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
   server: {
     host: true, // Listen on all addresses including LAN
     port: 5173,
+    allowedHosts: true as unknown as undefined, // Vite 6.0.6+ security feature
   },
 })


### PR DESCRIPTION
## Summary
- Add `--host 0.0.0.0` to LSP server commands in dev-start.sh
- Add `allowedHosts: true` to Vite configs for jl4-web and l4-wizard
- Fixes "Blocked request" error when accessing dev services via hostname (e.g., `http://nye:5173`)

## Test plan
- [ ] Run `./dev-start.sh full --run` and verify services are accessible from another machine on the network
- [ ] Verify no "Blocked request" errors when accessing via hostname

🤖 Generated with [Claude Code](https://claude.ai/code)