### PR TITLE
jl4-service: resolve record params across IMPORT boundaries

### DIFF
--- a/jl4-service/src/Backend/Jl4.hs
+++ b/jl4-service/src/Backend/Jl4.hs
@@ -54,6 +54,10 @@ data CompiledModule = CompiledModule
   , compiledEntityInfo :: !EntityInfo
   , compiledDecide :: !(Decide Resolved)
   , compiledImportEnv :: !EvalEnv.Environment        -- ^ Evaluator environment from imports
+  , compiledAllDeclares :: ![Declare Resolved]       -- ^ DECLAREs from the entry file AND every transitively-imported file.
+                                                     -- Consulted by 'buildModuleInfo' so a record parameter
+                                                     -- whose type is defined in an IMPORT'd file resolves —
+                                                     -- the entry module's own 'flattenDeclares' wouldn't see it.
   }
   deriving (Generic)
 
@@ -71,6 +75,10 @@ data SharedModuleContext = SharedModuleContext
   , sharedModuleContext :: !ModuleContext
   , sharedImportEnv :: !EvalEnv.Environment
   , sharedSource :: !Text
+  , sharedAllDeclares :: ![Declare Resolved]
+    -- ^ DECLAREs from the entry file + every transitively-imported
+    --   file. Carried through into 'CompiledModule.compiledAllDeclares'
+    --   so direct-AST evaluation can resolve cross-file record types.
   }
 
 -- | Build shared context from an already-typechecked module.
@@ -92,6 +100,11 @@ buildSharedContext filepath source moduleContext resolvedModule env entityInfo =
     , sharedModuleContext = moduleContext
     , sharedImportEnv = importEnv
     , sharedSource = source
+    -- Fallback path (single-file compile, no bundle info): the best we
+    -- can do is the entry module's own DECLAREs. The bundle-compile
+    -- path in Compiler.hs overrides this with the full cross-file set
+    -- via 'buildSharedContextWithDeclares'.
+    , sharedAllDeclares = moduleDeclaresOnly resolvedModule
     }
 
 -- | Build a CompiledModule for a single function, reusing shared context.
@@ -105,6 +118,7 @@ buildCompiledFromShared shared funName = runExceptT $ do
     , compiledEntityInfo = shared.sharedEntityInfo
     , compiledDecide = decide
     , compiledImportEnv = shared.sharedImportEnv
+    , compiledAllDeclares = shared.sharedAllDeclares
     }
  where
   evalErrorToText :: EvaluatorError -> Text
@@ -214,13 +228,18 @@ precompileModule filepath source moduleContext funName = runExceptT $ do
   -- environment to be pre-computed (it only evaluates the current module fresh)
   importEnv <- liftIO $ buildImportEnvironment filepath source moduleContext tcRes.entityInfo
 
-  -- Build the compiled module
+  -- Build the compiled module. precompileModule is the single-file
+  -- fallback — bundle compilation populates `compiledAllDeclares` from
+  -- the full import graph in Compiler.hs. Here we only have the entry
+  -- module's AST, so we fall back to its own declarations; that's the
+  -- best we can do without re-running the whole bundle typecheck.
   pure CompiledModule
     { compiledModule = tcRes.module'
     , compiledEnvironment = tcRes.environment
     , compiledEntityInfo = tcRes.entityInfo
     , compiledDecide = decide
     , compiledImportEnv = importEnv
+    , compiledAllDeclares = moduleDeclaresOnly tcRes.module'
     }
  where
   evalErrorToText :: EvaluatorError -> Text
@@ -310,11 +329,11 @@ data ModuleInfo = ModuleInfo
     -- ^ enum type unique -> [(variant name, variant constructor ref)]
   }
 
-buildModuleInfo :: Module Resolved -> ModuleInfo
-buildModuleInfo (MkModule _ _ section) = ModuleInfo
-  { miRecords      = Map.fromList [ r | Just r <- map recordFor (flattenDeclares section) ]
-  , miEnumVariants = Map.fromList [ r | Just r <- map enumFor   (flattenDeclares section) ]
-  }
+-- | Flatten a module's own top-level + nested DECLAREs. Does not
+-- follow IMPORTs — use 'compiledAllDeclares' (populated at bundle
+-- compile time) when cross-file types need to resolve.
+moduleDeclaresOnly :: Module Resolved -> [Declare Resolved]
+moduleDeclaresOnly (MkModule _ _ section) = flattenDeclares section
   where
     flattenDeclares :: Section Resolved -> [Declare Resolved]
     flattenDeclares (MkSection _ _ _ decls) = concatMap step decls
@@ -322,6 +341,13 @@ buildModuleInfo (MkModule _ _ section) = ModuleInfo
         step (Declare _ d)  = [d]
         step (Section _ s') = flattenDeclares s'
         step _              = []
+
+buildModuleInfo :: [Declare Resolved] -> ModuleInfo
+buildModuleInfo decls = ModuleInfo
+  { miRecords      = Map.fromList [ r | Just r <- map recordFor decls ]
+  , miEnumVariants = Map.fromList [ r | Just r <- map enumFor   decls ]
+  }
+  where
 
     recordFor :: Declare Resolved -> Maybe (Unique, (Resolved, [(Text, Type' Resolved)]))
     -- A 'RecordDecl' carries its value-level constructor in the 'Maybe n'
@@ -565,7 +591,7 @@ evaluateDirectAST compiled params assumeRefs assumeValues traceLevel includeGrap
   -- Build once per call: a lookup of every record / enum declaration in
   -- the compiled module so 'fnLiteralToExprTyped' can construct record
   -- literals and enum variants without re-running the typechecker.
-  let moduleInfo = buildModuleInfo compiled.compiledModule
+  let moduleInfo = buildModuleInfo compiled.compiledAllDeclares
       paramTypes = extractParamTypes compiled.compiledDecide
       paramMap   = Map.fromList [(name, val) | (name, Just val) <- params]
       assumeMap  = Map.fromList [(name, val) | (name, Just val) <- assumeValues]

--- a/jl4-service/src/Compiler.hs
+++ b/jl4-service/src/Compiler.hs
@@ -144,7 +144,14 @@ processTypecheckedFile logger deployId filepath content moduleContext
             -- Look up the import environment from the shared session
             importEnv = Map.findWithDefault Jl4.emptyEvalEnvironment filepath evalMap
 
-        -- Build shared context for all functions from this file
+        -- Build shared context for all functions from this file.
+        -- `collectAllDeclares` walks the entry file + every
+        -- transitively-imported module's DECLAREs. We stash the full
+        -- list on the shared context so the direct-AST evaluator
+        -- ('buildModuleInfo') can resolve record parameter types that
+        -- live in IMPORT'd files — e.g. the ASEAN Cosmetic Directive's
+        -- `Cosmetic Product` record declared in ACD_Declarations.l4
+        -- while the @export lives in ACD_Information.l4.
         let shared = Jl4.SharedModuleContext
               { Jl4.sharedModule = resolvedModule
               , Jl4.sharedEnvironment = env
@@ -152,6 +159,7 @@ processTypecheckedFile logger deployId filepath content moduleContext
               , Jl4.sharedModuleContext = moduleContext
               , Jl4.sharedImportEnv = importEnv
               , Jl4.sharedSource = content
+              , Jl4.sharedAllDeclares = Map.elems allDeclares
               }
 
         fns <- forM exports $ \export -> do
@@ -278,6 +286,12 @@ buildFromCborBundle logger deployId bundles sources storedMeta = do
                     , compiledEntityInfo = ei
                     , compiledDecide = decide
                     , compiledImportEnv = importEnv
+                    -- `sbDeclares` is the bundle's cached map of every
+                    -- DECLARE across the entry module and its
+                    -- transitive imports — exactly what the direct-AST
+                    -- evaluator needs to resolve cross-file record
+                    -- types (see Backend.Jl4.buildModuleInfo).
+                    , compiledAllDeclares = Map.elems bundle.sbDeclares
                     }
 
               let runFn = Jl4.createRunFunctionFromCompiled filepath apiDecl compiled content moduleContext

--- a/jl4-service/test/IntegrationSpec.hs
+++ b/jl4-service/test/IntegrationSpec.hs
@@ -38,7 +38,7 @@ import Network.Wai.Handler.Warp (testWithApplication)
 import System.Directory (removeDirectoryRecursive, doesDirectoryExist)
 import System.IO.Error (isPermissionError)
 
-import TestData (qualifiesJL4, recordJL4, maybeParamJL4, saleContractJL4, deonticExportJL4, deonticRecordPartyJL4, spacedFieldsJL4, assumeParamJL4)
+import TestData (qualifiesJL4, recordJL4, maybeParamJL4, saleContractJL4, deonticExportJL4, deonticRecordPartyJL4, spacedFieldsJL4, assumeParamJL4, importedRecordDeclJL4, importedRecordMainJL4)
 
 spec :: SpecWith ()
 spec = describe "integration" do
@@ -133,6 +133,33 @@ spec = describe "integration" do
               Map.lookup "age" fieldMap `shouldBe` Just (FnLitInt 30)
             other ->
               expectationFailure ("Expected FnObject with named fields, got: " <> show other)
+
+  describe "record parameter declared in an imported file" do
+    -- Regression: before the fix, the direct-AST fast path's
+    -- `buildModuleInfo` only walked the entry module's own
+    -- `flattenDeclares`, so a DECLARE that lived in an IMPORTed file
+    -- wasn't in `miRecords`. `lookupRecord` missed → evaluation bailed
+    -- with "FnObject but expected type is not a known record" for any
+    -- rule whose parameter was a cross-file record. The ASEAN Cosmetic
+    -- Directive deployment surfaced this in production. This test
+    -- pins the behaviour so we can't regress again.
+    it "resolves the record type across IMPORT boundaries" do
+      withServiceFromSources
+        "imported-record"
+        [ ("imported_record_decl.l4", importedRecordDeclJL4)
+        , ("imported_record_main.l4", importedRecordMainJL4)
+        ] \baseUrl mgr -> do
+          resp <- evalFunction baseUrl mgr "imported-record" "applicant-is-an-adult"
+            (Aeson.object
+              [ "arguments" Aeson..= Aeson.object
+                  [ "applicant" Aeson..= Aeson.object
+                      [ "name" Aeson..= ("Alice" :: Text)
+                      , "age" Aeson..= (30 :: Int)
+                      ]
+                  ]
+              ])
+          assertSuccess resp \r ->
+            Map.lookup "value" r.fnResult `shouldBe` Just (FnLitBool True)
 
   describe "MAYBE parameter handling" do
     it "handles NOTHING (null) for a MAYBE parameter" do

--- a/jl4-service/test/TestData.hs
+++ b/jl4-service/test/TestData.hs
@@ -15,6 +15,8 @@ module TestData (
   deonticRecordPartyJL4,
   spacedFieldsJL4,
   assumeParamJL4,
+  importedRecordDeclJL4,
+  importedRecordMainJL4,
 ) where
 
 import Backend.Jl4 as Jl4
@@ -287,6 +289,30 @@ GIVEN `first name` IS A STRING
       `is a citizen` IS A BOOLEAN
 GIVETH A BOOLEAN
 DECIDE `check person` IF `is a citizen`
+|]
+
+-- | Two-file fixture: a DECLARE'd record lives in the imported file and
+-- the @export'd function in the main file takes it as a parameter. Used
+-- to check that cross-file record parameters are resolvable on
+-- /evaluation — a regression site for the direct-AST fast path that
+-- only walks the entry module's own section for DECLAREs.
+importedRecordDeclJL4 :: Text
+importedRecordDeclJL4 =
+  [i|
+DECLARE Applicant HAS
+    name IS A STRING
+    age  IS A NUMBER
+|]
+
+importedRecordMainJL4 :: Text
+importedRecordMainJL4 =
+  [i|
+IMPORT imported_record_decl.l4
+
+@export
+GIVEN applicant IS A Applicant
+GIVETH A BOOLEAN
+DECIDE `applicant is an adult` IS applicant's age >= 18
 |]
 
 deonticRecordPartyJL4 :: Text


### PR DESCRIPTION
Regression in 72bab12d (direct-AST fast path): buildModuleInfo only walked the entry module's own DECLAREs, so a rule whose parameter type was defined in an IMPORTed file failed with "FnObject but expected type is not a known record" for every call. Surfaced in production on the ASEAN Cosmetic Directive deployment, where `Cosmetic Product` is declared in ACD_Declarations.l4 while the @export lives in ACD_Information.l4.

Fix plumbs the bundle-wide DECLAREs through:

- CompiledModule gains compiledAllDeclares :: [Declare Resolved].
- SharedModuleContext gains sharedAllDeclares; populated in Compiler from the pre-existing collectAllDeclares (walks tc.module' plus tc.dependencies transitively).
- buildModuleInfo now takes [Declare Resolved] directly instead of a Module, so it sees every DECLARE across the import graph.
- CBOR-restart path reuses bundle.sbDeclares, which already carries the transitive set.
- Single-file precompileModule falls back to the entry module's own DECLAREs — best it can do without a bundle typecheck.

Regression test in IntegrationSpec ("record parameter declared in an imported file"): two-file fixture (imported_record_decl.l4 + imported_record_main.l4), deploy + evaluate with a record arg. Fails on the old code (HTTP 422), passes after fix. Full suite (205 tests) green.