### PR TITLE
Fix jl4-service artifact path in release job

### DIFF
--- a/.github/workflows/main-tag.yml
+++ b/.github/workflows/main-tag.yml
@@ -622,8 +622,8 @@ jobs:
 
           # Collect jl4-service binary and SHA256
           if [ -d artifacts/jl4-service-linux-x64 ]; then
-            cp artifacts/jl4-service-linux-x64/bin/linux-x64/jl4-service release-artifacts/jl4-service-linux-x64
-            cp artifacts/jl4-service-linux-x64/bin/linux-x64/jl4-service.sha256 release-artifacts/jl4-service-linux-x64.sha256
+            cp artifacts/jl4-service-linux-x64/jl4-service release-artifacts/jl4-service-linux-x64
+            cp artifacts/jl4-service-linux-x64/jl4-service.sha256 release-artifacts/jl4-service-linux-x64.sha256
             echo "jl4-service SHA256: $(cat release-artifacts/jl4-service-linux-x64.sha256)"
           fi
 


### PR DESCRIPTION
upload-artifact@v4 strips the common path prefix (bin/linux-x64/), so downloaded files are at artifacts/jl4-service-linux-x64/jl4-service not artifacts/jl4-service-linux-x64/bin/linux-x64/jl4-service.