### PR TITLE
jl4-mlir: include imported DECLAREs in .schema.json

### DIFF
--- a/jl4-mlir/jl4-mlir.cabal
+++ b/jl4-mlir/jl4-mlir.cabal
@@ -97,6 +97,7 @@ test-suite jl4-mlir-test
   hs-source-dirs: test
   main-is: Main.hs
   build-depends:
+    bytestring,
     jl4-core,
     jl4-mlir,
     text >= 2 && < 2.1.2,

--- a/jl4-mlir/src/L4/MLIR/Pipeline.hs
+++ b/jl4-mlir/src/L4/MLIR/Pipeline.hs
@@ -128,6 +128,7 @@ compileToPipeline config filepath = do
             (Text.pack (baseName <> ".wasm"))
             (computeVersion filepath)  -- placeholder — real one in Compiler.hs
             mainModule
+            depModules
 
       case config.outputTarget of
         EmitMLIR -> do

--- a/jl4-mlir/src/L4/MLIR/Schema.hs
+++ b/jl4-mlir/src/L4/MLIR/Schema.hs
@@ -121,9 +121,13 @@ sanitizeWasmSymbol name =
 
 -- | Build the schema bundle for all @\@export@\-ed functions in a module.
 -- The bundle is then serialized to disk as @.schema.json@.
-bundleExports :: Text -> Text -> Module Resolved -> WasmBundle
-bundleExports wasmPath version resolvedModule =
-  let declares = declaresFromModule resolvedModule
+bundleExports :: Text -> Text -> Module Resolved -> [Module Resolved] -> WasmBundle
+bundleExports wasmPath version resolvedModule depModules =
+  -- Merge DECLAREs from imported modules so record/enum types defined in
+  -- IMPORTed files are visible when expanding parameter schemas. The main
+  -- module's declares take precedence on key collision.
+  let declares = Map.unions (declaresFromModule resolvedModule
+                            : map declaresFromModule depModules)
       exports  = getExportedFunctions resolvedModule
   in WasmBundle
        { bundleWasmFile = wasmPath

--- a/jl4-mlir/test/Main.hs
+++ b/jl4-mlir/test/Main.hs
@@ -16,9 +16,14 @@ import L4.MLIR.Dialect.Arith
 import L4.MLIR.Dialect.SCF
 import L4.MLIR.Runtime.Builtins (builtinDeclarations)
 import L4.MLIR.Lower (lowerProgramWithInfo)
+import L4.MLIR.Schema (bundleExports, encodeBundle)
 
-import L4.API.VirtualFS (checkWithImports, emptyVFS)
-import L4.Import.Resolution (TypeCheckWithDepsResult(..))
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text.Encoding as TE
+
+import L4.API.VirtualFS (checkWithImports, checkWithImportsAndUri, emptyVFS, vfsFromList)
+import L4.Import.Resolution (TypeCheckWithDepsResult(..), ResolvedImport(..))
+import L4.TypeCheck.Types (CheckResult(..))
 
 main :: IO ()
 main = do
@@ -30,6 +35,7 @@ main = do
     , test "arithmetic ops"                    testArithOps
     , test "@export ASSUMEs become args"       testExportAssumePromotion
     , test "internal callers fill via extern"  testInternalCallFillsAssumes
+    , test "schema picks up imported DECLAREs" testSchemaUsesImportedDeclares
     ]
   if and results
     then do
@@ -193,3 +199,44 @@ testInternalCallFillsAssumes = do
       pure $ T.isInfixOf "func.call @age()" mlir
           && T.isInfixOf "func.call @is_adult" mlir
       && Text.isInfixOf "arith.cmpf" mlir
+
+-- | When the @export-ed function's parameter type is DECLAREd in an
+-- IMPORTed module (not in the main file), the schema must still expand
+-- the record's fields. Regression test for the ASEAN Cosmetic Directive
+-- case where Information.l4 imports Declarations.l4 and the schema came
+-- out as bare {"type":"object"}.
+testSchemaUsesImportedDeclares :: IO Bool
+testSchemaUsesImportedDeclares = do
+  let declarations = T.unlines
+        [ "DECLARE Widget HAS"
+        , "    `serial`  IS A STRING"
+        , "    `weight`  IS A NUMBER"
+        ]
+      info = T.unlines
+        [ "IMPORT declarations"
+        , ""
+        , "@export Inspect a widget"
+        , "GIVEN w IS A Widget"
+        , "GIVETH A BOOLEAN"
+        , "DECIDE `widget ok` IS w's weight > 0"
+        ]
+      vfs = vfsFromList [("declarations", declarations)]
+  case checkWithImportsAndUri vfs "info" info of
+    Left errs -> do
+      putStrLn $ "\n    typecheck failed: " <> show errs
+      pure False
+    Right tc -> do
+      let mainMod = tc.tcdModule
+          depMods = map (\ri -> ri.riTypeChecked.program) tc.tcdResolvedImports
+          bundle  = bundleExports "info.wasm" "test" mainMod depMods
+          json    = TE.decodeUtf8 (LBS.toStrict (encodeBundle bundle))
+      -- The two field names must appear in the schema — they only show
+      -- up if the imported DECLARE was reachable from typeToParameter.
+      let ok = T.isInfixOf "\"serial\"" json
+            && T.isInfixOf "\"weight\"" json
+            && T.isInfixOf "\"propertyOrder\"" json
+      unless ok $
+        putStrLn $ "\n    schema missing imported fields. got:\n    " <> T.unpack json
+      pure ok
+  where
+    unless b act = if b then pure () else act


### PR DESCRIPTION
bundleExports only consulted the entry module's own DECLAREs, so a rule whose @export parameter type was defined in an IMPORTed file emitted a bare {"type":"object"} schema with no properties. Wasm compiles fine, but the runtime marshaler can't reach into the JSON arg, so every call got a null product pointer.

Surfaced compiling the ASEAN Cosmetic Directive bundle to wasm: ACD_Information.l4 declares @export ... GIVEN product IS A `Cosmetic Product`, but `Cosmetic Product` lives in ACD_Declarations.l4. Mirrors the jl4-service fix in ff022048 — same root cause, different codepath.

bundleExports now takes the dep modules already on hand from typecheckL4File and merges declaresFromModule across the import graph (main wins on collision). Pipeline.hs hands them through.

Regression test in jl4-mlir-test: two-module fixture (Widget DECLAREd in declarations, @export in info), assert the schema JSON contains the field names and a propertyOrder. Fails on the old code, passes after fix. Full suite (8 tests) green.