### PR TITLE
Fix DATETIME display to show ISO-8601 formatted values

### DIFF
--- a/doc/reference/libraries/datetime-example.l4
+++ b/doc/reference/libraries/datetime-example.l4
@@ -5,12 +5,13 @@ IMPORT daydate
 
 TIMEZONE IS SGT
 
+
 -- DateTime construction (uses document timezone SGT by default)
 DECIDE `the deadline` IS Datetime (Date 31 12 2025) 17 0 0
 #EVAL `the deadline`  -- 2025-12-31T17:00:00+08:00
 
 -- With explicit timezone override
-DECIDE `london meeting` IS Datetime (Date 1 6 2026) (TIME_FROM_HMS 9 0 0) "Europe/London"
+DECIDE `london meeting` IS Datetime (DATE_FROM_DMY 1 6 2026) (TIME_FROM_HMS 9 0 0) "Europe/London"
 #EVAL `london meeting`  -- 2026-06-01T09:00:00+01:00
 
 -- Date-only (midnight in document timezone)

--- a/jl4-core/src/L4/EvaluateLazy/Machine.hs
+++ b/jl4-core/src/L4/EvaluateLazy/Machine.hs
@@ -60,7 +60,7 @@ import L4.Evaluate.Operators
 import L4.Evaluate.ValueLazy
 import L4.TemporalContext (EvalClause (..), TemporalContext (..), applyEvalClauses)
 import L4.Parser.SrcSpan (SrcRange)
-import L4.Print
+import L4.Print hiding (tryLoadTZ, tryLoadTZPure, formatDateTimeIso)
 import L4.Syntax
 import qualified L4.TypeCheck as TypeCheck
 import L4.TypeCheck.Types (EntityInfo)

--- a/jl4/examples/ok/tests/datetime-tests.golden
+++ b/jl4/examples/ok/tests/datetime-tests.golden
@@ -2,13 +2,13 @@ Parsing successful
 Typechecking successful
 Evaluation successful
 datetime-tests.l4:16:1-21:
-  DATETIME IN "Asia/Singapore"
+  2025-06-15T14:30:00+0800
 datetime-tests.l4:17:1-17:
-  DATETIME IN "Asia/Singapore"
+  2025-12-31T17:00:00+0800
 datetime-tests.l4:18:1-23:
-  DATETIME IN "Europe/London"
+  2026-06-01T09:00:00+0100
 datetime-tests.l4:19:1-21:
-  DATETIME IN "Asia/Singapore"
+  2026-01-01T00:00:00+0800
 datetime-tests.l4:22:1-31:
   DATE OF 15, 6, 2025
 datetime-tests.l4:23:1-31:
@@ -32,15 +32,15 @@ datetime-tests.l4:35:1-38:
 datetime-tests.l4:36:1-36:
   assertion satisfied
 datetime-tests.l4:39:1-35:
-  DATETIME IN "Asia/Singapore"
+  2025-06-15T00:00:00+0800
 datetime-tests.l4:40:1-31:
-  DATETIME IN "Asia/Singapore"
+  2025-06-15T12:00:00+0800
 datetime-tests.l4:41:1-49:
-  DATETIME IN "Asia/Singapore"
+  2025-06-15T15:00:00+0800
 datetime-tests.l4:44:1-49:
-  DATETIME IN "Asia/Singapore"
+  2025-06-15T14:30:00+0800
 datetime-tests.l4:45:1-47:
-  DATETIME IN "Asia/Singapore"
+  2025-12-31T17:00:00+0800
 datetime-tests.l4:52:1-34:
   assertion satisfied
 datetime-tests.l4:53:1-33:


### PR DESCRIPTION
The printer was discarding the UTC time and only showing "DATETIME IN <timezone>" instead of actual datetime values like "2025-12-31T17:00:00+0800".