### PR TITLE
Fix test failures: list equality and library import priority

### DIFF
--- a/jl4-core/src/L4/EvaluateLazy/Machine.hs
+++ b/jl4-core/src/L4/EvaluateLazy/Machine.hs
@@ -2003,6 +2003,8 @@ runBinOpEquals ValNil                  ValNil           = Backward $ valBool Tru
 runBinOpEquals (ValCons r1 rs1)        (ValCons r2 rs2) = do
   PushFrame (EqConstructor1 r2 [(rs1, rs2)])
   EvalRef r1
+runBinOpEquals ValNil                  (ValCons _ _)   = Backward $ ValBool False
+runBinOpEquals (ValCons _ _)           ValNil           = Backward $ ValBool False
 runBinOpEquals (ValConstructor n1 rs1) (ValConstructor n2 rs2)
   | sameResolved n1 n2 && length rs1 == length rs2 =
     let

--- a/jl4-lsp/src/LSP/L4/Rules.hs
+++ b/jl4-lsp/src/LSP/L4/Rules.hs
@@ -447,11 +447,15 @@ jl4Rules evalConfig rootDirectory recorder = do
                         Just p  -> [p </> modName <.> "l4"]
                         Nothing -> []
 
-                  -- 2. XDG data directory (~/.local/share/jl4/libraries/)
+                  -- 2. Cabal's getDataDir (source tree during development, install prefix when installed)
+                  dataDir <- Paths_jl4_core.getDataDir
+                  let cabalPath = dataDir </> "libraries" </> modName <.> "l4"
+
+                  -- 3. XDG data directory (~/.local/share/jl4/libraries/)
                   xdgDataDir <- getXdgDirectory XdgData "jl4"
                   let xdgPath = xdgDataDir </> "libraries" </> modName <.> "l4"
 
-                  -- 3. VSCode extension bundled libraries
+                  -- 4. VSCode extension bundled libraries
                   -- The VSCode extension structure is:
                   --   extension/
                   --   ├── bin/<platform>/jl4-lsp[.exe]  <- executable is here
@@ -462,11 +466,7 @@ jl4Rules evalConfig rootDirectory recorder = do
                   let extensionRoot = exeDir </> ".." </> ".."
                   let bundledPath = extensionRoot </> "libraries" </> modName <.> "l4"
 
-                  -- 4. Cabal's getDataDir (for development / cabal run)
-                  dataDir <- Paths_jl4_core.getDataDir
-                  let cabalPath = dataDir </> "libraries" </> modName <.> "l4"
-
-                  pure $ envPaths <> [xdgPath, bundledPath, cabalPath]
+                  pure $ envPaths <> [cabalPath, xdgPath, bundledPath]
 
                 pure $ [Just rootPath, relPath] <> map Just builtinPaths
 


### PR DESCRIPTION
## Summary
- **List equality**: Add missing `ValNil`/`ValCons` cross-comparison cases in `runBinOpEquals`. Pattern matching `WHEN EMPTY` against a non-empty list was throwing "equality on unsupported types" instead of returning `False`. Fixes `legal-persons-tests.l4`.
- **Library import priority**: Reorder search so Cabal's data-dir is checked before XDG (`~/.local/share/jl4/libraries/`). Stale XDG-installed libraries were shadowing current source tree versions during development, causing 7 test failures (6 excel-date + ceo-performance-award).

## Test plan
- [x] `cabal test all` — 847 examples, 0 failures across all 6 test suites
- [x] Verified all 8 previously failing tests now pass
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)