### PR TITLE
Add string/number constructors for Datetime, Date, Time libraries

### DIFF
--- a/doc/reference/libraries/datetime-example.l4
+++ b/doc/reference/libraries/datetime-example.l4
@@ -6,7 +6,7 @@ IMPORT daydate
 TIMEZONE IS SGT
 
 
--- DateTime construction (uses document timezone SGT by default)
+-- DateTime construction from DATE + time components (uses document timezone SGT by default)
 DECIDE `the deadline` IS Datetime (Date 31 12 2025) 17 0 0
 #EVAL `the deadline`  -- 2025-12-31T17:00:00+08:00
 
@@ -17,6 +17,37 @@ DECIDE `london meeting` IS Datetime (DATE_FROM_DMY 1 6 2026) (TIME_FROM_HMS 9 0 
 -- Date-only (midnight in document timezone)
 DECIDE `start of year` IS Datetime (Date 1 1 2026)
 #EVAL `start of year`  -- 2026-01-01T00:00:00+08:00
+
+
+-- DateTime construction from numbers (DMY order, like Date d m y)
+DECIDE `full datetime` IS Datetime 31 12 2025 17 30 0
+#EVAL `full datetime`  -- 2025-12-31T17:30:00+08:00
+
+DECIDE `date and hour` IS Datetime 15 6 2025 14
+#EVAL `date and hour`  -- 2025-06-15T14:00:00+08:00
+
+DECIDE `date only` IS Datetime 25 12 2025
+#EVAL `date only`  -- 2025-12-25T00:00:00+08:00
+
+DECIDE `month and year` IS Datetime 6 2025
+#EVAL `month and year`  -- 2025-06-01T00:00:00+08:00
+
+DECIDE `year only` IS Datetime 2025
+#EVAL `year only`  -- 2025-01-01T00:00:00+08:00
+
+-- Number constructors with explicit timezone
+DECIDE `nyc new year` IS Datetime 1 1 2026 0 0 0 EST
+#EVAL `nyc new year`  -- 2026-01-01T00:00:00-05:00
+
+
+-- DateTime from ISO-8601 string (JSON interop) - returns MAYBE DATETIME
+DECIDE `from iso` IS Datetime "2025-06-15T10:30:00Z"
+#EVAL `from iso`  -- JUST OF (2025-06-15T18:30:00+0800)
+
+-- ISO string with explicit display timezone - returns MAYBE DATETIME
+DECIDE `from iso tz` IS Datetime "2025-06-15T10:30:00Z" SGT
+#EVAL `from iso tz`  -- JUST OF (2025-06-15T18:30:00+0800)
+
 
 -- Extracting components (returns local values)
 DECIDE `meeting` IS Datetime (Date 15 6 2025) (TIME_FROM_HMS 14 30 0)

--- a/doc/reference/libraries/datetime.md
+++ b/doc/reference/libraries/datetime.md
@@ -20,17 +20,18 @@ TIMEZONE IS SGT
 
 ### Features
 
-- DateTime construction with flexible overloads (date + time + optional timezone)
+- DateTime construction with flexible overloads (date + time, numbers in DMY order, or ISO-8601 strings)
 - Automatic use of document `TIMEZONE IS` declaration
 - Explicit timezone override per value using IANA timezone strings
 - Date, time, and timezone extraction from DateTime values
 - Time-of-day predicates (morning, afternoon, evening)
 - Cross-timezone comparison (UTC-based equality)
 - Relative datetime operations (at midnight, at noon, at specific time)
+- ISO-8601 string parsing for JSON interoperability
 
 ### Key Functions
 
-**DateTime Construction:**
+**DateTime Construction (from DATE/TIME):**
 
 - `Datetime date time` - Date + time in document timezone
 - `Datetime date time tz` - Date + time in explicit IANA timezone
@@ -38,6 +39,23 @@ TIMEZONE IS SGT
 - `Datetime date h m s tz` - Date + hours/minutes/seconds in explicit timezone
 - `Datetime date` - Date at midnight in document timezone
 - `Datetime date tz` - Date at midnight in explicit timezone
+
+**DateTime Construction (from numbers, DMY order):**
+
+- `Datetime d m y h mn s` - Day, month, year, hour, minute, second in document timezone
+- `Datetime d m y h mn s tz` - Same with explicit timezone
+- `Datetime d m y h mn` - Seconds default to 0
+- `Datetime d m y h` - Minutes and seconds default to 0
+- `Datetime d m y` - Midnight in document timezone
+- `Datetime m y` - 1st of month, midnight
+- `Datetime y` - January 1st, midnight
+
+All number-based constructors accept an optional trailing `tz` (STRING) for explicit timezone.
+
+**DateTime Construction (from strings, returns MAYBE DATETIME):**
+
+- `Datetime str` - Parse ISO-8601 string (e.g. `"2024-06-15T10:30:00Z"`)
+- `Datetime str tz` - Parse ISO-8601 string with explicit display timezone
 
 **DateTime Extractors:**
 

--- a/doc/reference/libraries/daydate-example.l4
+++ b/doc/reference/libraries/daydate-example.l4
@@ -1,12 +1,18 @@
 -- Daydate Example: Date calculations and temporal logic
 IMPORT daydate
 
--- Date construction
+-- Date construction from components
 DECIDE `Christmas 2024` IS Date 25 12 2024
 DECIDE `New Year 2025` IS Date 1 1 2025
 
 #EVAL `Christmas 2024`
 #EVAL `New Year 2025`
+
+-- Date from ISO string (returns MAYBE DATE, ignores time/timezone if present)
+DECIDE `from iso date` IS Date "2025-06-15"
+DECIDE `from iso datetime` IS Date "2025-06-15T10:30:00Z"
+#EVAL `from iso date`       -- JUST OF (DATE OF 15, 6, 2025)
+#EVAL `from iso datetime`   -- JUST OF (DATE OF 15, 6, 2025)
 
 -- Date arithmetic
 DECIDE `week later` IS `Christmas 2024` PLUS 7

--- a/doc/reference/libraries/daydate.md
+++ b/doc/reference/libraries/daydate.md
@@ -9,12 +9,14 @@ Can be imported into L4 files with `IMPORT daydate`. Automatically imports `date
 
 ### Features
 
-- Date construction from day/month/year or serial numbers
+- Date construction from day/month/year, serial numbers, strings, or DATETIME extraction
 - Date arithmetic (add/subtract days, weeks, months, years)
 - Weekday and weekend detection
 - Week-of-year calculations
 - Month and year helpers
 - Leap year detection
+- String parsing for JSON interoperability
+- DATETIME date extraction
 
 ### Key Functions
 
@@ -28,6 +30,8 @@ Can be imported into L4 files with `IMPORT daydate`. Automatically imports `date
 
 - `Date day month year` - Create date from components
 - `Date serialNumber` - Create date from serial number
+- `Date str` - Parse date string (ISO format, ignores time/timezone if present), returns MAYBE DATE
+- `Date dt` - Extract date from DATETIME (ignores time and timezone)
 - `Week weekNumber year` - First day of week
 - `Month month year` - First day of month
 - `Year year` - First day of year

--- a/doc/reference/libraries/time-example.l4
+++ b/doc/reference/libraries/time-example.l4
@@ -10,6 +10,10 @@ DECIDE `end of day` IS Time 17
 #EVAL `lunch break`    -- 12:30:00
 #EVAL `end of day`     -- 17:00:00
 
+-- Time from string (JSON interop) - returns MAYBE TIME
+DECIDE `from string` IS Time "14:30:00"
+#EVAL `from string`  -- JUST OF (TIME OF 14, 30, 0.0)
+
 -- AM/PM construction
 DECIDE `early meeting` IS Time 7 30 am
 DECIDE `dinner time` IS Time 7 pm

--- a/doc/reference/libraries/time.md
+++ b/doc/reference/libraries/time.md
@@ -9,12 +9,13 @@ Can be imported into L4 files with `IMPORT time`.
 
 ### Features
 
-- Time construction from hours/minutes/seconds or serial numbers
+- Time construction from hours/minutes/seconds, serial numbers, strings, or DATETIME extraction
 - AM/PM support via `Meridiem Indicator` enum
 - Time arithmetic (add/subtract hours, minutes, seconds) with midnight wrapping
 - Time-of-day predicates (morning, afternoon, evening)
 - Serial conversion (fraction of day: 0.0 = midnight, 0.5 = noon)
 - Comparison operators and min/max functions
+- String parsing for JSON interoperability
 
 ### Key Functions
 
@@ -31,6 +32,8 @@ Can be imported into L4 files with `IMPORT time`.
 - `Time h` - Create time (minutes and seconds default to 0)
 - `Time h m s am` / `Time h m s pm` - 12-hour AM/PM format
 - `Time h am` / `Time h pm` - Shorthand 12-hour format
+- `Time str` - Parse time string ("HH:MM:SS" or "HH:MM"), returns MAYBE TIME
+- `Time dt` - Extract time from DATETIME (ignores date and timezone)
 - `serial Serial to time` - Create time from day fraction
 
 **Time Extractors:**

--- a/doc/test-docs.sh
+++ b/doc/test-docs.sh
@@ -289,7 +289,8 @@ run_jl4_cli() {
     else
         # Run from repo root for proper library resolution
         # Use cabal run which sets up data-files paths correctly
-        (cd "$REPO_ROOT" && cabal run jl4:jl4-cli -v0 -- "$file" 2>&1)
+        # Set JL4_LIBRARY_PATH to prefer local libraries over installed ones
+        (cd "$REPO_ROOT" && JL4_LIBRARY_PATH="${JL4_LIBRARY_PATH:-jl4-core/libraries}" cabal run jl4:jl4-cli -v0 -- "$file" 2>&1)
     fi
 }
 

--- a/jl4-core/libraries/datetime.l4
+++ b/jl4-core/libraries/datetime.l4
@@ -61,6 +61,129 @@ GIVEN dt IS A DATETIME
 GIVETH A DATETIME
 `Datetime` MEANS dt
 
+-- Datetime d m y h mn s  -> day, month, year, hour, min, sec, document TIMEZONE
+GIVEN d  IS A NUMBER
+      mo IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      mn IS A NUMBER
+      s  IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d mo y) (TIME_FROM_HMS h mn s) TIMEZONE
+
+-- Datetime d m y h mn s tz  -> day, month, year, hour, min, sec, explicit tz
+GIVEN d  IS A NUMBER
+      mo IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      mn IS A NUMBER
+      s  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d mo y) (TIME_FROM_HMS h mn s) tz
+
+-- Datetime d m y h mn  -> day, month, year, hour, min, document TIMEZONE
+GIVEN d  IS A NUMBER
+      mo IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      mn IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d mo y) (TIME_FROM_HMS h mn 0) TIMEZONE
+
+-- Datetime d m y h mn tz  -> day, month, year, hour, min, explicit tz
+GIVEN d  IS A NUMBER
+      mo IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      mn IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d mo y) (TIME_FROM_HMS h mn 0) tz
+
+-- Datetime d m y h  -> day, month, year, hour, document TIMEZONE
+GIVEN d IS A NUMBER
+      m IS A NUMBER
+      y IS A NUMBER
+      h IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d m y) (TIME_FROM_HMS h 0 0) TIMEZONE
+
+-- Datetime d m y h tz  -> day, month, year, hour, explicit tz
+GIVEN d  IS A NUMBER
+      m  IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d m y) (TIME_FROM_HMS h 0 0) tz
+
+-- Datetime d m y  -> day, month, year, midnight, document TIMEZONE
+GIVEN d IS A NUMBER
+      m IS A NUMBER
+      y IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d m y) (TIME_FROM_HMS 0 0 0) TIMEZONE
+
+-- Datetime d m y tz  -> day, month, year, midnight, explicit tz
+GIVEN d  IS A NUMBER
+      m  IS A NUMBER
+      y  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d m y) (TIME_FROM_HMS 0 0 0) tz
+
+-- Datetime m y  -> month, year, 1st day, midnight, document TIMEZONE
+GIVEN m IS A NUMBER
+      y IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY 1 m y) (TIME_FROM_HMS 0 0 0) TIMEZONE
+
+-- Datetime m y tz  -> month, year, 1st day, midnight, explicit tz
+GIVEN m  IS A NUMBER
+      y  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY 1 m y) (TIME_FROM_HMS 0 0 0) tz
+
+-- Datetime y  -> year, January 1st, midnight, document TIMEZONE
+GIVEN y IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY 1 1 y) (TIME_FROM_HMS 0 0 0) TIMEZONE
+
+-- Datetime y tz  -> year, January 1st, midnight, explicit tz
+GIVEN y  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY 1 1 y) (TIME_FROM_HMS 0 0 0) tz
+
+-- Datetime str  -> parse ISO-8601 string (e.g. "2024-06-15T10:30:00Z"), document TIMEZONE
+GIVEN str IS A STRING
+GIVETH A MAYBE DATETIME
+`Datetime` MEANS
+    TODATETIME str
+
+-- Datetime str tz  -> parse ISO-8601 string with explicit display timezone
+GIVEN str IS A STRING
+      tz  IS A STRING
+GIVETH A MAYBE DATETIME
+`Datetime` MEANS
+    CONSIDER TODATETIME str
+    WHEN JUST dt THEN JUST (DATETIME_FROM_DTZ (DATETIME_DATE dt) (DATETIME_TIME dt) tz)
+    WHEN NOTHING THEN NOTHING
+
 
 §§ `DateTime Extractors`
 

--- a/jl4-core/libraries/daydate.l4
+++ b/jl4-core/libraries/daydate.l4
@@ -61,6 +61,21 @@ GIVEN date  IS A DATE
 GIVETH A DATE
 `Date` AKA `Days to date` MEANS date
 
+-- Date str  -> parse date string (YYYY-MM-DD, etc.), ignores time/timezone if present
+GIVEN str IS A STRING
+GIVETH A MAYBE DATE
+`Date` AKA `Days to date` MEANS
+    CONSIDER DATEVALUE str
+    WHEN RIGHT d THEN JUST d
+    WHEN LEFT err THEN
+        CONSIDER TODATETIME str
+        WHEN JUST dt THEN JUST (DATETIME_DATE dt)
+        WHEN NOTHING THEN NOTHING
+
+-- Date dt  -> extract date from DATETIME (ignores time and timezone)
+GIVEN dt IS A DATETIME
+GIVETH A DATE
+`Date` AKA `Days to date` MEANS DATETIME_DATE dt
 
 
 

--- a/jl4-core/libraries/tests/datetime.ep.golden
+++ b/jl4-core/libraries/tests/datetime.ep.golden
@@ -61,6 +61,129 @@ GIVEN dt IS A DATETIME
 GIVETH A DATETIME
 `Datetime` MEANS dt
 
+-- Datetime d m y h mn s  -> day, month, year, hour, min, sec, document TIMEZONE
+GIVEN d  IS A NUMBER
+      mo IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      mn IS A NUMBER
+      s  IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d mo y) (TIME_FROM_HMS h mn s) TIMEZONE
+
+-- Datetime d m y h mn s tz  -> day, month, year, hour, min, sec, explicit tz
+GIVEN d  IS A NUMBER
+      mo IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      mn IS A NUMBER
+      s  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d mo y) (TIME_FROM_HMS h mn s) tz
+
+-- Datetime d m y h mn  -> day, month, year, hour, min, document TIMEZONE
+GIVEN d  IS A NUMBER
+      mo IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      mn IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d mo y) (TIME_FROM_HMS h mn 0) TIMEZONE
+
+-- Datetime d m y h mn tz  -> day, month, year, hour, min, explicit tz
+GIVEN d  IS A NUMBER
+      mo IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      mn IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d mo y) (TIME_FROM_HMS h mn 0) tz
+
+-- Datetime d m y h  -> day, month, year, hour, document TIMEZONE
+GIVEN d IS A NUMBER
+      m IS A NUMBER
+      y IS A NUMBER
+      h IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d m y) (TIME_FROM_HMS h 0 0) TIMEZONE
+
+-- Datetime d m y h tz  -> day, month, year, hour, explicit tz
+GIVEN d  IS A NUMBER
+      m  IS A NUMBER
+      y  IS A NUMBER
+      h  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d m y) (TIME_FROM_HMS h 0 0) tz
+
+-- Datetime d m y  -> day, month, year, midnight, document TIMEZONE
+GIVEN d IS A NUMBER
+      m IS A NUMBER
+      y IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d m y) (TIME_FROM_HMS 0 0 0) TIMEZONE
+
+-- Datetime d m y tz  -> day, month, year, midnight, explicit tz
+GIVEN d  IS A NUMBER
+      m  IS A NUMBER
+      y  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY d m y) (TIME_FROM_HMS 0 0 0) tz
+
+-- Datetime m y  -> month, year, 1st day, midnight, document TIMEZONE
+GIVEN m IS A NUMBER
+      y IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY 1 m y) (TIME_FROM_HMS 0 0 0) TIMEZONE
+
+-- Datetime m y tz  -> month, year, 1st day, midnight, explicit tz
+GIVEN m  IS A NUMBER
+      y  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY 1 m y) (TIME_FROM_HMS 0 0 0) tz
+
+-- Datetime y  -> year, January 1st, midnight, document TIMEZONE
+GIVEN y IS A NUMBER
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY 1 1 y) (TIME_FROM_HMS 0 0 0) TIMEZONE
+
+-- Datetime y tz  -> year, January 1st, midnight, explicit tz
+GIVEN y  IS A NUMBER
+      tz IS A STRING
+GIVETH A DATETIME
+`Datetime` MEANS
+    DATETIME_FROM_DTZ (DATE_FROM_DMY 1 1 y) (TIME_FROM_HMS 0 0 0) tz
+
+-- Datetime str  -> parse ISO-8601 string (e.g. "2024-06-15T10:30:00Z"), document TIMEZONE
+GIVEN str IS A STRING
+GIVETH A MAYBE DATETIME
+`Datetime` MEANS
+    TODATETIME str
+
+-- Datetime str tz  -> parse ISO-8601 string with explicit display timezone
+GIVEN str IS A STRING
+      tz  IS A STRING
+GIVETH A MAYBE DATETIME
+`Datetime` MEANS
+    CONSIDER TODATETIME str
+    WHEN JUST dt THEN JUST (DATETIME_FROM_DTZ (DATETIME_DATE dt) (DATETIME_TIME dt) tz)
+    WHEN NOTHING THEN NOTHING
+
 
 §§ `DateTime Extractors`
 

--- a/jl4-core/libraries/tests/daydate.ep.golden
+++ b/jl4-core/libraries/tests/daydate.ep.golden
@@ -61,6 +61,21 @@ GIVEN date  IS A DATE
 GIVETH A DATE
 `Date` AKA `Days to date` MEANS date
 
+-- Date str  -> parse date string (YYYY-MM-DD, etc.), ignores time/timezone if present
+GIVEN str IS A STRING
+GIVETH A MAYBE DATE
+`Date` AKA `Days to date` MEANS
+    CONSIDER DATEVALUE str
+    WHEN RIGHT d THEN JUST d
+    WHEN LEFT err THEN
+        CONSIDER TODATETIME str
+        WHEN JUST dt THEN JUST (DATETIME_DATE dt)
+        WHEN NOTHING THEN NOTHING
+
+-- Date dt  -> extract date from DATETIME (ignores time and timezone)
+GIVEN dt IS A DATETIME
+GIVETH A DATE
+`Date` AKA `Days to date` MEANS DATETIME_DATE dt
 
 
 

--- a/jl4-core/libraries/tests/time.ep.golden
+++ b/jl4-core/libraries/tests/time.ep.golden
@@ -48,6 +48,16 @@ GIVEN t IS A TIME
 GIVETH A TIME
 `Time` MEANS t
 
+-- Time str  -> parse time string (HH:MM:SS, HH:MM)
+GIVEN str IS A STRING
+GIVETH A MAYBE TIME
+`Time` MEANS TOTIME str
+
+-- Time dt  -> extract time from DATETIME (ignores date and timezone)
+GIVEN dt IS A DATETIME
+GIVETH A TIME
+`Time` MEANS DATETIME_TIME dt
+
 -- Time h m s am/pm  (3 NUMBERs + Meridiem Indicator -> TIME)
 GIVEN h  IS A NUMBER
       m  IS A NUMBER

--- a/jl4-core/libraries/time.l4
+++ b/jl4-core/libraries/time.l4
@@ -48,6 +48,16 @@ GIVEN t IS A TIME
 GIVETH A TIME
 `Time` MEANS t
 
+-- Time str  -> parse time string (HH:MM:SS, HH:MM)
+GIVEN str IS A STRING
+GIVETH A MAYBE TIME
+`Time` MEANS TOTIME str
+
+-- Time dt  -> extract time from DATETIME (ignores date and timezone)
+GIVEN dt IS A DATETIME
+GIVETH A TIME
+`Time` MEANS DATETIME_TIME dt
+
 -- Time h m s am/pm  (3 NUMBERs + Meridiem Indicator -> TIME)
 GIVEN h  IS A NUMBER
       m  IS A NUMBER

--- a/jl4-core/src/L4/TypeCheck/Environment.hs
+++ b/jl4-core/src/L4/TypeCheck/Environment.hs
@@ -472,7 +472,7 @@ timeFromHmsBuiltin :: Type' Resolved
 timeFromHmsBuiltin = fun_ [number, number, number] time
 
 toTimeBuiltin :: Type' Resolved
-toTimeBuiltin = fun_ [string] time
+toTimeBuiltin = fun_ [string] (maybeType time)
 
 -- DATETIME builtins
 
@@ -492,7 +492,7 @@ datetimeFromDtzBuiltin :: Type' Resolved
 datetimeFromDtzBuiltin = fun_ [date, time, string] datetime
 
 toDatetimeBuiltin :: Type' Resolved
-toDatetimeBuiltin = fun_ [string] datetime
+toDatetimeBuiltin = fun_ [string] (maybeType datetime)
 
 -- TIMEZONE (nullary → STRING)
 

--- a/jl4-lsp/src/LSP/L4/Rules.hs
+++ b/jl4-lsp/src/LSP/L4/Rules.hs
@@ -790,8 +790,9 @@ jl4Rules evalConfig rootDirectory recorder = do
         { _range = srcRangeToLspRange range
         , _severity =
             case res of
-              EvaluateLazy.Assertion False -> Just LSP.DiagnosticSeverity_Error
-              _                            -> Just LSP.DiagnosticSeverity_Information
+              EvaluateLazy.Assertion False  -> Just LSP.DiagnosticSeverity_Error
+              EvaluateLazy.Reduction (Left _) -> Just LSP.DiagnosticSeverity_Error
+              _                             -> Just LSP.DiagnosticSeverity_Information
         , _code = Nothing
         , _codeDescription = Nothing
         , _source = Just "eval"


### PR DESCRIPTION
- Add DMY-order number constructors for Datetime (1-6 args, with/without tz)
- Add ISO-8601 string parsing constructors for Datetime, Date, and Time
- Fix TODATETIME/TOTIME type signatures to return MAYBE (matching evaluator)
- Fix eval error severity in LSP from Information to Error
- Update doc test script to use local libraries by default
- Update documentation and examples for all new constructors