### PR TITLE
Fix l4-cli-test on Windows: read process output as raw bytes

### DIFF
--- a/jl4/jl4.cabal
+++ b/jl4/jl4.cabal
@@ -117,3 +117,4 @@ test-suite l4-cli-test
     filepath,
     hspec,
     process,
+    text,

--- a/jl4/tests-cli/Main.hs
+++ b/jl4/tests-cli/Main.hs
@@ -12,7 +12,10 @@ module Main where
 
 import Control.Monad (unless)
 import Data.List (isInfixOf)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import Data.Aeson (Value(..), eitherDecode)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Key as Key
@@ -20,7 +23,15 @@ import System.Directory (doesFileExist)
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode(..), exitFailure)
 import System.FilePath ((</>))
-import System.Process (proc, readCreateProcessWithExitCode)
+import System.IO (hClose, hSetBinaryMode)
+import System.Process
+  ( CreateProcess(..)
+  , StdStream(..)
+  , createProcess
+  , proc
+  , readCreateProcessWithExitCode
+  , waitForProcess
+  )
 import Test.Hspec
 
 ----------------------------------------------------------------------------
@@ -78,10 +89,34 @@ data Output = Output
   , outStderr :: String
   } deriving (Eq, Show)
 
+-- | Run the l4 binary and capture its stdout + stderr.
+--
+-- Reads both streams as raw bytes and decodes them as UTF-8 leniently,
+-- bypassing @readCreateProcessWithExitCode@'s reliance on the system
+-- locale encoding. On Windows CI runners the locale is typically CP1252,
+-- which rejects the UTF-8 lead bytes (0xC2, 0xE2, …) that @l4.exe@
+-- writes for section markers (§) and en/em-dashes in help text — that
+-- is the @hGetContents: cannot decode byte sequence starting from 194@
+-- failure we saw on the first Windows build.
 runL4 :: FilePath -> [String] -> IO Output
 runL4 bin args = do
-  (code, out, err) <- readCreateProcessWithExitCode (proc bin args) ""
-  pure (Output code out err)
+  let cp = (proc bin args)
+        { std_in  = CreatePipe
+        , std_out = CreatePipe
+        , std_err = CreatePipe
+        }
+  (Just hin, Just hout, Just herr, ph) <- createProcess cp
+  hClose hin
+  hSetBinaryMode hout True
+  hSetBinaryMode herr True
+  soutBytes <- BS.hGetContents hout
+  serrBytes <- BS.hGetContents herr
+  code <- waitForProcess ph
+  pure Output
+    { outExit   = code
+    , outStdout = T.unpack (TE.decodeUtf8Lenient soutBytes)
+    , outStderr = T.unpack (TE.decodeUtf8Lenient serrBytes)
+    }
 
 -- | Assert the CLI exited 0 with a given substring on stdout.
 expectOk :: FilePath -> [String] -> String -> IO ()


### PR DESCRIPTION
The previous runL4 used readCreateProcessWithExitCode, which decodes the child's stdout and stderr using the system locale encoding. On the Windows CI runner that locale is CP1252, which rejects the UTF-8 lead bytes that l4.exe produces — 0xC2 for §, 0xE2 for en/em-dashes in help text, etc. — triggering:

  hGetContents: invalid argument (cannot decode byte sequence starting from 194)

on every test whose output includes a section marker or unicode punctuation. Only the pure-ASCII tests (unparseable-garbage rejection, --format png/svg failure messages, the empty-stdout fmt-on-broken-file case) survived.

Switch runL4 to createProcess + hSetBinaryMode + BS.hGetContents, then decode both streams explicitly as UTF-8 via Data.Text.Encoding's decodeUtf8Lenient. Result: platform-independent, locale-independent reads of whatever bytes l4 actually writes.

Adds `text` to the l4-cli-test build-depends (decodeUtf8Lenient) and imports the createProcess / waitForProcess / StdStream machinery from System.Process. readCreateProcessWithExitCode stays as-is for the `cabal list-bin exe:l4` call in locateL4Binary (its output is ASCII).

All 20 tests still pass on macOS; the Windows CI pass is the intended fix.