### PR TITLE
Switch AWS networking from dhcpcd to systemd-networkd

### DIFF
--- a/nix/aws-ec2.nix
+++ b/nix/aws-ec2.nix
@@ -9,20 +9,20 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  # without this we get weird delay errors upon nixos-rebuild switch
-  systemd.services.systemd-networkd-wait-online.enable = lib.mkForce false;
-  networking.useDHCP = lib.mkDefault true;
-  # AWS VPC DNS resolver — fallback in case dhcpcd doesn't populate resolv.conf.
+  # Use systemd-networkd instead of dhcpcd for more predictable DNS management.
+  # This avoids resolvconf signature mismatches when resolv.conf is manually edited.
+  networking.useDHCP = false;
+  networking.useNetworkd = true;
+  systemd.network.networks."10-ens5" = {
+    matchConfig.Name = "ens5";
+    networkConfig.DHCP = "yes";
+    linkConfig.RequiredForOnline = "yes";
+  };
+  # AWS VPC DNS resolver — fallback in case DHCP doesn't populate resolv.conf.
   # Without this, ACME cert renewal fails (can't resolve letsencrypt.org).
   networking.nameservers = [ "172.31.0.2" "169.254.169.253" ];
-  # but consider the alternative
-    # networking.useDHCP = false;
-    # networking.useNetworkd = true;
-    # systemd.network.networks."10-ens5" = {
-    #   matchConfig.Name = "ens5";
-    #   networkConfig.DHCP = "yes";
-    #   linkConfig.RequiredForOnline = "yes";
-    # };
+  # Disable wait-online to avoid deployment timeouts
+  systemd.services.systemd-networkd-wait-online.enable = lib.mkForce false;
   
   time.timeZone = "Asia/Singapore";
 


### PR DESCRIPTION
This change fixes the resolvconf signature mismatch issue that caused network-setup.service to fail after manual DNS edits. systemd-networkd with systemd-resolved provides more predictable DNS management and avoids the fragile resolvconf signature checking.