### PR TITLE
Force UTF-8 on stdin/stdout/stderr + locale in l4 Main

### DIFF
--- a/jl4/app/Main.hs
+++ b/jl4/app/Main.hs
@@ -7,6 +7,7 @@
 module Main where
 
 import Control.Applicative ((<|>))
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
 import Options.Applicative
   ( Parser
   , ParserInfo
@@ -23,6 +24,7 @@ import Options.Applicative
   , subparser
   )
 import qualified Options.Applicative as Options
+import System.IO (hSetEncoding, stdin, stdout, stderr)
 
 import L4.Cli.Ast (AstOptions, astCmd, astOptionsParser)
 import L4.Cli.Batch (BatchOptions, batchCmd, batchOptionsParser)
@@ -85,6 +87,26 @@ commandInfo = info (helper <*> commandParser)
 
 main :: IO ()
 main = do
+  -- Force UTF-8 everywhere. On Windows, GHC's default locale encoding is
+  -- whatever the user codepage happens to be (CP1252 / CP437 / CP850 …),
+  -- which means two independent disasters:
+  --
+  --   1. `Text.readFile` in LSP.Core.Shake decodes `.l4` source as the
+  --      system codepage, so `§` (bytes 0xC2 0xA7) comes back as "┬º"
+  --      and the parser bails with `unexpected '┬'`.
+  --   2. `putStrLn`-family writes to stdout/stderr run their Text through
+  --      the same codepage, so echoing a `§` back as part of a diagnostic
+  --      crashes with `hPutChar: cannot encode character '\167'`.
+  --
+  -- `setLocaleEncoding` fixes (1) by making *new* handles UTF-8 by
+  -- default. The three explicit `hSetEncoding` calls fix (2) by
+  -- overriding the standard handles, which were already opened by the
+  -- runtime before `main` started and so inherited the original locale.
+  setLocaleEncoding utf8
+  hSetEncoding stdin  utf8
+  hSetEncoding stdout utf8
+  hSetEncoding stderr utf8
+
   cmd <- customExecParser (prefs showHelpOnEmpty) commandInfo
   case cmd of
     CmdRun        opts -> runCmd        opts


### PR DESCRIPTION
GHC on Windows defaults all I/O to the user codepage (CP1252 / CP437 / CP850), which breaks l4.exe in two independent ways:

1. `Text.readFile` in LSP.Core.Shake decodes `.l4` source as the system codepage, so a `§` section marker (bytes 0xC2 0xA7) comes back as the two-character sequence "┬º" and the parser rejects it with `unexpected '┬'`. This is why tests that touch any fixture with a section header failed on Windows CI with a totally nonsensical parse error.

2. When l4 writes a diagnostic echoing the offending source back to stderr, the stderr encoder hits `§` and crashes with `hPutChar: invalid argument (cannot encode character '\167')`.

Fix both at the top of `main`:

    setLocaleEncoding utf8           -- covers future file reads etc.
    hSetEncoding stdin  utf8         -- overrides the three standard
    hSetEncoding stdout utf8         -- handles that were already opened
    hSetEncoding stderr utf8         -- by the RTS before main started

`setLocaleEncoding` is the right lever for (1) because `Text.readFile` and any freshly-opened handle consult it. The explicit `hSetEncoding` trio is needed for (2) because the standard handles' encoding is latched from the locale *once*, at runtime initialization, and changing the locale after the fact doesn't retroactively update them.

Unix/macOS are already UTF-8 so both calls are no-ops there — all 20 CLI tests still pass locally. The real verification happens when the Windows CI job reruns.