### PR TITLE
Add specification for homoiconicity and higher-order obligations

### DIFF
--- a/doc/dev/specs/todo/HOMOICONICITY-SPEC.md
+++ b/doc/dev/specs/todo/HOMOICONICITY-SPEC.md
@@ -28,7 +28,7 @@ This single sentence requires L4 to express:
 4. **Netting arithmetic** - the new obligation amount is computed from canceled obligations
 5. **All happening simultaneously** - no intermediate states
 
-Current L4 regulative syntax can express individual obligations, but cannot express these *operations on* obligations because:
+Current L4 regulative syntax can express individual obligations, but cannot express these _operations on_ obligations because:
 
 - Obligations exist only as **static syntax** (AST nodes like `PARTY p MUST action`), not as **runtime values** that can be inspected, filtered, or transformed
 - There is no mechanism to refer to "all obligations matching criteria X"
@@ -275,7 +275,7 @@ Common legal formulations:
 
 **This requirement is optional for initial implementation but represents the full vision of homoiconicity.**
 
-Beyond treating obligations as runtime values, full homoiconicity would allow introspection and manipulation of the *regulative rule graph itself* - the HENCE/LEST state machine structure:
+Beyond treating obligations as runtime values, full homoiconicity would allow introspection and manipulation of the _regulative rule graph itself_ - the HENCE/LEST state machine structure:
 
 ```
 rules : RuleGraph
@@ -310,7 +310,7 @@ PARTY Commissioner
       MODIFY rule's deadline BY extensionDays
 ```
 
-This is a deeper level of reflection than the obligation registry (R2) - it operates on the *structure of the contract* rather than just the *active obligations* created by executing that structure.
+This is a deeper level of reflection than the obligation registry (R2) - it operates on the _structure of the contract_ rather than just the _active obligations_ created by executing that structure.
 
 ## Proposed Syntax
 


### PR DESCRIPTION
## Summary

- Adds spec for extending L4's regulative rule syntax to support **obligations as first-class values**
- Enables legal patterns like novation netting (IFEMA 3.3), powers hierarchies, procure clauses
- Proposes nested syntax for higher-order operators: `GRANT`, `REVOKE`, `CREATE`, `WAIVE`, `EXTEND`, `PROCURE`
- Introduces `YIELDS` for contract continuation semantics (contracts that terminate by producing successor contracts)
- Documents jurisprudential foundations (Hohfeld, Kelsen, Hart, Raz)
- Includes detailed examples: police detention powers hierarchy, acquisition agreements, EPA delegation

## Test plan

- [ ] Review spec for consistency with existing L4 syntax
- [ ] Validate examples against intended semantics
- [ ] No code changes - specification document only

🤖 Generated with [Claude Code](https://claude.com/claude-code)